### PR TITLE
enable the WAF

### DIFF
--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -190,7 +190,7 @@ metadata:
       grpc_set_header l5d-dst-override $service_name.$namespace.svc.cluster.local:$service_port;
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
This changes the WAF from detect-only to enforcing. Requests that match one of the OWASP filters will receive a 403.