### PR TITLE
WIP: adds the manifests required for a native GKE ingress

### DIFF
--- a/deploy/kubernetes/gcloud-dev-settings.yaml
+++ b/deploy/kubernetes/gcloud-dev-settings.yaml
@@ -6,6 +6,7 @@ CLUSTER_MACHINE_TYPE: 'n1-highmem-4'   # n1-standard-2, n1-standard-4 .. n1-stan
 CLUSTER_NUM_NODES: 1
 
 CLUSTER_EXTERNAL_IP: '104.198.135.79'
+CLUSTER_EXTERNAL_IP_NAME: 'seqr-dev'
 CLUSTER_HOSTNAME: 'seqr-dev.broadinstitute.org'
 BASE_URL: 'https://seqr-dev.broadinstitute.org/'
 

--- a/deploy/kubernetes/ingress/backend-config.yml
+++ b/deploy/kubernetes/ingress/backend-config.yml
@@ -1,0 +1,8 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  namespace: {{ NAMESPACE }}
+  name: seqr-backend-config
+spec:
+  securityPolicy:
+    name: "seqr-waf-policy" # this needs to be externally defined

--- a/deploy/kubernetes/ingress/frontend-config.yml
+++ b/deploy/kubernetes/ingress/frontend-config.yml
@@ -1,0 +1,9 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: seqr-frontend-config
+  namespace: {{ NAMESPACE }}
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT

--- a/deploy/kubernetes/ingress/ingress.yml
+++ b/deploy/kubernetes/ingress/ingress.yml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: seqr-ingress
+  namespace: {{ NAMESPACE }}
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: {{ CLUSTER_STATIC_IP_NAME }}
+    networking.gke.io/v1beta1.FrontendConfig: "seqr-frontend-config"
+    networking.gke.io/managed-certificates: "seqr-tls-certificate"
+spec:
+  rules:
+    - host: {{ CLUSTER_HOSTNAME }}
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: seqr
+            servicePort: {{ SEQR_SERVICE_PORT }}

--- a/deploy/kubernetes/ingress/managed-cert.yml
+++ b/deploy/kubernetes/ingress/managed-cert.yml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: seqr-tls-certificate
+  namespace: {{ NAMESPACE }}
+spec:
+  domains:
+    - {{ CLUSTER_HOSTNAME }}

--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 metadata:
   name: seqr
   namespace: {{ NAMESPACE }}
+  annotations:
+    cloud.google.com/backend-config: '{"default": "seqr-backend-config"}'
   labels:
     name: seqr
     deployment: {{ DEPLOY_TO }}


### PR DESCRIPTION
This is the more invasive approach to SQR-68. Unfortunately, you can't associate the same host/path with two different ingress objects, so we'll need downtime to cut this over. Associating our static external IP with the new ingress would also require some downtime.

I think the benefits of this approach compared to ingress-nginx are:

- We use a google managed TLS cert here, and don't have to maintain another cert/secret, and it's automatically renewed as long as it's associated with an ingress
- We can do away with keeping the ingress-nginx controller installed and up to date
- GKE ingress affords us some built-in DDOS protection
- The cloudarmor security policy (where the actual WAF rules are defined) can take advantage of OWASP rule sets that are kept up to date automatically

Still left to do:
- we need to figure out where the definition of the cloud armor rule definitions should live. We would use pre-defined rules for those, but we need to create the policy, and add those rules to it. I'd likely use Terraform to do this.
- replace `deploy_nginx` in servctl with something that applies this.
- remove the ingress-nginx stuff once we're deployed (we need the manifests temporarily to cleanly remove them)

Assuming we don't delete everything and deploy everything anew, my rough estimation of the process for shipping this would be:

1) define and create the cloud armor policy
2) remove (`kubectl delete`) the ingress-nginx Ingress object and controller
3) apply the native ingress manifests

From the brief testing I did with this, it takes ~20-30mins for google to provision the certificate, and fresh ingress objects take like 20mins to start properly sending traffic to pods. I'd budget around 1.5-2 hours of downtime to allow for some extra padding.