### PR TITLE
Local pm and analyst permissions

### DIFF
--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -178,6 +178,12 @@ spec:
           value: "{{ TERRA_PERMS_CACHE_EXPIRE_SECONDS }}"
         - name: TERRA_WORKSPACE_CACHE_EXPIRE_SECONDS
           value: "{{ TERRA_WORKSPACE_CACHE_EXPIRE_SECONDS }}"
+        - name: ANALYST_PROJECT_CATEGORY
+          value: "{{ ANALYST_PROJECT_CATEGORY }}"
+        - name: ANALYST_USER_GROUP
+          value: "{{ ANALYST_USER_GROUP }}"
+        - name: PM_USER_GROUP
+          value: "{{ PM_USER_GROUP }}"
         readinessProbe:
           exec:
             command:

--- a/deploy/kubernetes/shared-settings.yaml
+++ b/deploy/kubernetes/shared-settings.yaml
@@ -38,6 +38,11 @@ ELASTICSEARCH_PROTOCOL: http
 SEQR_GIT_BRANCH: 'master'
 POSTGRES_USERNAME: postgres
 
+ANALYST_PROJECT_CATEGORY: analyst-projects
+ANALYST_USER_GROUP: analysts
+PM_USER_GROUP: project-managers
+
+
 # this is a security measure to prevent kubectl commands from working unless they are run on a machine with a listed ip address
 # this allows cluster administration only from known machines or from machines on google cloud.
 MASTER_AUTHORIZED_NETWORKS: '69.173.112.0/21,69.173.127.232/29,69.173.127.128/26,69.173.127.0/25,69.173.127.240/28,69.173.127.224/30,69.173.127.230/31,69.173.120.0/22,69.173.127.228/32,69.173.126.0/24,69.173.96.0/20,69.173.64.0/19,69.173.127.192/27,69.173.124.0/23'

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -164,7 +164,9 @@ class MatchmakerAPITest(AuthenticationTestCase):
     databases = '__all__'
     fixtures = ['users', '1kg_project', 'reference_data']
 
-    def test_get_individual_mme_matches(self):
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
+    def test_get_individual_mme_matches(self, mock_analyst_group):
         url = reverse(get_individual_mme_matches, args=[SUBMISSION_GUID])
         self.check_collaborator_login(url)
 
@@ -246,11 +248,18 @@ class MatchmakerAPITest(AuthenticationTestCase):
 
         self.login_analyst_user()
         response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertDictEqual(response_json['mmeResultsByGuid'][RESULT_STATUS_GUID], PARSED_RESULT)
         self.assertFalse('originatingSubmission' in response_json['mmeResultsByGuid']['MR0007228_VCGS_FAM50_156'])
 
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP', 'analysts')
     @mock.patch('seqr.utils.communication_utils.SLACK_TOKEN', MOCK_SLACK_TOKEN)
     @mock.patch('seqr.utils.communication_utils.logger')
     @mock.patch('seqr.utils.communication_utils.Slacker')
@@ -865,6 +874,8 @@ class MatchmakerAPITest(AuthenticationTestCase):
         self.assertEqual(response.reason_phrase, 'email error')
         self.assertDictEqual(response.json(), {'error': 'no connection'})
 
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP', 'analysts')
     def test_update_mme_contact_note(self):
         url = reverse(update_mme_contact_note, args=['GeneDx'])
         self.check_analyst_login(url)

--- a/seqr/migrations/0020_remove_project_disable_staff_access.py
+++ b/seqr/migrations/0020_remove_project_disable_staff_access.py
@@ -4,8 +4,9 @@
 
 from django.db import migrations
 
-from settings import ANALYST_PROJECT_CATEGORY, ANALYST_USER_GROUP, PM_USER_GROUP
-
+ANALYST_PROJECT_CATEGORY = 'analyst-projects'
+ANALYST_USER_GROUP = 'analysts'
+PM_USER_GROUP = 'project-managers'
 
 def create_analyst_project_group(apps, schema_editor):
     ProjectCategory = apps.get_model('seqr', 'ProjectCategory')

--- a/seqr/views/apis/dashboard_api_tests.py
+++ b/seqr/views/apis/dashboard_api_tests.py
@@ -37,6 +37,8 @@ DASHBOARD_PROJECT_FIELDS.update(PROJECT_FIELDS)
 
 class DashboardPageTest(object):
 
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP', 'analysts')
     def test_dashboard_page_data(self):
         url = reverse(dashboard_page_data)
         self.check_require_login(url)
@@ -70,6 +72,7 @@ class DashboardPageTest(object):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.json()['projectsByGuid']), 4)
 
