### PR TITLE
exempt postgres until we can try linkerd's opaque ports

### DIFF
--- a/deploy/kubernetes/postgres/postgres.gcloud.yaml
+++ b/deploy/kubernetes/postgres/postgres.gcloud.yaml
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/inject: enabled
+        config.linkerd.io/skip-inbound-ports: "5432"
       labels:
         name: postgres
         deployment: {{ DEPLOY_TO }}

--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -31,6 +31,7 @@ spec:
       annotations:
         linkerd.io/inject: enabled
         config.linkerd.io/skip-outbound-ports: "6379"
+        config.linkerd.io/skip-outbound-ports: "5432"
       labels:
         name: seqr
         deployment: {{ DEPLOY_TO }}


### PR DESCRIPTION
This change is in response to pg_dumps failing in seqr. My understanding is that connections to the postgres database are succeeding and normal app usage is fine, but dumps are performing very slowly (or the connections are timing out and leaving the dump stuck part-way through). We'll have to test linkerd's new opaque ports setting when 2.10 is released. This may help with timeouts, but may not help with performance; we'll need further investigation later if that doesn't fix the problem.

Once the ports are exempted from the mesh, dumps succeed in a reasonable amount of time.