### PR TITLE
Added Google auth for local users.

### DIFF
--- a/seqr/utils/social_auth_pipeline.py
+++ b/seqr/utils/social_auth_pipeline.py
@@ -16,10 +16,14 @@ def validate_anvil_registration(backend, response, *args, **kwargs):
             return redirect('/login?anvilLoginFailed=true')
 
 
-def log_signed_in(backend, response, user=None, is_new=False, *args, **kwargs):
+def validate_user_exist(backend, response, user=None, *args, **kwargs):
     if not user:
-        logger.warning('Google user {} is trying to login without an existing seqr account'.format(response['email']))
+        logger.warning('Google user {} is trying to login without an existing seqr account ({}).'
+                       .format(response['email'], backend.name))
         return redirect('/login?googleLoginFailed=true')
+
+
+def log_signed_in(backend, response, is_new=False, *args, **kwargs):
     logger.info('Logged in {} ({})'.format(response['email'], backend.name))
     if is_new:
         logger.info('Created user {} ({})'.format(response['email'], backend.name))

--- a/seqr/utils/social_auth_pipeline.py
+++ b/seqr/utils/social_auth_pipeline.py
@@ -13,10 +13,13 @@ def validate_anvil_registration(backend, response, *args, **kwargs):
             anvil_call('get', 'register', response['access_token'])
         except TerraNotFoundException as et:
             logger.warning('User {} is trying to login without registration on AnVIL. {}'.format(response['email'], str(et)))
-            return redirect('/login?googleLoginFailed=true')
+            return redirect('/login?anvilLoginFailed=true')
 
 
-def log_signed_in(backend, response, is_new=False, *args, **kwargs):
+def log_signed_in(backend, response, user=None, is_new=False, *args, **kwargs):
+    if not user:
+        logger.warning('Google user {} is trying to login without an existing seqr account'.format(response['email']))
+        return redirect('/login?googleLoginFailed=true')
     logger.info('Logged in {} ({})'.format(response['email'], backend.name))
     if is_new:
         logger.info('Created user {} ({})'.format(response['email'], backend.name))

--- a/seqr/utils/social_auth_pipeline_tests.py
+++ b/seqr/utils/social_auth_pipeline_tests.py
@@ -17,7 +17,7 @@ class SocialAuthPipelineTest(TestCase):
         responses.add(responses.GET, url, status=404)
         r = validate_anvil_registration(GoogleOAuth2(), {'access_token': '', 'email': 'test@seqr.org'})
         mock_logger.warning.assert_called_with('User test@seqr.org is trying to login without registration on AnVIL. None called Terra API: GET /register got status 404 with reason: Not Found')
-        self.assertEqual(r.url, '/login?googleLoginFailed=true')
+        self.assertEqual(r.url, '/login?anvilLoginFailed=true')
         self.assertEqual(len(mock_logger.method_calls), 1)
 
         mock_logger.reset_mock()
@@ -28,14 +28,20 @@ class SocialAuthPipelineTest(TestCase):
 
     @mock.patch('seqr.utils.social_auth_pipeline.logger')
     def test_log_signed_in(self, mock_logger):
-        log_signed_in(GoogleOAuth2(), {'email': 'test_user@test.com'})
+        log_signed_in(GoogleOAuth2(), {'email': 'test_user@test.com'}, user='test')
         mock_logger.info.assert_called_with('Logged in test_user@test.com (google-oauth2)')
         self.assertEqual(len(mock_logger.method_calls), 1)
 
         mock_logger.reset_mock()
-        log_signed_in(GoogleOAuth2(), {'email': 'test_user@test.com'}, is_new=True)
+        log_signed_in(GoogleOAuth2(), {'email': 'test_user@test.com'}, is_new=True, user='test')
         mock_logger.info.assert_has_calls([
             mock.call('Logged in test_user@test.com (google-oauth2)'),
             mock.call('Created user test_user@test.com (google-oauth2)'),
         ])
         self.assertEqual(len(mock_logger.method_calls), 2)
+
+        mock_logger.reset_mock()
+        r = log_signed_in(GoogleOAuth2(), {'email': 'test_user@test.com'})
+        mock_logger.warning.assert_called_with('Google user test_user@test.com is trying to login without an existing seqr account')
+        self.assertEqual(r.url, '/login?googleLoginFailed=true')
+        self.assertEqual(len(mock_logger.method_calls), 1)

--- a/seqr/views/react_app.py
+++ b/seqr/views/react_app.py
@@ -6,9 +6,8 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.middleware.csrf import rotate_token
 from django.template import loader
 from django.http import HttpResponse
-from settings import SEQR_VERSION, SEQR_PRIVACY_VERSION, SEQR_TOS_VERSION, CSRF_COOKIE_NAME, DEBUG
+from settings import SEQR_VERSION, SEQR_PRIVACY_VERSION, SEQR_TOS_VERSION, CSRF_COOKIE_NAME, DEBUG, GOOGLE_AUTH_CONFIG_DIR
 from seqr.views.utils.orm_to_json_utils import _get_json_for_user
