### PR TITLE
feat (#1627): Ensure es client code is backwards compatible with ES6

### DIFF
--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -558,7 +558,8 @@ class EsSearch(object):
             response_hits, response_total = self._parse_compound_het_response(response)
             return response_hits, response_total, True, index_name
 
-        response_total = response.hits.total['value']
+        hits_total = response.hits.total
+        response_total = hits_total if (isinstance(hits_total, int)) else hits_total['value']
         logger.info('Total hits: {} ({} seconds)'.format(response_total, response.took / 1000.0))
         return [self._parse_hit(hit) for hit in response], response_total, False, index_name
 

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -50,7 +50,8 @@ def get_index_metadata(index_name, client, include_fields=False, use_cache=True)
             index_name, e.error if hasattr(e, 'error') else str(e)))
     index_metadata = {}
     for index_name, mapping in mappings.items():
-        variant_mapping = mapping['mappings']
+        variant_mapping_type = mapping['mappings'].get('variant', mapping['mappings'].get('structural_variant', None))
+        variant_mapping = mapping['mappings'] if variant_mapping_type is None else variant_mapping_type
         index_metadata[index_name] = variant_mapping.get('_meta', {})
         if include_fields:
             index_metadata[index_name]['fields'] = {


### PR DESCRIPTION
As discussed in #1627 - this PR should not be accepted but raising this as a reference for other users on the changes required to work with Elasticsearch 6.

(cherry picked from commit 7ae922efacd9784fbfedaaac1d5615748066f9f6)
