### PR TITLE
Fix deploy pipeline runner command

### DIFF
--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -357,8 +357,6 @@ def deploy_pipeline_runner(settings):
         "-f deploy/docker/%(COMPONENT_LABEL)s/Dockerfile",
     ])
 
-    deploy_pod("pipeline-runner", settings, wait_until_pod_is_running=True)
-
 
 def deploy_kube_scan(settings):
     print_separator("kube-scan")


### PR DESCRIPTION
We have a command for deploying pipeline runner as we need to maintain a docker image for local deploys. However, there is no pipeline runner kubernetes pod in our deployment so the `deploy_pod` line just fails and isn't needed