### PR TITLE
Saved variant performance

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 coverage==5.1
 django-compressor==2.1.1
-django-debug-toolbar==1.11                      # https://github.com/jazzband/django-debug-toolbar
-django-debug-toolbar-request-history==0.0.11    # for debugging database queries on async requests.
+django-debug-toolbar==3.2                      # https://github.com/jazzband/django-debug-toolbar
 mock                                            # mock objects for unit tests
 responses==0.10.15                               # mock HTTP responses for unit tests
 urllib3-mock==0.3.3                             # mock urllib3 for tests

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -19,7 +19,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_f
     get_json_for_variant_functional_data_tag_types, get_json_for_locus_lists, \
     get_json_for_project_collaborator_list, _get_json_for_models, get_json_for_matchmaker_submissions
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
-    check_user_created_object_permissions, pm_required
+    check_user_created_object_permissions, pm_required, user_is_analyst, has_case_review_permissions
 from settings import API_LOGIN_REQUIRED_URL, ANALYST_PROJECT_CATEGORY
 
 
@@ -139,9 +139,10 @@ def project_page_data(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)
     update_project_from_json(project, {'last_accessed_date': timezone.now()}, request.user)
 
-    response = _get_project_child_entities(project, request.user)
+    is_analyst = user_is_analyst(request.user)
+    response = _get_project_child_entities(project, request.user, is_analyst)
 
-    project_json = _get_json_for_project(project, request.user)
+    project_json = _get_json_for_project(project, request.user, is_analyst=is_analyst)
     project_json['collaborators'] = get_json_for_project_collaborator_list(request.user, project)
     project_json['locusListGuids'] = list(response['locusListsByGuid'].keys())
     project_json['detailsLoaded'] = True
@@ -157,12 +158,15 @@ def project_page_data(request, project_guid):
         'projectsByGuid': {project_guid: project_json},
         'genesById': get_genes(gene_ids),
     })
+
     return create_json_response(response)
 
 
-def _get_project_child_entities(project, user):
-    families_by_guid = _retrieve_families(project.guid, user)
-    individuals_by_guid, individual_models = _retrieve_individuals(project.guid, user)
+def _get_project_child_entities(project, user, is_analyst):
+    has_case_review_perm = has_case_review_permissions(project, user)
+
+    families_by_guid = _retrieve_families(project.guid, is_analyst, has_case_review_perm)
+    individuals_by_guid, individual_models = _retrieve_individuals(project.guid, is_analyst, has_case_review_perm)
     for individual_guid, individual in individuals_by_guid.items():
         families_by_guid[individual['familyGuid']]['individualGuids'].add(individual_guid)
     samples_by_guid = _retrieve_samples(
@@ -172,7 +176,7 @@ def _get_project_child_entities(project, user):
         sample_guid_key='igvSampleGuids')
     mme_submissions_by_guid = _retrieve_mme_submissions(individuals_by_guid, individual_models)
     analysis_groups_by_guid = _retrieve_analysis_groups(project)
-    locus_lists = get_json_for_locus_lists(LocusList.objects.filter(projects__id=project.id), user)
+    locus_lists = get_json_for_locus_lists(LocusList.objects.filter(projects__id=project.id), user, is_analyst=is_analyst)
     locus_lists_by_guid = {locus_list['locusListGuid']: locus_list for locus_list in locus_lists}
     return {
         'familiesByGuid': families_by_guid,
@@ -185,7 +189,7 @@ def _get_project_child_entities(project, user):
     }
 
 
-def _retrieve_families(project_guid, user):
+def _retrieve_families(project_guid, is_analyst, has_case_review_perm):
     """Retrieves family-level metadata for the given project.
 
     Args:
@@ -196,7 +200,8 @@ def _retrieve_families(project_guid, user):
     """
     family_models = Family.objects.filter(project__guid=project_guid)
 
-    families = _get_json_for_families(family_models, user, project_guid=project_guid)
+    families = _get_json_for_families(
+        family_models, project_guid=project_guid, is_analyst=is_analyst, has_case_review_perm=has_case_review_perm)
 
     families_by_guid = {}
     for family in families:
@@ -207,7 +212,7 @@ def _retrieve_families(project_guid, user):
     return families_by_guid
 
 
