### PR TITLE
disable redis protocol inspection

### DIFF
--- a/deploy/kubernetes/redis/redis.gcloud.yaml
+++ b/deploy/kubernetes/redis/redis.gcloud.yaml
@@ -26,6 +26,8 @@ spec:
     metadata:
       annotations:
         linkerd.io/inject: enabled
+        config.linkerd.io/skip-outbound-ports: "6379"
+        config.linkerd.io/skip-inbound-ports: "6379"
       labels:
         name: redis
         deployment: {{ DEPLOY_TO }}

--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/inject: enabled
+        config.linkerd.io/skip-outbound-ports: "6379"
       labels:
         name: seqr
         deployment: {{ DEPLOY_TO }}


### PR DESCRIPTION
Linkerd's protocol inspection appears to create issues with seqr's communication to redis (I suspect this is our bug: https://github.com/linkerd/linkerd2/issues/5344). We didn't see this in dev, but our testing wasn't really sufficient.

skipping these ports fixed search within seqr prod -- we'll try the proposed fix from the upstream issue in dev once we can reproduce the problem there.