### PR TITLE
switch to the latest recommended modsecurity regex format

### DIFF
--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -175,7 +175,7 @@ data:
     SecRuleRemoveById 932115
     Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
     # adds application/vnd.ga4gh.matchmaker.v1.0+json to the list of allowed content-types
-    SecAction "id:900220,phase:1,nolog,pass,t:none,setvar:\'tx.allowed_request_content_type=application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/soap+xml|application/x-amf|application/json|application/octet-stream|text/plain|application/vnd.ga4gh.matchmaker.v1.0+json\'"
+    SecAction "id:900220,phase:1,nolog,pass,t:none,setvar:\'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |application/vnd.ga4gh.matchmaker.v1.0+json| |text/plain|\'"
 ---
 # docs @ https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
 kind: Ingress


### PR DESCRIPTION
The rule update to allow the matchmaker content-type wasn't working. This rule change updates us to modsecurity's latest syntax, and appears to be correctly allowing our matchmaker requests through.