### PR TITLE
better error handling for terra errors

### DIFF
--- a/seqr/utils/middleware.py
+++ b/seqr/utils/middleware.py
@@ -9,6 +9,7 @@ import traceback
 
 from seqr.utils.elasticsearch.utils import InvalidIndexException, InvalidSearchException
 from seqr.views.utils.json_utils import create_json_response
+from seqr.views.utils.terra_api_utils import TerraAPIException
 from settings import DEBUG
 
 logger = logging.getLogger()
@@ -22,6 +23,7 @@ EXCEPTION_ERROR_MAP = {
     elasticsearch.exceptions.ConnectionError: 504,
     elasticsearch.exceptions.TransportError: lambda e: int(e.status_code) if e.status_code != 'N/A' else 400,
     HTTPError: lambda e: int(e.response.status_code),
+    TerraAPIException: lambda e: e.status_code,
 }
 
 EXCEPTION_MESSAGE_MAP = {

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -22,12 +22,23 @@ logger = logging.getLogger(__name__)
 
 class TerraAPIException(Exception):
     def __init__(self, message, status_code):
+        """
+        Custom Exception to capture Terra API call failures
+
+        :param message: error message
+        :param status_code: the status code associated with the failed request
+        """
         super(TerraAPIException, self).__init__(message)
         self.status_code = status_code
 
 
 class TerraNotFoundException(TerraAPIException):
     def __init__(self, message):
+        """
+        Custom Exception to capture Terra API calls that fail with 404 Not Found
+
+        :param message: error message
+        """
         super(TerraNotFoundException, self).__init__(message, 404)
 
 

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -21,11 +21,14 @@ logger = logging.getLogger(__name__)
 
 
 class TerraAPIException(Exception):
-    pass
+    def __init__(self, message, status_code):
+        super(TerraAPIException, self).__init__(message)
+        self.status_code = status_code
 
 
 class TerraNotFoundException(TerraAPIException):
-    pass
+    def __init__(self, message):
+        super(TerraNotFoundException, self).__init__(message, 404)
 
 
 def google_auth_enabled():
@@ -69,7 +72,7 @@ def _get_social_access_token(user):
             social.refresh_token(strategy)
         except Exception as ee:
             logger.warning('Refresh token failed. {}'.format(str(ee)))
-            raise TerraAPIException('Refresh token failed. {}'.format(str(ee)))
+            raise TerraAPIException('Refresh token failed. {}'.format(str(ee)), 401)
     return social.extra_data['access_token']
 
 
@@ -89,7 +92,7 @@ def anvil_call(method, path, access_token, user=None, headers=None, root_url=Non
     if r.status_code != 200:
         logger.error('{} {} {} {} {}'.format(method.upper(), url, r.status_code, len(r.text), user))
         raise TerraAPIException('Error: called Terra API: {} /{} got status: {} with a reason: {}'.format(method.upper(),
-            path, r.status_code, r.reason))
+            path, r.status_code, r.reason), r.status_code)
 
     logger.info('{} {} {} {} {}'.format(method.upper(), url, r.status_code, len(r.text), user))
 

--- a/seqr/views/utils/terra_api_utils_tests.py
+++ b/seqr/views/utils/terra_api_utils_tests.py
@@ -107,7 +107,7 @@ class TerraApiUtilsCase(TestCase):
         mock_logger.reset_mock()
         mock_redis.return_value.get.return_value = None
         responses.add(responses.GET, url, status = 401)
-        with self.assertRaises(Exception) as ec:
+        with self.assertRaises(TerraAPIException) as ec:
             _ = list_anvil_workspaces(user)
         self.assertEqual(str(ec.exception),
             'Error: called Terra API: GET /api/workspaces?fields=public,workspace.name,workspace.namespace got status: 401 with a reason: Unauthorized')
@@ -122,6 +122,7 @@ class TerraApiUtilsCase(TestCase):
             _ = list_anvil_workspaces(user)
         self.assertEqual(str(te.exception),
             'Refresh token failed. 401 Client Error: Unauthorized for url: https://accounts.google.com/o/oauth2/token')
+        self.assertEqual(te.exception.status_code, 401)
         mock_logger.warning.assert_called_with('Refresh token failed. 401 Client Error: Unauthorized for url: https://accounts.google.com/o/oauth2/token')
         self.assertEqual(len(mock_logger.method_calls), 1)
 
@@ -147,6 +148,7 @@ class TerraApiUtilsCase(TestCase):
             _ = user_get_workspace_acl(user, 'my-seqr-billing', 'my-seqr-workspace')
         self.assertEqual(str(ec.exception),
             'Error: called Terra API: GET /api/workspaces/my-seqr-billing/my-seqr-workspace/acl got status: 401 with a reason: Unauthorized')
+        self.assertEqual(ec.exception.status_code, 401)
         mock_logger.error.assert_called_with(
             'GET https://terra.api/api/workspaces/my-seqr-billing/my-seqr-workspace/acl 401 0 test_user')
         self.assertEqual(len(mock_logger.method_calls), 1)


### PR DESCRIPTION
In dev I noticed that when my token refresh failed the API returned an unhandled 500 error and the ui did not show any sort of useful error message. This updates the middleware to correctly handle these errors and return the appropriate response code and json errors to the client