### PR TITLE
expire cached search results

### DIFF
--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -4,6 +4,7 @@ import jmespath
 import json
 import re
 from collections import defaultdict
+from datetime import timedelta
 from django.test import TestCase
 from elasticsearch.exceptions import ConnectionTimeout
 from sys import maxsize
@@ -995,7 +996,9 @@ class EsUtilsTest(TestCase):
             self.assertSetEqual(SOURCE_FIELDS, set(source))
 
     def assertCachedResults(self, results_model, expected_results, sort='xpos'):
-        self.assertDictEqual(json.loads(REDIS_CACHE.get('search_results__{}__{}'.format(results_model.guid, sort))), expected_results)
+        cache_key = 'search_results__{}__{}'.format(results_model.guid, sort)
+        self.assertDictEqual(json.loads(REDIS_CACHE.get(cache_key)), expected_results)
+        MOCK_REDIS.expire.assert_called_with(cache_key, timedelta(weeks=2))
 
     @urllib3_responses.activate
     def test_get_es_variants_for_variant_tuples(self):

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import elasticsearch
 from elasticsearch_dsl import Q
 import logging
@@ -131,7 +132,7 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, **
 
     variant_results = es_search.search(**search_kwargs)
 
-    safe_redis_set_json(cache_key, es_search.previous_search_results)
+    safe_redis_set_json(cache_key, es_search.previous_search_results, expire=timedelta(weeks=2))
 
     return variant_results, es_search.previous_search_results['total_results']
 

--- a/seqr/utils/redis_utils.py
+++ b/seqr/utils/redis_utils.py
@@ -21,9 +21,11 @@ def safe_redis_get_json(cache_key):
     return None
 
 
-def safe_redis_set_json(cache_key, value):
+def safe_redis_set_json(cache_key, value, expire=None):
     try:
         redis_client = redis.StrictRedis(host=REDIS_SERVICE_HOSTNAME, socket_connect_timeout=3)
         redis_client.set(cache_key, json.dumps(value))
+        if expire:
+            redis_client.expire(cache_key, expire)
     except Exception as e:
         logger.error('Unable to write to redis host {}: {}'.format(REDIS_SERVICE_HOSTNAME, str(e)))

--- a/seqr/utils/redis_utils_tests.py
+++ b/seqr/utils/redis_utils_tests.py
@@ -42,6 +42,12 @@ class RedisUtilsTest(TestCase):
     def test_safe_redis_set_json(self, mock_redis, mock_logger):
         safe_redis_set_json('test_key', {'a': 1})
         mock_redis.return_value.set.assert_called_with('test_key', '{"a": 1}')
+        mock_redis.return_value.expire.assert_not_called()
+        mock_logger.error.assert_not_called()
+
+        safe_redis_set_json('test_key', {'a': 1}, expire=100)
+        mock_redis.return_value.set.assert_called_with('test_key', '{"a": 1}')
+        mock_redis.return_value.expire.assert_called_with('test_key', 100)
         mock_logger.error.assert_not_called()
 
         # test with redis connection error


### PR DESCRIPTION
Seqr caches search results, but when data reloads it is crucial that the cache is reset, or users see weird/ inaccurate results (see https://github.com/broadinstitute/seqr-private/issues/935)

One reason why resetting the cache fails is that there are so many keys to delete that the reset times out. While caching is crucial in the shorter terms (especially for recessive searches where there is a bunch of post processing that we cache) search itself always completes in a reasonable amount of time, so having the results cache expire after a couple weeks won't cause any serious performance changes to the user, and will ensure that users can never see seriously outdated results