### PR TITLE
Enables modsecurity and owasp rulesets on ingress-nginx

### DIFF
--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -48,7 +48,12 @@ metadata:
   namespace: ingress-nginx
 data:
   enable-modsecurity: "true"
-  enable-owasp-modsecurity-crs: "true"
+  modsecurity-snippet: |
+    SecAuditLogType Serial
+    SecAuditLog /dev/stdout
+    SecAuditLogFormat JSON
+    SecRuleRemoveById 920350
+    Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
 ---
 # docs @ https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
 kind: Ingress
@@ -59,7 +64,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine DetectionOnly
 spec:
   tls:
     - hosts:

--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -32,6 +32,24 @@ spec:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/component: controller
 ---
+# ConfigMap modified to enable modsecurity, owasp crs
+# Source: ingress-nginx/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-3.10.1
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.41.2
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: controller
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+data:
+  enable-modsecurity: "true"
+  enable-owasp-modsecurity-crs: "true"
+---
 # docs @ https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
 kind: Ingress
 apiVersion: networking.k8s.io/v1beta1
@@ -40,6 +58,8 @@ metadata:
   namespace: {{ NAMESPACE }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/enable-owasp-core-rules: "true"
 spec:
   tls:
     - hosts:

--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -6,10 +6,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-2.10.0
+    helm.sh/chart: ingress-nginx-3.10.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: 0.33.0
+    app.kubernetes.io/version: 0.41.2
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
   name: ingress-nginx-controller

--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -388,7 +388,7 @@ def deploy_nginx(settings):
         return
 
     print_separator("nginx")
-    run("kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud/deploy.yaml" % locals())
+    run("kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.41.2/deploy/static/provider/cloud/deploy.yaml" % locals())
     if settings["DELETE_BEFORE_DEPLOY"]:
         run("kubectl delete -f %(DEPLOYMENT_TEMP_DIR)s/deploy/kubernetes/nginx/nginx.yaml" % settings, errors_to_ignore=["not found"])
     run("kubectl apply -f %(DEPLOYMENT_TEMP_DIR)s/deploy/kubernetes/nginx/nginx.yaml" % settings)


### PR DESCRIPTION
This is the less invasive option for SQR-68, where we enable the modsecurity plugin for our existing ingress-nginx.

My understanding is that this includes the ruleset from https://github.com/coreruleset/coreruleset, and therefore we might need to upgrade our ingress-nginx controller periodically (and perhaps initially) to stay up to date. By default, it operates in detection-only mode, so we'd need some log alerts to let us know what's happening. I can also look into how to configure it to actually act on threats once we're confident that it won't break anything.

One open question I have on this:
- It looks like the ingress-nginx project provides a helm chart to deploy itself. Did we use that to deploy this ingress originally, or did we simply use the [quickstart](https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/cloud/deploy.yaml) ?

The other option I'm exploring for this to switch to a native GKE Ingress -- this one will take me a bit longer, so I wanted to leave this option open first. We can always switch to a GKE Ingress later.