-from seqr.views.utils.terra_api_utils import anvil_enabled
 
 
 @login_required
@@ -47,7 +46,7 @@ def _render_app_html(request, initial_json):
     initial_json['meta'] = {
         'version': '{}-{}'.format(SEQR_VERSION, ui_version),
         'hijakEnabled': DEBUG or False,
-        'googleLoginEnabled': anvil_enabled(),
+        'googleLoginEnabled': bool(GOOGLE_AUTH_CONFIG_DIR),
     }
 
     html = html.replace(

--- a/settings.py
+++ b/settings.py
@@ -327,33 +327,25 @@ SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_URL_NAMESPACE = 'social'
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
 
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.social_auth.associate_by_email',
+    'social_core.pipeline.social_auth.associate_user',
+    'seqr.utils.social_auth_pipeline.log_signed_in',
+)
+
 if TERRA_API_ROOT_URL:
     SOCIAL_AUTH_GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
         'access_type': 'offline',  # to make the access_token can be refreshed after expired (expiration time is 1 hour)
     }
 
-    SOCIAL_AUTH_PIPELINE = (
-        'seqr.utils.social_auth_pipeline.validate_anvil_registration',
-        'social_core.pipeline.social_auth.social_details',
-        'social_core.pipeline.social_auth.social_uid',
-        'social_core.pipeline.social_auth.social_user',
-        'social_core.pipeline.user.get_username',
-        'social_core.pipeline.social_auth.associate_by_email',
-        'social_core.pipeline.user.create_user',
-        'social_core.pipeline.social_auth.associate_user',
-        'social_core.pipeline.social_auth.load_extra_data',
-        'social_core.pipeline.user.user_details',
-        'seqr.utils.social_auth_pipeline.log_signed_in',
-    )
-else:
-    SOCIAL_AUTH_PIPELINE = (
-        'social_core.pipeline.social_auth.social_details',
-        'social_core.pipeline.social_auth.social_uid',
-        'social_core.pipeline.social_auth.social_user',
-        'social_core.pipeline.user.get_username',
-        'social_core.pipeline.social_auth.associate_by_email',
-        'social_core.pipeline.social_auth.associate_user',
-        'social_core.pipeline.social_auth.load_extra_data',
-        'social_core.pipeline.user.user_details',
-        'seqr.utils.social_auth_pipeline.log_signed_in',
-    )
+    SOCIAL_AUTH_PIPELINE = ('seqr.utils.social_auth_pipeline.validate_anvil_registration',) + \
+                           SOCIAL_AUTH_PIPELINE[:4] + \
+                           ('social_core.pipeline.user.get_username',
+                           'social_core.pipeline.user.create_user') + \
+                           SOCIAL_AUTH_PIPELINE[4:5] + \
+                           ('social_core.pipeline.social_auth.load_extra_data',
+                           'social_core.pipeline.user.user_details') + \
+                           SOCIAL_AUTH_PIPELINE[5:]

--- a/settings.py
+++ b/settings.py
@@ -327,14 +327,15 @@ SOCIAL_AUTH_POSTGRES_JSONFIELD = True
 SOCIAL_AUTH_URL_NAMESPACE = 'social'
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
 
-SOCIAL_AUTH_PIPELINE = (
+SOCIAL_AUTH_PIPELINE_BASE = (
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',
     'social_core.pipeline.social_auth.social_user',
     'social_core.pipeline.social_auth.associate_by_email',
-    'social_core.pipeline.social_auth.associate_user',
-    'seqr.utils.social_auth_pipeline.log_signed_in',
 )
+SOCIAL_AUTH_PIPELINE_USER_EXIST = ('seqr.utils.social_auth_pipeline.validate_user_exist',)
+SOCIAL_AUTH_PIPELINE_ASSOCIATE_USER = ('social_core.pipeline.social_auth.associate_user',)
+SOCIAL_AUTH_PIPELINE_LOG = ('seqr.utils.social_auth_pipeline.log_signed_in',)
 
 if TERRA_API_ROOT_URL:
     SOCIAL_AUTH_GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
@@ -342,10 +343,13 @@ if TERRA_API_ROOT_URL:
     }
 
     SOCIAL_AUTH_PIPELINE = ('seqr.utils.social_auth_pipeline.validate_anvil_registration',) + \
-                           SOCIAL_AUTH_PIPELINE[:4] + \
+                           SOCIAL_AUTH_PIPELINE_BASE + \
                            ('social_core.pipeline.user.get_username',
-                           'social_core.pipeline.user.create_user') + \
-                           SOCIAL_AUTH_PIPELINE[4:5] + \
+                            'social_core.pipeline.user.create_user') + \
+                           SOCIAL_AUTH_PIPELINE_ASSOCIATE_USER + \
                            ('social_core.pipeline.social_auth.load_extra_data',
-                           'social_core.pipeline.user.user_details') + \
-                           SOCIAL_AUTH_PIPELINE[5:]
+                            'social_core.pipeline.user.user_details') + \
+                           SOCIAL_AUTH_PIPELINE_LOG
+else:
+    SOCIAL_AUTH_PIPELINE = SOCIAL_AUTH_PIPELINE_BASE + SOCIAL_AUTH_PIPELINE_USER_EXIST + \
+                           SOCIAL_AUTH_PIPELINE_ASSOCIATE_USER + SOCIAL_AUTH_PIPELINE_LOG

