### PR TITLE
update references from macarthurlab to broad

### DIFF
--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -1,7 +1,7 @@
 ## Active seqr incidents
 
 There are currently no known seqr incidents. 
-If you are experiencing any difficulties, email seqr@broadinstitute.org or submit a [github issue](https://github.com/macarthur-lab/seqr/issues)
+If you are experiencing any difficulties, email seqr@broadinstitute.org or submit a [github issue](https://github.com/broadinstitute/seqr/issues)
 
 ## Past seqr incidents
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 seqr
 ====
-[![Build Status](https://travis-ci.org/macarthur-lab/seqr.svg?branch=master)](https://travis-ci.org/macarthur-lab/seqr)
+[![Build Status](https://travis-ci.org/broadinstitute/seqr.svg?branch=master)](https://travis-ci.org/broadinstitute/seqr)
 
 seqr is a web-based tool for rare disease genomics.
 This repository contains code that underlies the [Broad seqr instance](http://seqr.broadinstitute.org) and other seqr deployments. To check for any active incidents occuring on the Broad seqr instance, check [here](/INCIDENTS.md)

--- a/deploy/LOCAL_INSTALL.md
+++ b/deploy/LOCAL_INSTALL.md
@@ -27,7 +27,7 @@ The steps below describe how to create a new empty seqr instance with a single A
 ```
 SEQR_DIR=$(pwd)
 
-wget https://raw.githubusercontent.com/macarthur-lab/seqr/master/docker-compose.yml
+wget https://raw.githubusercontent.com/broadinstitute/seqr/master/docker-compose.yml
 
 docker-compose up -d seqr   # start up the seqr docker image in the background after also starting other components it depends on (postgres, redis, elasticsearch). This may take 10+ minutes.
 docker-compose logs -f seqr  # (optional) continuously print seqr logs to see when it is done starting up or if there are any errors. Type Ctrl-C to exit from the logs. 
@@ -59,7 +59,7 @@ The steps below describe how to annotate a callset and then load it into your on
    ```
    SEQR_DIR=$(pwd)
    
-   wget https://raw.githubusercontent.com/macarthur-lab/seqr/master/docker-compose.yml
+   wget https://raw.githubusercontent.com/broadinstitute/seqr/master/docker-compose.yml
    
    docker-compose up -d pipeline-runner            # start the pipeline-runner container 
    docker-compose exec pipeline-runner /bin/bash   # open a shell inside the pipeline-runner container (analogous to ssh'ing into a remote machine)
@@ -219,4 +219,4 @@ After the dataset is loaded into elasticsearch, it can be added to your seqr pro
 
 #### Enable read viewing in the browser (optional): 
 
-To make .bam/.cram files viewable in the browser through igv.js, see **[ReadViz Setup Instructions](https://github.com/macarthur-lab/seqr/blob/master/deploy/READVIZ_SETUP.md)**      
+To make .bam/.cram files viewable in the browser through igv.js, see **[ReadViz Setup Instructions](https://github.com/broadinstitute/seqr/blob/master/deploy/READVIZ_SETUP.md)**      

--- a/deploy/MIGRATE.md
+++ b/deploy/MIGRATE.md
@@ -6,7 +6,7 @@ This README describes steps for migrating an older seqr instance.
    pg_dump -U postgres seqrdb | gzip -c - > backup.gz
    ```
 
-2. Download or clone the lastest seqr code from [https://github.com/macarthur-lab/seqr](https://github.com/macarthur-lab/seqr)
+2. Download or clone the lastest seqr code from [https://github.com/broadinstitute/seqr](https://github.com/broadinstitute/seqr)
 
 3. Run migrations:
    ```

--- a/deploy/READVIZ_SETUP.md
+++ b/deploy/READVIZ_SETUP.md
@@ -5,7 +5,7 @@ for individual variants to be viewed in the browser using [IGV.js](https://githu
 If your read files are located on the machine that's running the seqr application server, these steps will enable
 viewing this read data through IGV.js:
 
-1) When running seqr using docker-compose (as [described here](https://github.com/macarthur-lab/seqr/blob/master/deploy/LOCAL_INSTALL.md)), 
+1) When running seqr using docker-compose (as [described here](https://github.com/broadinstitute/seqr/blob/master/deploy/LOCAL_INSTALL.md)), 
 place the bam/cram and index files in the `./data/readviz/` sub-directory that was created under the directory containing
 the docker-compose.yml file. When you start seqr, docker-compose will mount the `./data/readviz/` directory to a `/readviz`
 top-level directory inside the seqr container.

--- a/deploy/docker/elasticsearch/Dockerfile
+++ b/deploy/docker/elasticsearch/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk
 
-MAINTAINER MacArthur Lab
+LABEL maintainer="Broad TGG"
 
 ENV ELASTICSEARCH_VERSION="6.3.2"
 

--- a/deploy/docker/kibana/Dockerfile
+++ b/deploy/docker/kibana/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk
 
-MAINTAINER MacArthur Lab
+LABEL maintainer="Broad TGG"
 
 ENV KIBANA_VERSION="6.3.2"
 

--- a/deploy/docker/pipeline-runner/Dockerfile
+++ b/deploy/docker/pipeline-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/minideb:stretch
 
-MAINTAINER MacArthur Lab
+LABEL maintainer="Broad TGG"
 
 # install commmon utilities
 RUN install_packages \

--- a/deploy/docker/postgres/Dockerfile
+++ b/deploy/docker/postgres/Dockerfile
@@ -1,6 +1,6 @@
 FROM postgres:12.3
 
-MAINTAINER MacArthur Lab
+LABEL maintainer="Broad TGG"
 
 # install wget
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates htop less wget curl \

--- a/deploy/docker/redis/Dockerfile
+++ b/deploy/docker/redis/Dockerfile
@@ -1,6 +1,6 @@
 FROM redis:6.0.6
 
-MAINTAINER MacArthur Lab
+LABEL maintainer="Broad TGG"
 
 COPY bashrc /root/.bashrc
 

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:stretch
 
-MAINTAINER MacArthur Lab
+LABEL maintainer="Broad TGG"
 
 # install commmon utilities
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -116,7 +116,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 ARG DISABLE_CACHE=1
 
 # update seqr repo
-RUN git clone -q https://github.com/macarthur-lab/seqr
+RUN git clone -q https://github.com/broadinstitute/seqr
 
 WORKDIR /seqr
 

--- a/seqr/models.py
+++ b/seqr/models.py
@@ -276,7 +276,7 @@ class Family(ModelWithGUID):
         ]
 
 
-# TODO should be an ArrayField directly on family once family fields have audit trail (https://github.com/macarthur-lab/seqr-private/issues/449)
+# TODO should be an ArrayField directly on family once family fields have audit trail (https://github.com/broadinstitute/seqr-private/issues/449)
 class FamilyAnalysedBy(ModelWithGUID):
     family = models.ForeignKey(Family)
 

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -642,7 +642,7 @@ class EsSearch(object):
                 lifted_over_chrom = grch37_locus['contig']
                 lifted_over_pos = grch37_locus['position']
             else:
-                # TODO once all projects are lifted in pipeline, remove this code (https://github.com/macarthur-lab/seqr/issues/1010)
+                # TODO once all projects are lifted in pipeline, remove this code (https://github.com/broadinstitute/seqr/issues/1010)
                 liftover_grch38_to_grch37 = _liftover_grch38_to_grch37()
                 if liftover_grch38_to_grch37:
                     grch37_coord = liftover_grch38_to_grch37.convert_coordinate(
@@ -1029,7 +1029,7 @@ class EsSearch(object):
         return var_fields[0].lstrip('chr'), int(var_fields[1]), var_fields[2], var_fields[3]
 
 
-# TODO  move liftover to hail pipeline once upgraded to 0.2 (https://github.com/macarthur-lab/seqr/issues/1010)
+# TODO  move liftover to hail pipeline once upgraded to 0.2 (https://github.com/broadinstitute/seqr/issues/1010)
 LIFTOVER_GRCH38_TO_GRCH37 = None
 def _liftover_grch38_to_grch37():
     global LIFTOVER_GRCH38_TO_GRCH37

--- a/servctl
+++ b/servctl
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2.7
-# TODO convert to python 3(https://github.com/macarthur-lab/seqr-private/issues/883)
+# TODO convert to python 3 (https://github.com/broadinstitute/seqr-private/issues/883)
 
 import argparse
 import logging

--- a/ui/package.json
+++ b/ui/package.json
@@ -200,7 +200,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/macarthur-lab/seqr.git"
+    "url": "git+https://github.com/broadinstitute/seqr.git"
   },
   "license": "AGPL-3.0"
 }

--- a/ui/pages/Public/LandingPage.jsx
+++ b/ui/pages/Public/LandingPage.jsx
@@ -60,9 +60,9 @@ export default () =>
               </a>
             </List.Item>
             <List.Item>
-              The <a target="_blank" href="http://github.com/macarthur-lab/seqr"><b>source code</b></a> is available on
+              The <a target="_blank" href="http://github.com/broadinstitute/seqr"><b>source code</b></a> is available on
               github. Please use the &nbsp;
-              <a target="_blank" href="http://github.com/macarthur-lab/seqr/issues"><b>github issues page</b></a> to
+              <a target="_blank" href="http://github.com/broadinstitute/seqr/issues"><b>github issues page</b></a> to
               submit bug reports or feature requests
             </List.Item>
           </List>

--- a/ui/shared/components/page/Footer.jsx
+++ b/ui/shared/components/page/Footer.jsx
@@ -23,7 +23,7 @@ const Footer = React.memo(({ version }) =>
         <TableHeaderCell width={2} disabled>seqr {version}</TableHeaderCell>
         <TableHeaderCell width={6}>
           For bug reports or feature requests please submit  &nbsp;
-          <a href="https://github.com/macarthur-lab/seqr/issues">Github Issues</a>
+          <a href="https://github.com/broadinstitute/seqr/issues">Github Issues</a>
         </TableHeaderCell>
         <TableHeaderCell width={5} textAlign="right">
           If you have questions or feedback, &nbsp;


### PR DESCRIPTION
Now that we have moved the org for the seqr repo, this updates all the hardcoded links that use the old url. This is not necessary (transferring a repo causes all the old links to redirect correctly) but its nicer to have them updated

Also, I updated the "maintainer" for all the docker images to be the TGG, and changed the syntax for the maintainer since the old "MAINTAINER" syntax is deprecated (https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)