### PR TITLE
do not regenerate postgres password

### DIFF
--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -4,7 +4,6 @@ import logging
 import os
 from pprint import pformat
 import time
-import uuid
 
 from deploy.servctl_utils.other_command_utils import check_kubernetes_context, set_environment, get_disk_names
 from deploy.servctl_utils.kubectl_utils import is_pod_running, get_pod_name, get_node_name, run_in_pod, \
@@ -73,6 +72,7 @@ SECRETS = {
     'kibana': ['elasticsearch.password'],
     'matchbox': ['{deploy_to}/config.json'],
     'nginx': ['{deploy_to}/tls.key', '{deploy_to}/tls.crt'],
+    'postgres': ['password'],
     'seqr': [
         'omim_key', 'postmark_server_token', 'slack_token', 'airtable_key', 'django_key', 'seqr_es_password',
         '{deploy_to}/google_client_id',  '{deploy_to}/google_client_secret'
@@ -179,8 +179,6 @@ def deploy_secrets(settings):
                     secret_label=secret_label, deploy_to_prefix=settings['DEPLOY_TO_PREFIX'], file=file)
                 for file in SECRETS[secret_label]
             ]
-        elif secret_label == 'postgres':
-            secret_command.append('--from-literal=password={}'.format(uuid.uuid4()))
         else:
             raise ValueError('Invalid secret component {}'.format(secret_label))
         if secret_label == GCLOUD_CLIENT:


### PR DESCRIPTION
It turns out this really brings down seqr when we deploy secrets, as the docker image uses the secret when it initializes the db but does not keep it synced. We will manage credential rotation by doing a manual process once a year, until we can move to a google managed postgres instance. I will update the secrets backups with the appropriate new file