### PR TITLE
fix discovery sheet handling of updated hpo categories

### DIFF
--- a/seqr/fixtures/reference_data.json
+++ b/seqr/fixtures/reference_data.json
@@ -1254,7 +1254,7 @@
     "fields": {
         "hpo_id": "HP:0001631",
         "parent_id": "HP:0008800",
-        "category_id": "HP:0001626",
+        "category_id": "HP:0025354",
         "is_category": "f",
         "name": "Defect in the atrial septum",
         "definition": "",
@@ -1293,7 +1293,7 @@
     "fields": {
         "hpo_id": "HP:0001636",
         "parent_id": "HP:0008800",
-        "category_id": "HP:0001626",
+        "category_id": "HP:0033127",
         "is_category": "f",
         "name": "Tetralogy of Fallot",
         "definition": "",

--- a/seqr/views/apis/staff_api_tests.py
+++ b/seqr/views/apis/staff_api_tests.py
@@ -240,7 +240,7 @@ EXPECTED_MME_DETAILS_METRICS = {
 EXPECTED_DISCOVERY_SHEET_ROW = \
     {'project_guid': 'R0001_1kg', 'pubmed_ids': '', 'posted_publicly': '',
      'solved': 'TIER 1 GENE', 'head_or_neck': 'N', 'analysis_complete_status': 'complete',
-     'cardiovascular_system': 'Y', 'n_kindreds_overlapping_sv_similar_phenotype': '2',
+     'cardiovascular_system': 'N', 'n_kindreds_overlapping_sv_similar_phenotype': '2',
      'biochemical_function': 'Y', 'omim_number_post_discovery': '615120,615123',
      'genome_wide_linkage': 'NA 2', 'metabolism_homeostasis': 'N', 'growth': 'N',
      't0': '2017-02-05T06:42:55.397Z', 'months_since_t0': 38, 'sample_source': 'CMG',
@@ -248,7 +248,7 @@ EXPECTED_DISCOVERY_SHEET_ROW = \
      'expected_inheritance_model': 'Autosomal recessive inheritance',
      'extras_variant_tag_list': ['21-3343353-GAGA-G  RP11-206L10.5  tier 1 - novel gene and phenotype'],
      'protein_interaction': 'N', 'n_kindreds': '1', 'num_individuals_sequenced': 3,
-     'musculature': 'N', 'sequencing_approach': 'WES', 'neoplasm': 'N',
+     'musculature': 'Y', 'sequencing_approach': 'WES', 'neoplasm': 'N',
      'collaborator': '1kg project n\xe5me with uni\xe7\xf8de',
      'actual_inheritance_model': 'de novo', 'novel_mendelian_gene': 'Y',
      'endocrine_system': 'N', 'patient_cells': 'N', 'komp_early_release': 'N',

--- a/ui/shared/components/panel/HpoPanel.jsx
+++ b/ui/shared/components/panel/HpoPanel.jsx
@@ -38,6 +38,7 @@ export const CATEGORY_NAMES = {
   'HP:0045027': 'Thoracic Cavity',
   'HP:0025354': 'Cellular Phenotype',
   'HP:0025142': 'Constitution',
+  'HP:0033127': 'Musculoskeletal',
 }
 
 export const getHpoTermsForCategory = (features, nonstandardFeatures) => {


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/seqr-private/issues/927

HPO updated their category mapping, which broke our parsing for the discovery sheet. This updates the discovery sheet to work with the new HPO categories per the discussion on the ticket, and also cleans up the category to discovery column mapping to make the code easier to understand/ more explicit