### PR TITLE
do not show last tagged sort on search page

### DIFF
--- a/ui/shared/components/panel/search/VariantSearchResults.jsx
+++ b/ui/shared/components/panel/search/VariantSearchResults.jsx
@@ -13,7 +13,7 @@ import {
   getVariantSearchDisplay,
   getSearchedVariantExportConfig,
 } from 'redux/selectors'
-import { VARIANT_SORT_FIELD_NO_FAMILY_SORT, VARIANT_PAGINATION_FIELD } from '../../../utils/constants'
+import { VARIANT_SEARCH_SORT_FIELD, VARIANT_PAGINATION_FIELD } from '../../../utils/constants'
 import DataLoader from '../../DataLoader'
 import { QueryParamsEditor } from '../../QueryParamEditor'
 import { HorizontalSpacer } from '../../Spacers'
@@ -33,7 +33,7 @@ const LargeRow = styled(Grid.Row)`
 const scrollToTop = () => window.scrollTo(0, 0)
 
 const FIELDS = [
-  VARIANT_SORT_FIELD_NO_FAMILY_SORT,
+  VARIANT_SEARCH_SORT_FIELD,
 ]
 
 export const DisplayVariants = React.memo(({ displayVariants }) =>

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -820,7 +820,7 @@ const VARIANT_SORT_OPTONS = [
       ),
   },
 ]
-const VARIANT_SORT_OPTONS_NO_FAMILY_SORT = VARIANT_SORT_OPTONS.slice(1)
+const VARIANT_SEARCH_SORT_OPTONS = VARIANT_SORT_OPTONS.slice(1, VARIANT_SORT_OPTONS.length - 1)
 
 export const VARIANT_SORT_LOOKUP = VARIANT_SORT_OPTONS.reduce(
   (acc, opt) => ({
@@ -838,7 +838,7 @@ const BASE_VARIANT_SORT_FIELD = {
   label: 'Sort By:',
 }
 export const VARIANT_SORT_FIELD = { ...BASE_VARIANT_SORT_FIELD, options: VARIANT_SORT_OPTONS }
-export const VARIANT_SORT_FIELD_NO_FAMILY_SORT = { ...BASE_VARIANT_SORT_FIELD, options: VARIANT_SORT_OPTONS_NO_FAMILY_SORT }
+export const VARIANT_SEARCH_SORT_FIELD = { ...BASE_VARIANT_SORT_FIELD, options: VARIANT_SEARCH_SORT_OPTONS }
 export const VARIANT_HIDE_EXCLUDED_FIELD = {
   name: 'hideExcluded',
   component: InlineToggle,


### PR DESCRIPTION
Similar to "family" sort, "last tagged" sort should only be shown on the saved variant page, not the search page