### PR TITLE
Use diifferent secrets for different envs

### DIFF
--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -75,7 +75,7 @@ SECRETS = {
     'nginx': ['{deploy_to}/tls.key', '{deploy_to}/tls.crt'],
     'seqr': [
         'omim_key', 'postmark_server_token', 'slack_token', 'airtable_key', 'django_key', 'seqr_es_password',
-        'google_client_id',  'google_client_secret'
+        '{deploy_to}/google_client_id',  '{deploy_to}/google_client_secret'
     ],
 }
 


### PR DESCRIPTION
This allows us to use different gcloud client ids for different environments. This doesn't change the command you need to run to deploy secrets