### PR TITLE
whitelists a request that was being issued to dismiss a popup in kibana

### DIFF
--- a/deploy/kubernetes/nginx/nginx.yaml
+++ b/deploy/kubernetes/nginx/nginx.yaml
@@ -175,6 +175,8 @@ data:
     SecRuleRemoveById 932115
     # whitelist google auth requests from local file access attempt rule
     SecRule REQUEST_URI "@beginsWith /complete/google-oauth2" "id:2000,phase:2,pass,nolog,ctl:ruleRemoveById=930120"
+    # whitelist popup dismissal in kibana
+    SecRule REQUEST_URI "@beginsWith /api/telemetry/v2/userHasSeenNotice" "id:2001,phase:2,pass,nolog,ctl:ruleRemoveById=911100"
     Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf
     # adds application/vnd.ga4gh.matchmaker.v1.0+json to the list of allowed content-types
     SecAction "id:900220,phase:1,nolog,pass,t:none,setvar:\'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/x-amf| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json| |application/octet-stream| |application/csp-report| |application/xss-auditor-report| |application/vnd.ga4gh.matchmaker.v1.0+json| |text/plain|\'"


### PR DESCRIPTION
`PUT` requests to `/api/telemetry/v2/userHasSeenNotice` were being denied by the WAF, which meant we couldn't dismiss a popup/notice that kept appearing inside kibana.