### PR TITLE
Update build badges for Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,4 +1,4 @@
-name: Seqr tests
+name: Unit Tests
 
 # Run the test suite on pushes (incl. merges) to master and dev
 # Run the test suite when a PR is opened, pushed to, or reopened

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 seqr
 ====
-![Build Status](https://github.com/broadinstitute/seqr/workflows/Seqr%20tests/badge.svg?branch=master) | ![Local Install Tests](https://github.com/broadinstitute/seqr/workflows/local%20install%20tests/badge.svg?branch=master)
+![Unit Tests](https://github.com/broadinstitute/seqr/workflows/Unit%20Tests/badge.svg?branch=master) | ![Local Install Tests](https://github.com/broadinstitute/seqr/workflows/local%20install%20tests/badge.svg?branch=master)
 
 seqr is a web-based tool for rare disease genomics.
 This repository contains code that underlies the [Broad seqr instance](http://seqr.broadinstitute.org) and other seqr deployments. To check for any active incidents occuring on the Broad seqr instance, check [here](/INCIDENTS.md)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 seqr
 ====
-[![Build Status](https://travis-ci.org/broadinstitute/seqr.svg?branch=master)](https://travis-ci.org/broadinstitute/seqr)
+![Build Status](https://github.com/broadinstitute/seqr/workflows/Seqr%20tests/badge.svg?branch=master) | ![Local Install Tests](https://github.com/broadinstitute/seqr/workflows/local%20install%20tests/badge.svg?branch=master)
 
 seqr is a web-based tool for rare disease genomics.
 This repository contains code that underlies the [Broad seqr instance](http://seqr.broadinstitute.org) and other seqr deployments. To check for any active incidents occuring on the Broad seqr instance, check [here](/INCIDENTS.md)


### PR DESCRIPTION
We had a build status badge in our readme referencing travis, this updates the readme to include badges for our github actions workflows.