### PR TITLE
Status endpoint

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -4,6 +4,7 @@ The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/1.9/topics/http/urls/
 """
 from seqr.views.react_app import main_app, no_login_main_app
+from seqr.views.status import status_view
 from seqr.views.apis.dataset_api import \
     update_individual_igv_sample, \
     add_variants_dataset_handler, \
@@ -261,7 +262,7 @@ api_endpoints = {
 
 }
 
-urlpatterns = []
+urlpatterns = [url('^status', status_view)]
 
 # core react page templates
 urlpatterns += [url("^%(url_endpoint)s$" % locals(), main_app) for url_endpoint in react_app_pages]
@@ -276,9 +277,6 @@ urlpatterns += [
     url('^logout$', logout_view),
     url(API_LOGIN_REQUIRED_URL.lstrip('/'), login_required_error)
 ]
-
-#urlpatterns += [
-#   url("^api/v1/%(url_endpoint)s$" % locals(), handler_function) for url_endpoint, handler_function in api_endpoints.items()]
 
 kibana_urls = '^(?:%s)' % ('|'.join([
     "app", "bundles", "elasticsearch", "plugins", "ui", "api/apm", "api/console", "api/index_management", "api/index_patterns",

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -18,8 +18,9 @@ class InvalidIndexException(Exception):
     pass
 
 
-def get_es_client(timeout=60):
-    return elasticsearch.Elasticsearch(hosts=[{"host": ELASTICSEARCH_SERVICE_HOSTNAME, "port": ELASTICSEARCH_SERVICE_PORT}],  timeout=timeout)
+def get_es_client(timeout=60, **kwargs):
+    return elasticsearch.Elasticsearch(
+        hosts=[{'host': ELASTICSEARCH_SERVICE_HOSTNAME, 'port': ELASTICSEARCH_SERVICE_PORT}], timeout=timeout, **kwargs)
 
 
 def get_index_metadata(index_name, client, include_fields=False):

--- a/seqr/views/status.py
+++ b/seqr/views/status.py
@@ -39,10 +39,10 @@ def status_view(request):
 
     # Test kibana connection
     try:
-        requests.get('http://{}/status'.format(KIBANA_SERVER), timeout=3).raise_for_status()
+        requests.head('http://{}/status'.format(KIBANA_SERVER), timeout=3).raise_for_status()
     except Exception as e:
         dependent_services_ok = False
-        logger.error('Unable to connect kibana: {}'.format(str(e)))
+        logger.error('Unable to connect to kibana: {}'.format(str(e)))
 
 
     return create_json_response(

--- a/seqr/views/status.py
+++ b/seqr/views/status.py
@@ -1,0 +1,51 @@
+from django.db import connections
+import logging
+import redis
+import requests
+
+from settings import SEQR_VERSION, KIBANA_SERVER, REDIS_SERVICE_HOSTNAME, DATABASES
+from seqr.utils.elasticsearch.utils import get_es_client
+from seqr.views.utils.json_utils import create_json_response
+
+logger = logging.getLogger(__name__)
+
+
+def status_view(request):
+    """Status endpoint for monitoring app availability."""
+    dependent_services_ok = True
+
+    # Test database connection
+    for db_connection_key in DATABASES.keys():
+        try:
+            connections[db_connection_key].cursor()
+        except Exception as e:
+            dependent_services_ok = False
+            logger.error('Unable to connect to database "{}": {}'.format(db_connection_key, e))
+
+    # Test redis connection
+    try:
+        redis.StrictRedis(host=REDIS_SERVICE_HOSTNAME, socket_connect_timeout=3).ping()
+    except Exception as e:
+        dependent_services_ok = False
+        logger.error('Unable to connect to redis: {}'.format(str(e)))
+
+    # Test elasticsearch connection
+    try:
+        if not get_es_client(timeout=3, max_retries=0).ping():
+            raise ValueError('No response from elasticsearch ping')
+    except Exception as e:
+        dependent_services_ok = False
+        logger.error('Unable to connect to elasticsearch: {}'.format(str(e)))
+
+    # Test kibana connection
+    try:
+        requests.get('http://{}/status'.format(KIBANA_SERVER), timeout=3).raise_for_status()
+    except Exception as e:
+        dependent_services_ok = False
+        logger.error('Unable to connect kibana: {}'.format(str(e)))
+
+
+    return create_json_response(
+        {'version': SEQR_VERSION, 'dependent_services_ok': dependent_services_ok},
+        status= 200 if dependent_services_ok else 400
+    )

--- a/seqr/views/status_tests.py
+++ b/seqr/views/status_tests.py
@@ -1,0 +1,45 @@
+from django.test import TestCase
+from django.urls.base import reverse
+import mock
+from requests import HTTPError
+import responses
+
+from seqr.views.status import status_view
+from seqr.views.utils.test_utils import urllib3_responses
+
+
+class StatusTest(TestCase):
+
+    @mock.patch('seqr.views.status.redis.StrictRedis')
+    @mock.patch('seqr.views.status.connections')
+    @mock.patch('seqr.views.status.logger')
+    @responses.activate
+    @urllib3_responses.activate
+    def test_status(self, mock_logger, mock_db_connections, mock_redis):
+        url = reverse(status_view)
+
+        mock_db_connections.__getitem__.return_value.cursor.side_effect = Exception('No connection')
+        mock_redis.return_value.ping.side_effect = HTTPError('Bad connection')
+        responses.add(responses.HEAD, 'http://localhost:5601/status', status=500)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(response.json(), {'version': 'v1.0', 'dependent_services_ok': False})
+        mock_logger.error.assert_has_calls([
+            mock.call('Unable to connect to database "default": No connection'),
+            mock.call('Unable to connect to database "reference_data": No connection'),
+            mock.call('Unable to connect to redis: Bad connection'),
+            mock.call('Unable to connect to elasticsearch: No response from elasticsearch ping'),
+            mock.call('Unable to connect to kibana: 500 Server Error: Internal Server Error for url: http://localhost:5601/status'),
+        ])
+
+        mock_logger.reset_mock()
+        mock_db_connections.__getitem__.return_value.cursor.side_effect = None
+        mock_redis.return_value.ping.side_effect = None
+        urllib3_responses.add(responses.HEAD, '/', status=200)
+        responses.replace(responses.HEAD, 'http://localhost:5601/status', status=200)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), {'version': 'v1.0', 'dependent_services_ok': True})
+        mock_logger.error.assert_not_called()


### PR DESCRIPTION
Adds a status endpoint that we can set up for monitoring in stackdriver. This endpoint is publicly available, so it does not return any details about our tech stack/ what our dependent services are. Instead, it checks if dependent services are up and logs errors if they aren't and we will set up alerting on those errors 