### PR TITLE
update kuberentes yaml for 1.16

### DIFF
--- a/deploy/kubernetes/postgres/postgres.gcloud.yaml
+++ b/deploy/kubernetes/postgres/postgres.gcloud.yaml
@@ -13,12 +13,15 @@ spec:
     name: postgres
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: postgres
   namespace: {{ NAMESPACE }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: postgres
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/redis/redis.gcloud.yaml
+++ b/deploy/kubernetes/redis/redis.gcloud.yaml
@@ -13,12 +13,15 @@ spec:
     name: redis
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: redis
   namespace: {{ NAMESPACE }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: redis
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -14,7 +14,7 @@ spec:
     name: seqr
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: seqr
   namespace: {{ NAMESPACE }}
@@ -23,6 +23,9 @@ metadata:
     deployment: {{ DEPLOY_TO }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: seqr
   template:
     metadata:
       labels:


### PR DESCRIPTION
We recently updated kubernetes for our deployments from version 1.15 to 1.16 but we didn't update some of our deployment files to meet the spec for the new version. This fixes it