### PR TITLE
Adds a couple of WAF config updates to handle some potential false positives

### DIFF
--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -52,8 +52,19 @@ data:
     SecAuditLogType Serial
     SecAuditLog /dev/stdout
     SecAuditLogFormat JSON
+    # local requests
     SecRuleRemoveById 920350
+    # regex match for windows command injection, contained many false positives
+    SecRuleRemoveByID 932115
     Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
+    # adds 'application/vnd.ga4gh.matchmaker.v1.0+json' to the list of allowed content-types
+    SecAction \
+      "id:900220,\
+      phase:1,\
+      nolog,\
+      pass,\
+      t:none,\
+      setvar:'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|text/plain|application/vnd.ga4gh.matchmaker.v1.0+json'"
 ---
 # docs @ https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
 kind: Ingress

--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -55,7 +55,7 @@ data:
     # local requests
     SecRuleRemoveById 920350
     # regex match for windows command injection, contained many false positives
-    SecRuleRemoveByID 932115
+    SecRuleRemoveById 932115
     Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
     # adds 'application/vnd.ga4gh.matchmaker.v1.0+json' to the list of allowed content-types
     SecAction \


### PR DESCRIPTION
Two actual changes, and one comment added here:

1) disables a rule which caught things like `within` and `sort` contained in seqr's URLs. The rule is meant to prevent windows command injection, so I don't think we need to worry too much about them.

2) Modify the default list of allowed Content-Types. We had many POST requests to a `/api/matchmaker/v1/match` uri, which had the content-type set to `application/vnd.ga4gh.matchmaker.v1.0+json`, and these looked like legitimate requests to me.

3) The changed comment is above the removal of rule 920350 so that we remember what that does. This OWASP rule blocks requests from localhost/private networks. Many of the requests coming through kubernetes (both actual app traffic and health checking) appear to be internal traffic, and need to be allowed. So this rule is disabled to allow the app to work.