### PR TITLE
Move the heavier tests to a workflow that only runs on release branches

### DIFF
--- a/.github/workflows/local-install-tests.yml
+++ b/.github/workflows/local-install-tests.yml
@@ -1,0 +1,16 @@
+name: local install tests
+
+# Run the docker-compose test suite on pushes (incl. merges) to master and dev
+on:
+  push:
+    branches:
+      - master
+      - dev
+
+jobs:
+  local_install_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run test_local_deployment script
+        run: ./test_local_deployment.sh

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -74,11 +74,3 @@ jobs:
       working-directory: ./ui
     - run: npm test
       working-directory: ./ui
-
-  local_install_test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run test_local_deployment script
-        run: ./test_local_deployment.sh


### PR DESCRIPTION
We want to avoid hitting our GCR repo on every PR commit, so this switches the local install tests workflow to only run on changes to the dev and master branches.