### PR TITLE
multiple port skips need to be a comma separated string

### DIFF
--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -30,8 +30,7 @@ spec:
     metadata:
       annotations:
         linkerd.io/inject: enabled
-        config.linkerd.io/skip-outbound-ports: "6379"
-        config.linkerd.io/skip-outbound-ports: "5432"
+        config.linkerd.io/skip-outbound-ports: "6379,5432"
       labels:
         name: seqr
         deployment: {{ DEPLOY_TO }}


### PR DESCRIPTION
When skipping multiple ports, they need to be supplied in a comma separated string, or only the last annotation applies. So, in this case, redis was timing out after skipping the postgres port 😞 

I've applied this hotfix on prod, and both ports are now skipped there.