### PR TITLE
Added login restrictions to privileged users.

### DIFF
--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -11,7 +11,7 @@ import logging
 
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.permissions_utils import user_is_data_manager
-from settings import SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
+from seqr.views.utils.terra_api_utils import google_auth_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -19,24 +19,29 @@ logger = logging.getLogger(__name__)
 def login_view(request):
     request_json = json.loads(request.body)
     if not request_json.get('email'):
-        return create_json_response({}, status=400, reason='Email is required')
+        error = 'Email is required'
+        return create_json_response({'error': error}, status=400, reason=error)
     if not request_json.get('password'):
-        return create_json_response({}, status=400, reason='Password is required')
+        error = 'Password is required'
+        return create_json_response({'error': error}, status=400, reason=error)
 
     # Django's iexact filtering will improperly match unicode characters, which creates a security risk.
     # Instead, query for the lower case match to allow case-insensitive matching
     users = User.objects.annotate(email_lower=Lower('email')).filter(email_lower=request_json['email'].lower())
     if users.count() != 1:
-        return create_json_response({}, status=401, reason='Invalid credentials')
+        error = 'Invalid credentials'
+        return create_json_response({'error': error}, status=401, reason=error)
 
     user = users.first()
-    if SOCIAL_AUTH_GOOGLE_OAUTH2_KEY and (user_is_data_manager(user) or user.is_superuser):
+    if google_auth_enabled() and (user_is_data_manager(user) or user.is_superuser):
         logger.warning("Privileged user {} is trying to login without Google authentication.".format(user))
-        return create_json_response({}, status=401, reason='Privileged user must login with Google authentication.')
+        error = 'Privileged user must login with Google authentication.'
+        return create_json_response({'error': error}, status=401, reason=error)
 
     u = authenticate(username=user.username, password=request_json['password'])
     if not u:
-        return create_json_response({}, status=401, reason='Invalid credentials')
+        error = 'Invalid credentials'
+        return create_json_response({'error': error}, status=401, reason=error)
 
     login(request, u)
     logger.info('Logged in {}'.format(u.email), extra={'user': u})

--- a/seqr/views/apis/auth_api_tests.py
+++ b/seqr/views/apis/auth_api_tests.py
@@ -88,7 +88,7 @@ class AuthAPITest(TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.reason_phrase, 'Invalid credentials')
 
-    @mock.patch('seqr.views.apis.auth_api.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', 'test_key')
+    @mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', 'test_key')
     def test_login_view_with_google(self):
         url = reverse(login_view)
 
@@ -110,6 +110,17 @@ class AuthAPITest(TestCase):
                                     data=json.dumps(req_values))
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.reason_phrase, 'Privileged user must login with Google authentication.')
+
+        # send login request with a non-privileged user and a correct password
+        req_values = {
+            'email': 'test_new_user@institute.com',
+            'password': 'password123'
+        }
+        response = self.client.post(url, content_type='application/json',
+                                    data=json.dumps(req_values))
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertTrue(response_json['success'])
 
     def test_logout_view(self):
         url = reverse(login_view)

--- a/seqr/views/apis/auth_api_tests.py
+++ b/seqr/views/apis/auth_api_tests.py
@@ -1,3 +1,4 @@
+import mock
 import json
 
 from django.test import TestCase
@@ -67,6 +68,48 @@ class AuthAPITest(TestCase):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertTrue(response_json['success'])
+
+        # send login request with a privileged account (data manage or superuser) while Google auth is not enabled
+        req_values = {
+            'email': 'test_data_manager@test.com',
+            'password': 'not-a-password'
+        }
+        response = self.client.post(url, content_type='application/json',
+                                    data=json.dumps(req_values))
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.reason_phrase, 'Invalid credentials')
+
+        req_values = {
+            'email': 'test_superuser@test.com',
+            'password': 'not-a-password'
+        }
+        response = self.client.post(url, content_type='application/json',
+                                    data=json.dumps(req_values))
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.reason_phrase, 'Invalid credentials')
+
+    @mock.patch('seqr.views.apis.auth_api.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', 'test_key')
+    def test_login_view_with_google(self):
+        url = reverse(login_view)
+
+        # send login request with a privileged account (data manage or superuser) while Google auth is enabled
+        req_values = {
+            'email': 'test_data_manager@test.com',
+            'password': 'not-a-password'
+        }
+        response = self.client.post(url, content_type='application/json',
+                                    data=json.dumps(req_values))
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.reason_phrase, 'Privileged user must login with Google authentication.')
+
+        req_values = {
+            'email': 'test_superuser@test.com',
+            'password': 'not-a-password'
+        }
+        response = self.client.post(url, content_type='application/json',
+                                    data=json.dumps(req_values))
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.reason_phrase, 'Privileged user must login with Google authentication.')
 
     def test_logout_view(self):
         url = reverse(login_view)

--- a/seqr/views/react_app.py
+++ b/seqr/views/react_app.py
@@ -6,8 +6,9 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.middleware.csrf import rotate_token
 from django.template import loader
 from django.http import HttpResponse
-from settings import SEQR_VERSION, SEQR_PRIVACY_VERSION, SEQR_TOS_VERSION, CSRF_COOKIE_NAME, DEBUG, SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
+from settings import SEQR_VERSION, SEQR_PRIVACY_VERSION, SEQR_TOS_VERSION, CSRF_COOKIE_NAME, DEBUG
 from seqr.views.utils.orm_to_json_utils import _get_json_for_user
+from seqr.views.utils.terra_api_utils import google_auth_enabled
 
 
 @login_required
@@ -46,7 +47,7 @@ def _render_app_html(request, initial_json):
     initial_json['meta'] = {
         'version': '{}-{}'.format(SEQR_VERSION, ui_version),
         'hijakEnabled': DEBUG or False,
-        'googleLoginEnabled': bool(SOCIAL_AUTH_GOOGLE_OAUTH2_KEY),
+        'googleLoginEnabled': google_auth_enabled(),
     }
 
     html = html.replace(

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -11,7 +11,7 @@ from django.core.exceptions import PermissionDenied
 from social_django.models import UserSocialAuth
 from social_django.utils import load_strategy
 
-from settings import SEQR_VERSION, TERRA_API_ROOT_URL
+from settings import SEQR_VERSION, TERRA_API_ROOT_URL, SOCIAL_AUTH_GOOGLE_OAUTH2_KEY
 
 SEQR_USER_AGENT = "seqr/" + SEQR_VERSION
 
@@ -24,6 +24,10 @@ class TerraAPIException(Exception):
 
 class TerraNotFoundException(TerraAPIException):
     pass
+
+
+def google_auth_enabled():
+    return bool(SOCIAL_AUTH_GOOGLE_OAUTH2_KEY)
 
 
 def anvil_enabled():


### PR DESCRIPTION
All privileged users (data managers and superusers) must log in with Google Auth if Google Auth is enabled.