### PR TITLE
feat: Parameterised repo and branch when building Seqr image

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -114,9 +114,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 
 # DISABLE_CACHE work-around to force git pull on every docker build, based on https://github.com/docker/docker/issues/1996
 ARG DISABLE_CACHE=1
+ARG SEQR_REPO=https://github.com/broadinstitute/seqr
+ARG SEQR_GIT_BRANCH=master
 
 # update seqr repo
-RUN git clone -q https://github.com/broadinstitute/seqr
+RUN git clone -q $SEQR_REPO --single-branch --branch $SEQR_GIT_BRANCH
 
 WORKDIR /seqr
 


### PR DESCRIPTION
This change allows forked repos to easily override the repository and branch when building their own images using [docker build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)

Overriding is optional and default values are the same as original.

E.g.:

```bash
docker-compose build \
  --build-arg "SEQR_REPO=https://github.com/ssadedin/seqr" \
  --build-arg "SEQR_GIT_BRANCH=mcri/master"
```

(cherry picked from commit 8c66148a8aa7f57e13de9e5320c2211cda80d6d3)
