### PR TITLE
adds a whitelist rule for requests to /complete/google

### DIFF
--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -173,6 +173,8 @@ data:
     SecRuleRemoveById 920350
     # regex match for windows command injection, contained many false positives
     SecRuleRemoveById 932115
+    # whitelist google auth requests from local file access attempt rule
+    SecRule REQUEST_URI "@beginsWith /complete/google" "id:2000,phase:2,pass,nolog,ctl:ruleRemoveById=930120"
     Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
     # adds application/vnd.ga4gh.matchmaker.v1.0+json to the list of allowed content-types
     SecAction "id:900220,phase:1,nolog,pass,t:none,setvar:\'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |application/vnd.ga4gh.matchmaker.v1.0+json| |text/plain|\'"

--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -174,7 +174,7 @@ data:
     # regex match for windows command injection, contained many false positives
     SecRuleRemoveById 932115
     # whitelist google auth requests from local file access attempt rule
-    SecRule REQUEST_URI "@beginsWith /complete/google" "id:2000,phase:2,pass,nolog,ctl:ruleRemoveById=930120"
+    SecRule REQUEST_URI "@beginsWith /complete/google-oauth2" "id:2000,phase:2,pass,nolog,ctl:ruleRemoveById=930120"
     Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
     # adds application/vnd.ga4gh.matchmaker.v1.0+json to the list of allowed content-types
     SecAction "id:900220,phase:1,nolog,pass,t:none,setvar:\'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |application/vnd.ga4gh.matchmaker.v1.0+json| |text/plain|\'"


### PR DESCRIPTION
Requests for completing google authentication were getting caught by the WAF because they contained the string `.profile` in the request uri (`.profile` is a common file that gets looked for when scanning for inadvertently exposed secrets).

I believe this whitelist will turn off that rule when the request uri begins with `/complete/google`.