+    @mock.patch('seqr.views.utils.orm_to_json_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
     def test_export_projects_table(self):
         url = reverse(export_projects_table_handler)
         self.check_require_login(url)

--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import mock
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls.base import reverse
@@ -22,7 +23,8 @@ PREVIOUS_FAMILY_ID_FIELD = 'previousFamilyId'
 class FamilyAPITest(AuthenticationTestCase):
     fixtures = ['users', '1kg_project']
 
-    def test_edit_families_handler(self):
+    @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
+    def test_edit_families_handler(self, mock_pm_group):
         url = reverse(edit_families_handler, args=[PROJECT_GUID])
         self.check_manager_login(url)
 
@@ -56,12 +58,19 @@ class FamilyAPITest(AuthenticationTestCase):
         url = reverse(edit_families_handler, args=[PM_REQUIRED_PROJECT_GUID])
         response = self.client.post(url, content_type='application/json', data=json.dumps({}))
         self.assertEqual(response.status_code, 403)
+
         self.login_pm_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+        mock_pm_group.__bool__.return_value = True
+        mock_pm_group.resolve_expression.return_value = 'project-managers'
+
         response = self.client.post(url, content_type='application/json', data=json.dumps({
             'families': [{'familyGuid': 'F000012_12'}]}))
         self.assertEqual(response.status_code, 200)
 
-    def test_delete_families_handler(self):
+    @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
+    def test_delete_families_handler(self, mock_pm_group):
         url = reverse(delete_families_handler, args=[PROJECT_GUID])
         self.check_manager_login(url)
 
@@ -88,7 +97,13 @@ class FamilyAPITest(AuthenticationTestCase):
         url = reverse(delete_families_handler, args=[PM_REQUIRED_PROJECT_GUID])
         response = self.client.post(url, content_type='application/json', data=json.dumps({}))
         self.assertEqual(response.status_code, 403)
+
         self.login_pm_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+        mock_pm_group.__bool__.return_value = True
+        mock_pm_group.resolve_expression.return_value = 'project-managers'
+
         response = self.client.post(url, content_type='application/json', data=json.dumps({
             'families': [{'familyGuid': 'F000012_12'}]}))
         self.assertEqual(response.status_code, 200)
@@ -159,14 +174,21 @@ class FamilyAPITest(AuthenticationTestCase):
         self.assertListEqual(list(response_json.keys()), [FAMILY_GUID])
         self.assertIsNone(response_json[FAMILY_GUID]['assignedAnalyst'])
 
-    def test_update_success_story_types(self):
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
+    def test_update_success_story_types(self, mock_analyst_group):
         url = reverse(update_family_fields_handler, args=[FAMILY_GUID])
         self.check_manager_login(url)
 
         response = self.client.post(url, content_type='application/json',
                                     data=json.dumps({'successStoryTypes': ['O', 'D']}))
         self.assertEqual(response.status_code, 403)
+
         self.login_analyst_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
 
         # send valid request
         response = self.client.post(url, content_type='application/json',
@@ -175,7 +197,8 @@ class FamilyAPITest(AuthenticationTestCase):
         response_json = response.json()
         self.assertListEqual(response_json[FAMILY_GUID]['successStoryTypes'], ['O', 'D'])
 
-    def test_receive_families_table_handler(self):
+    @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
+    def test_receive_families_table_handler(self, mock_pm_group):
         url = reverse(receive_families_table_handler, args=[PROJECT_GUID])
         self.check_manager_login(url)
 
@@ -229,6 +252,12 @@ class FamilyAPITest(AuthenticationTestCase):
         url = reverse(receive_families_table_handler, args=[PM_REQUIRED_PROJECT_GUID])
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
+
         self.login_pm_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+        mock_pm_group.__bool__.return_value = True
+        mock_pm_group.resolve_expression.return_value = 'project-managers'
+
         response = self.client.post(url, {'f': SimpleUploadedFile('families.tsv', 'Family ID\n1'.encode('utf-8'))})
         self.assertEqual(response.status_code, 200)

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -55,7 +55,8 @@ def create_project_handler(request):
     }
 
     project = create_model_from_json(Project, project_args, user=request.user)
-    ProjectCategory.objects.get(name=ANALYST_PROJECT_CATEGORY).projects.add(project)
+    if ANALYST_PROJECT_CATEGORY:
+        ProjectCategory.objects.get(name=ANALYST_PROJECT_CATEGORY).projects.add(project)
 
     return create_json_response({
         'projectsByGuid': {

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -17,6 +17,8 @@ EMPTY_PROJECT_GUID = 'R0002_empty'
 
 class ProjectAPITest(object):
 
+    @mock.patch('seqr.views.apis.project_api.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP', 'project-managers')
     def test_create_update_and_delete_project(self):
         create_project_url = reverse(create_project_handler)
         self.check_pm_login(create_project_url)
@@ -68,7 +70,27 @@ class ProjectAPITest(object):
         new_project = Project.objects.filter(name='new_project')
         self.assertEqual(len(new_project), 0)
 
-    def test_project_page_data(self):
+    def test_create_project_no_pm(self):
+        create_project_url = reverse(create_project_handler)
+        self.check_superuser_login(create_project_url)
+
+        response = self.client.post(create_project_url, content_type='application/json', data=json.dumps(
+            {'name': 'new_project', 'description': 'new project description', 'genomeVersion': '38'}
+        ))
+        self.assertEqual(response.status_code, 200)
+
+        # check that project was created
+        new_project = Project.objects.get(name='new_project')
+        self.assertEqual(new_project.description, 'new project description')
+        self.assertEqual(new_project.genome_version, '38')
+        self.assertEqual(new_project.created_by, self.super_user)
+        self.assertListEqual([], list(new_project.projectcategory_set.all()))
+
+        self.assertSetEqual(set(response.json()['projectsByGuid'].keys()), {new_project.guid})
+
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
+    def test_project_page_data(self, mock_analyst_group):
         url = reverse(project_page_data, args=[PROJECT_GUID])
         self.check_collaborator_login(url)
 
@@ -130,6 +152,11 @@ class ProjectAPITest(object):
 
         # Test analyst users have internal fields returned
         self.login_analyst_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -216,9 +243,11 @@ class AnvilProjectAPITest(AnvilAuthenticationTestCase, ProjectAPITest):
         self.mock_get_ws_acl.assert_called_with(self.analyst_user,
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
         self.assertEqual(self.mock_get_ws_acl.call_count, 2)
-        self.mock_get_ws_access_level.assert_called_with(self.collaborator_user,
+        self.mock_get_ws_access_level.assert_called_with(self.analyst_user,
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-        self.assertEqual(self.mock_get_ws_access_level.call_count, 5)
+        self.mock_get_ws_access_level.assert_any_call(self.collaborator_user,
+            'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 6)
 
     def test_empty_project_page_data(self):
         url = reverse(project_page_data, args=[EMPTY_PROJECT_GUID])
@@ -247,9 +276,11 @@ class MixProjectAPITest(MixAuthenticationTestCase, ProjectAPITest):
         self.mock_get_ws_acl.assert_called_with(self.analyst_user,
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
         self.assertEqual(self.mock_get_ws_acl.call_count, 2)
-        self.mock_get_ws_access_level.assert_called_with(self.collaborator_user,
+        self.mock_get_ws_access_level.assert_any_call(self.collaborator_user,
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-        self.assertEqual(self.mock_get_ws_access_level.call_count, 4)
+        self.mock_get_ws_access_level.assert_called_with(self.analyst_user,
+             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 5)
 
     def test_empty_project_page_data(self):
         super(MixProjectAPITest, self).test_empty_project_page_data()

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -106,7 +106,10 @@ INVALID_CREATE_VARIANT_REQUEST_BODY['variant']['chrom'] = '27'
 
 class SavedVariantAPITest(object):
 
-    def test_saved_variant_data(self):
+    @mock.patch('seqr.views.apis.saved_variant_api.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
+    def test_saved_variant_data(self, mock_analyst_group):
         url = reverse(saved_variant_data, args=['R0001_1kg'])
         self.check_collaborator_login(url)
 
@@ -159,6 +162,10 @@ class SavedVariantAPITest(object):
 
         # Test cross-project discovery for analyst users
         self.login_analyst_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
@@ -775,7 +782,7 @@ class AnvilSavedVariantAPITest(AnvilAuthenticationTestCase, SavedVariantAPITest)
 
     def test_saved_variant_data(self):
         super(AnvilSavedVariantAPITest, self).test_saved_variant_data()
-        assert_no_list_ws_has_al(self, 5)
+        assert_no_list_ws_has_al(self, 6)
 
     def test_create_saved_variant(self):
         super(AnvilSavedVariantAPITest, self).test_create_saved_variant()
@@ -832,7 +839,7 @@ class MixSavedVariantAPITest(MixAuthenticationTestCase, SavedVariantAPITest):
 
     def test_saved_variant_data(self):
         super(MixSavedVariantAPITest, self).test_saved_variant_data()
-        assert_no_list_ws_has_al(self, 1)
+        assert_no_list_ws_has_al(self, 2)
 
     def test_create_saved_variant(self):
         super(MixSavedVariantAPITest, self).test_create_saved_variant()

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -23,10 +23,18 @@ EXPECTED_MME_DETAILS_METRICS = {
 class SummaryDataAPITest(AuthenticationTestCase):
     fixtures = ['users', '1kg_project', 'reference_data']
 
+    @mock.patch('seqr.views.apis.summary_data_api.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     @mock.patch('matchmaker.matchmaker_utils.datetime')
-    def test_mme_details(self, mock_datetime):
+    def test_mme_details(self, mock_datetime, mock_analyst_group):
         url = reverse(mme_details)
         self.check_analyst_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
 
         mock_datetime.now.return_value = datetime(2020, 4, 27, 20, 16, 1)
         response = self.client.get(url)
@@ -38,9 +46,17 @@ class SummaryDataAPITest(AuthenticationTestCase):
         self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000233750', 'ENSG00000227232', 'ENSG00000223972', 'ENSG00000186092'})
         self.assertEqual(len(response_json['submissions']), 3)
 
-    def test_success_story(self):
+    @mock.patch('seqr.views.apis.summary_data_api.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
+    def test_success_story(self, mock_analyst_group):
         url = reverse(success_story, args=['all'])
         self.check_analyst_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -60,10 +76,18 @@ class SummaryDataAPITest(AuthenticationTestCase):
         self.assertEqual(len(response_json['rows']), 1)
         self.assertDictEqual(response_json['rows'][0], EXPECTED_SUCCESS_STORY)
 
+    @mock.patch('seqr.views.apis.summary_data_api.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     @mock.patch('seqr.views.apis.summary_data_api.MAX_SAVED_VARIANTS', 1)
-    def test_saved_variants_page(self):
+    def test_saved_variants_page(self, mock_analyst_group):
         url = reverse(saved_variants_page, args=['Tier 1 - Novel gene and phenotype'])
         self.check_analyst_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        mock_analyst_group.__bool__.return_value = True
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 400)

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -21,6 +21,8 @@ USER_OPTION_FIELDS = {'displayName', 'firstName', 'lastName', 'username', 'email
 
 class UsersAPITest(object):
 
+    @mock.patch('seqr.views.apis.users_api.ANALYST_USER_GROUP', 'analysts')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP', 'analysts')
     def test_get_all_analyst_options(self):
         get_all_analyst_url = reverse(get_all_analyst_options)
         self.check_require_login(get_all_analyst_url)

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -9,7 +9,7 @@ from seqr.views.utils.terra_api_utils import is_google_authenticated, user_get_w
 from settings import API_LOGIN_REQUIRED_URL, ANALYST_USER_GROUP, PM_USER_GROUP, ANALYST_PROJECT_CATEGORY
 
 def user_is_analyst(user):
-    return ANALYST_USER_GROUP and user.groups.filter(name=ANALYST_USER_GROUP).exists()
+    return bool(ANALYST_USER_GROUP) and user.groups.filter(name=ANALYST_USER_GROUP).exists()
 
 def user_is_data_manager(user):
     return user.is_staff

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -9,13 +9,13 @@ from seqr.views.utils.terra_api_utils import is_google_authenticated, user_get_w
 from settings import API_LOGIN_REQUIRED_URL, ANALYST_USER_GROUP, PM_USER_GROUP, ANALYST_PROJECT_CATEGORY
 
 def user_is_analyst(user):
-    return user.groups.filter(name=ANALYST_USER_GROUP).exists()
+    return ANALYST_USER_GROUP and user.groups.filter(name=ANALYST_USER_GROUP).exists()
 
 def user_is_data_manager(user):
     return user.is_staff
 
 def user_is_pm(user):
-    return user.groups.filter(name=PM_USER_GROUP).exists()
+    return user.groups.filter(name=PM_USER_GROUP).exists() if PM_USER_GROUP else user.is_superuser
 
 # User access decorators
 analyst_required = user_passes_test(user_is_analyst, login_url=API_LOGIN_REQUIRED_URL)

--- a/settings.py
+++ b/settings.py
@@ -261,9 +261,9 @@ AIRTABLE_API_KEY = os.environ.get("AIRTABLE_API_KEY")
 
 API_LOGIN_REQUIRED_URL = '/api/login-required-error'
 
-ANALYST_PROJECT_CATEGORY = 'analyst-projects'
-ANALYST_USER_GROUP = 'analysts'
-PM_USER_GROUP = 'project-managers'
+ANALYST_PROJECT_CATEGORY = os.environ.get('ANALYST_PROJECT_CATEGORY')
+ANALYST_USER_GROUP = os.environ.get('ANALYST_USER_GROUP')
+PM_USER_GROUP = os.environ.get('PM_USER_GROUP')
 
 # External service settings
 ELASTICSEARCH_SERVICE_HOSTNAME = os.environ.get('ELASTICSEARCH_SERVICE_HOSTNAME', 'localhost')


### PR DESCRIPTION
Changes the way PM and analyst permissions are handles in local installs. For local installations, where the user groups are not defined, PM permissions are made available to superusers and analyst permissions are not made available to anyone. This makes no changes tot our current production seqr, which will continue to use groups for PMs and analysts