--- a/settings.py
+++ b/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'seqr',
     'reference_data',
     'matchmaker',
+    'social_django',
 ]
 
 MIDDLEWARE = [
@@ -171,6 +172,7 @@ LOGGING = {
 TERRA_API_ROOT_URL = os.environ.get('TERRA_API_ROOT_URL')
 
 AUTHENTICATION_BACKENDS = (
+    'social_core.backends.google.GoogleOAuth2',
     'django.contrib.auth.backends.ModelBackend',
     'guardian.backends.ObjectPermissionBackend',
 )
@@ -315,25 +317,21 @@ SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = [
     'openid'
 ]
 
-if TERRA_API_ROOT_URL or (len(sys.argv) >= 2 and sys.argv[1] == 'test'):
-    AUTHENTICATION_BACKENDS = ('social_core.backends.google.GoogleOAuth2',) + AUTHENTICATION_BACKENDS
+# Use Google sub ID as the user ID, safer than using email
+USE_UNIQUE_USER_ID = True
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = GOOGLE_AUTH_CLIENT_CONFIG.get('web', {}).get('client_id')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = GOOGLE_AUTH_CLIENT_CONFIG.get('web', {}).get('client_secret')
+
+SOCIAL_AUTH_POSTGRES_JSONFIELD = True
+SOCIAL_AUTH_URL_NAMESPACE = 'social'
+SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
+
+if TERRA_API_ROOT_URL:
     SOCIAL_AUTH_GOOGLE_OAUTH2_AUTH_EXTRA_ARGUMENTS = {
         'access_type': 'offline',  # to make the access_token can be refreshed after expired (expiration time is 1 hour)
     }
 
-    # Use Google sub ID as the user ID, safer than using email
-    USE_UNIQUE_USER_ID = True
-
-    SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = GOOGLE_AUTH_CLIENT_CONFIG.get('web', {}).get('client_id')
-    SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = GOOGLE_AUTH_CLIENT_CONFIG.get('web', {}).get('client_secret')
-
-    SOCIAL_AUTH_GOOGLE_PLUS_AUTH_EXTRA_ARGUMENTS = {
-          'access_type': 'offline'
-    }
-
-    SOCIAL_AUTH_POSTGRES_JSONFIELD = True
-    SOCIAL_AUTH_URL_NAMESPACE = 'social'
-    SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
     SOCIAL_AUTH_PIPELINE = (
         'seqr.utils.social_auth_pipeline.validate_anvil_registration',
         'social_core.pipeline.social_auth.social_details',
@@ -347,4 +345,15 @@ if TERRA_API_ROOT_URL or (len(sys.argv) >= 2 and sys.argv[1] == 'test'):
         'social_core.pipeline.user.user_details',
         'seqr.utils.social_auth_pipeline.log_signed_in',
     )
-    INSTALLED_APPS.append('social_django')
+else:
+    SOCIAL_AUTH_PIPELINE = (
+        'social_core.pipeline.social_auth.social_details',
+        'social_core.pipeline.social_auth.social_uid',
+        'social_core.pipeline.social_auth.social_user',
+        'social_core.pipeline.user.get_username',
+        'social_core.pipeline.social_auth.associate_by_email',
+        'social_core.pipeline.social_auth.associate_user',
+        'social_core.pipeline.social_auth.load_extra_data',
+        'social_core.pipeline.user.user_details',
+        'seqr.utils.social_auth_pipeline.log_signed_in',
+    )

--- a/ui/pages/Login/components/Login.jsx
+++ b/ui/pages/Login/components/Login.jsx
@@ -26,10 +26,14 @@ const Login = ({ onSubmit, googleLoginEnabled, location }) =>
     {googleLoginEnabled &&
     <div>
       <Divider />
-      {location.search === '?googleLoginFailed=true' &&
+      {location.search === '?anvilLoginFailed=true' &&
       <Message visible warning>
         Logging in has failed. Make sure you have registered your account on AnVIL. <br />
         Click this link <a href="https://anvil.terra.bio">https://anvil.terra.bio</a>, sign in to AnVIL with Google, and register your account.
+      </Message> }
+      {location.search === '?googleLoginFailed=true' &&
+      <Message visible warning>
+        No existing seqr account for the Google user.
       </Message> }
       <a href="/login/google-oauth2">Sign in with Google</a>
     </div>}


### PR DESCRIPTION
This PR adds the ability for existing users to be able to log in through Google, even before seqr is connected to AnVIL.
If the environment variable `GOOGLE_AUTH_CONFIG_DIR` is defined then Google auth is enabled. An existing seqr user can log in through Google if the user's email matches the Google account's email. Only when the environment variable `TERRA_API_ROOT_URL` is defined, seqr will use AnVIL for Google-signing-in user authentication. 