### PR TITLE
deploy secrets for individual components

### DIFF
--- a/servctl
+++ b/servctl
@@ -201,6 +201,8 @@ if args.command in [DEPLOY_COMMAND, DEPLOY_ALL_COMMAND]:
                 components_to_connect_to = ["es-kibana"]
             else:
                 components_to_connect_to = []
+        elif components_to_deploy[0] == 'secrets':
+            components_to_connect_to = ['secrets']
         else:
             components_to_connect_to = components_to_deploy
 


### PR DESCRIPTION
I am always stressed out that the `servctl deploy secrets` command deletes and redeploys all secrets for a given environment, since usually I am only updating secrets for one particular component and am worried that I might accidentally be messing up the other ones. This modifies the command parsing so while you still can redeploy all the secrets, you can also specify what component's secrets you want to update, i.e. `servctl deploy secrets nginx`