### PR TITLE
Deletes the kubescan deployment when delete_before_deploy is true

### DIFF
--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -412,7 +412,7 @@ def deploy_kube_scan(settings):
     print_separator("kube-scan")
 
     if settings["DELETE_BEFORE_DEPLOY"]:
-        run("kubectl apply -f https://raw.githubusercontent.com/octarinesec/kube-scan/master/kube-scan.yaml")
+        run("kubectl delete -f https://raw.githubusercontent.com/octarinesec/kube-scan/master/kube-scan.yaml")
 
         if settings["ONLY_PUSH_TO_REGISTRY"]:
             return


### PR DESCRIPTION
Saw this while working on something else, and I felt like the `apply` in this if branch wanted to be a `delete`.