-def _retrieve_individuals(project_guid, user):
+def _retrieve_individuals(project_guid, is_analyst, has_case_review_perm):
     """Retrieves individual-level metadata for the given project.
 
     Args:
@@ -219,7 +224,8 @@ def _retrieve_individuals(project_guid, user):
     individual_models = Individual.objects.filter(family__project__guid=project_guid)
 
     individuals = _get_json_for_individuals(
-        individual_models, user=user, project_guid=project_guid, add_hpo_details=True)
+        individual_models, project_guid=project_guid, add_hpo_details=True, is_analyst=is_analyst,
+        has_case_review_perm=has_case_review_perm)
 
     individuals_by_guid = {}
     for i in individuals:

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -71,6 +71,8 @@ class ProjectAPITest(object):
         new_project = Project.objects.filter(name='new_project')
         self.assertEqual(len(new_project), 0)
 
+    @mock.patch('seqr.views.apis.project_api.ANALYST_PROJECT_CATEGORY', None)
+    @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP', None)
     def test_create_project_no_pm(self):
         create_project_url = reverse(create_project_handler)
         self.check_superuser_login(create_project_url)
@@ -90,6 +92,7 @@ class ProjectAPITest(object):
         self.assertSetEqual(set(response.json()['projectsByGuid'].keys()), {new_project.guid})
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
+    @mock.patch('seqr.views.utils.orm_to_json_utils.ANALYST_USER_GROUP', 'analysts')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     def test_project_page_data(self, mock_analyst_group):
         url = reverse(project_page_data, args=[PROJECT_GUID])
@@ -254,7 +257,7 @@ class AnvilProjectAPITest(AnvilAuthenticationTestCase, ProjectAPITest):
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
         self.mock_get_ws_access_level.assert_any_call(self.collaborator_user,
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-        self.assertEqual(self.mock_get_ws_access_level.call_count, 6)
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 5)
 
     def test_empty_project_page_data(self):
         url = reverse(project_page_data, args=[EMPTY_PROJECT_GUID])
@@ -287,7 +290,7 @@ class MixProjectAPITest(MixAuthenticationTestCase, ProjectAPITest):
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
         self.mock_get_ws_access_level.assert_called_with(self.analyst_user,
              'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-        self.assertEqual(self.mock_get_ws_access_level.call_count, 5)
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 4)
 
     def test_empty_project_page_data(self):
         super(MixProjectAPITest, self).test_empty_project_page_data()

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -32,7 +32,8 @@ def saved_variant_data(request, project_guid, variant_guids=None):
     if family_guids:
         variant_query = SavedVariant.objects.filter(family__guid__in=family_guids)
     else:
-        variant_query = SavedVariant.objects.filter(family__project=project)
+        get_note_only = bool(request.GET.get('includeNoteVariants'))
+        variant_query = SavedVariant.objects.filter(family__project=project, varianttag__isnull=get_note_only).distinct()
     if variant_guids:
         variant_query = variant_query.filter(guid__in=variant_guids)
         if variant_query.count() < 1:

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -123,9 +123,7 @@ class SavedVariantAPITest(object):
         })
 
         variants = response_json['savedVariantsByGuid']
-        self.assertSetEqual(
-            set(variants.keys()),
-            {'SV0000002_1248367227_r0390_100', 'SV0000001_2103343353_r0390_100', COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID})
+        self.assertSetEqual(set(variants.keys()), {'SV0000002_1248367227_r0390_100', 'SV0000001_2103343353_r0390_100'})
 
         variant = variants['SV0000001_2103343353_r0390_100']
         fields = {
@@ -140,9 +138,18 @@ class SavedVariantAPITest(object):
         self.assertSetEqual(
             set(variant['tagGuids']), {'VT1708633_2103343353_r0390_100', 'VT1726961_2103343353_r0390_100'},
         )
+        self.assertListEqual(variant['noteGuids'], [])
 
         tag = response_json['variantTagsByGuid']['VT1708633_2103343353_r0390_100']
         self.assertSetEqual(set(tag.keys()), TAG_FIELDS)
+
+        # get variants with no tags for whole project
+        response = self.client.get('{}?includeNoteVariants=true'.format(url))
+        self.assertEqual(response.status_code, 200)
+        variants = response.json()['savedVariantsByGuid']
+        self.assertSetEqual(set(variants.keys()), {COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID})
+        self.assertListEqual(variants[COMPOUND_HET_1_GUID]['tagGuids'], [])
+        self.assertListEqual(variant['noteGuids'], [])
 
         # filter by family
         response = self.client.get('{}?families=F000002_2'.format(url))
@@ -176,7 +183,7 @@ class SavedVariantAPITest(object):
         variants = response_json['savedVariantsByGuid']
         self.assertSetEqual(
             set(variants.keys()),
-            {'SV0000002_1248367227_r0390_100', 'SV0000001_2103343353_r0390_100', COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID}
+            {'SV0000002_1248367227_r0390_100', 'SV0000001_2103343353_r0390_100'}
         )
         self.assertListEqual(variants['SV0000002_1248367227_r0390_100']['discoveryTags'], [{
             'savedVariant': {
@@ -782,7 +789,7 @@ class AnvilSavedVariantAPITest(AnvilAuthenticationTestCase, SavedVariantAPITest)
 
     def test_saved_variant_data(self):
         super(AnvilSavedVariantAPITest, self).test_saved_variant_data()
-        assert_no_list_ws_has_al(self, 6)
+        assert_no_list_ws_has_al(self, 7)
 
     def test_create_saved_variant(self):
         super(AnvilSavedVariantAPITest, self).test_create_saved_variant()

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -31,6 +31,7 @@ from seqr.views.utils.orm_to_json_utils import \
     get_json_for_saved_variants_with_tags, \
     get_json_for_saved_search,\
     get_json_for_saved_searches, \
+    get_json_for_discovery_tags, \
     _get_json_for_models
 from seqr.views.utils.permissions_utils import check_project_permissions, get_projects_user_can_view, user_is_analyst
 from seqr.views.utils.variant_utils import get_variant_key, saved_variant_genes
@@ -551,12 +552,10 @@ def _get_saved_variants(variants, families, include_discovery_tags=False):
     hg37_family_guids = {family.guid for family in families if family.project.genome_version == GENOME_VERSION_GRCh37}
 
     variant_q = Q()
-    discovery_variant_q = Q()
     variants_by_id = {}
     for variant in variants:
         variants_by_id[get_variant_key(**variant)] = variant
         variant_q |= Q(variant_id=variant['variantId'], family__guid__in=variant['familyGuids'])
-        discovery_variant_q |= Q(Q(variant_id=variant['variantId']) & ~Q(family__guid__in=variant['familyGuids']))
         if variant['liftedOverGenomeVersion'] == GENOME_VERSION_GRCh37 and hg37_family_guids:
             variant_hg37_families = [family_guid for family_guid in variant['familyGuids'] if family_guid in hg37_family_guids]
             if variant_hg37_families:
@@ -565,12 +564,16 @@ def _get_saved_variants(variants, families, include_discovery_tags=False):
                 variants_by_id[get_variant_key(
                     xpos=lifted_xpos, ref=variant['ref'], alt=variant['alt'], genomeVersion=variant['liftedOverGenomeVersion']
                 )] = variant
-    discovery_variant_q &= Q(family__project__projectcategory__name=ANALYST_PROJECT_CATEGORY)
 
     saved_variants = SavedVariant.objects.filter(variant_q)
 
-    json = get_json_for_saved_variants_with_tags(
-        saved_variants, add_details=True, discovery_tags_query=discovery_variant_q if include_discovery_tags else None)
+    json = get_json_for_saved_variants_with_tags(saved_variants, add_details=True)
+
+    discovery_tags = {}
+    if include_discovery_tags:
+        discovery_tags, discovery_response = get_json_for_discovery_tags(variants)
+        json.update(discovery_response)
+
     variants_to_saved_variants = {}
     for saved_variant in json['savedVariantsByGuid'].values():
         family_guids = saved_variant['familyGuids']
@@ -587,12 +590,13 @@ def _get_saved_variants(variants, families, include_discovery_tags=False):
         for family_guid in family_guids:
             variants_to_saved_variants[searched_variant['variantId']][family_guid] = saved_variant['variantGuid']
 
-    for variant_id, tags in json.pop('discoveryTags', {}).items():
+    for variant_id, tags in discovery_tags.items():
         searched_variant = variants_by_id.get(variant_id)
         if searched_variant:
             if not searched_variant.get('discoveryTags'):
                 searched_variant['discoveryTags'] = []
-            searched_variant['discoveryTags'] += tags
+            searched_variant['discoveryTags'] += [
+                tag for tag in tags if tag['savedVariant']['familyGuid'] not in searched_variant['familyGuids']]
 
     return json, variants_to_saved_variants
 

--- a/settings.py
+++ b/settings.py
@@ -67,14 +67,14 @@ CSRF_COOKIE_HTTPONLY = False
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # django-debug-toolbar settings
-ENABLE_DJANGO_DEBUG_TOOLBAR = False
+ENABLE_DJANGO_DEBUG_TOOLBAR = True
 if ENABLE_DJANGO_DEBUG_TOOLBAR:
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
     INSTALLED_APPS = ['debug_toolbar'] + INSTALLED_APPS
     INTERNAL_IPS = ['127.0.0.1']
     SHOW_COLLAPSED = True
     DEBUG_TOOLBAR_PANELS = [
-        'ddt_request_history.panels.request_history.RequestHistoryPanel',
+        'debug_toolbar.panels.history.HistoryPanel',
         'debug_toolbar.panels.timer.TimerPanel',
         'debug_toolbar.panels.settings.SettingsPanel',
         'debug_toolbar.panels.headers.HeadersPanel',

--- a/settings.py
+++ b/settings.py
@@ -79,11 +79,11 @@ if ENABLE_DJANGO_DEBUG_TOOLBAR:
         'debug_toolbar.panels.settings.SettingsPanel',
         'debug_toolbar.panels.headers.HeadersPanel',
         'debug_toolbar.panels.request.RequestPanel',
-        'debug_toolbar.panels.profiling.ProfilingPanel',
         'debug_toolbar.panels.sql.SQLPanel',
         'debug_toolbar.panels.staticfiles.StaticFilesPanel',
         'debug_toolbar.panels.logging.LoggingPanel',
         'debug_toolbar.panels.redirects.RedirectsPanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
     ]
     DEBUG_TOOLBAR_CONFIG = {
         'RESULTS_CACHE_SIZE': 100,

--- a/settings.py
+++ b/settings.py
@@ -67,7 +67,7 @@ CSRF_COOKIE_HTTPONLY = False
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # django-debug-toolbar settings
-ENABLE_DJANGO_DEBUG_TOOLBAR = True
+ENABLE_DJANGO_DEBUG_TOOLBAR = False
 if ENABLE_DJANGO_DEBUG_TOOLBAR:
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
     INSTALLED_APPS = ['debug_toolbar'] + INSTALLED_APPS

--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -156,6 +156,9 @@ export const getSavedVariantTableState = state => (
   state.currentProjectGuid ? state.savedVariantTableState : state.allProjectSavedVariantTableState
 )
 
+const matchingVariants = (variants, matchFunc) =>
+  variants.filter(o => (Array.isArray(o) ? o : [o]).some(matchFunc))
+
 export const getPairedSelectedSavedVariants = createSelector(
   getSavedVariantsByGuid,
   (state, props) => props.match.params,
@@ -203,17 +206,17 @@ export const getPairedSelectedSavedVariants = createSelector(
       return acc
     }, [])
 
-    if (tag) {
-      if (tag === NOTE_TAG_NAME) {
-        pairedVariants = pairedVariants.filter(o => (Array.isArray(o) ? o : [o]).some(({ noteGuids }) => noteGuids.length))
-      } else if (tag !== SHOW_ALL) {
-        pairedVariants = pairedVariants.filter(o => (Array.isArray(o) ? o : [o]).some(({ tagGuids }) => tagGuids.some(tagGuid => tagsByGuid[tagGuid].name === tag)))
-      }
+    if (tag === NOTE_TAG_NAME) {
+      pairedVariants = matchingVariants(pairedVariants, ({ noteGuids }) => noteGuids.length)
+    } else if (tag && tag !== SHOW_ALL) {
+      pairedVariants = matchingVariants(
+        pairedVariants, ({ tagGuids }) => tagGuids.some(tagGuid => tagsByGuid[tagGuid].name === tag))
+    } else if (!familyGuid) {
+      pairedVariants = matchingVariants(pairedVariants, ({ tagGuids }) => tagGuids.length)
     }
 
     if (gene) {
-      pairedVariants = pairedVariants.filter(o => (Array.isArray(o) ? o : [o]).some(
-        ({ transcripts }) => gene in (transcripts || {})))
+      pairedVariants = matchingVariants(pairedVariants, ({ transcripts }) => gene in (transcripts || {}))
     }
 
     return pairedVariants


### PR DESCRIPTION
The saved variants page has gotten much slower, to the point it can no longer load for our larger projects. This speeds up the saved variants and project pages by:
- restructuring how checking analyst and pm permissions works to minimize the number of separate database calls needed
- restructuring how fetching and formatting discovery tags works to make it much faster

Another issue is that the project failing to load has ~2000 tagged variants, and then an additional ~6000 variants with no tags that do have notes(which is too many to load in a reasonable amount of time). Most of the time when looking at the whole project people only care abut truly tagged variants, so this changes the behavior for  viewing all the tagged variants in a project to only show those without tags if the user specifically clicks into viewing the "has notes" option