### PR TITLE
X frame options

### DIFF
--- a/seqr/views/apis/staff_api.py
+++ b/seqr/views/apis/staff_api.py
@@ -1512,7 +1512,7 @@ def proxy_to_kibana(request):
         token = base64.b64encode('kibana:{}'.format(KIBANA_ELASTICSEARCH_PASSWORD).encode('utf-8'))
         headers['Authorization'] = 'Basic {}'.format(token.decode('utf-8'))
 
-    url = "{scheme}://{host}{path}".format(scheme=request.scheme, host=KIBANA_SERVER, path=request.get_full_path())
+    url = "http://{host}{path}".format(host=KIBANA_SERVER, path=request.get_full_path())
 
     request_method = getattr(requests.Session(), request.method.lower())
 

--- a/settings.py
+++ b/settings.py
@@ -62,6 +62,7 @@ ALLOWED_HOSTS = ['*']
 
 CSRF_COOKIE_NAME = 'csrf_token'
 CSRF_COOKIE_HTTPONLY = False
+X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # django-debug-toolbar settings
 ENABLE_DJANGO_DEBUG_TOOLBAR = False


### PR DESCRIPTION
These changes:

- sets Django back to the pre-3.0 default of X-Frame-Options response headers to `SAMEORIGIN`
- sets the proxy_to_kibana method to explicitly speak http, since kibana is not configured to speak https.