### PR TITLE
expire sessions after 1 day

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -64,6 +64,7 @@ ALLOWED_HOSTS = ['*']
 
 CSRF_COOKIE_NAME = 'csrf_token'
 CSRF_COOKIE_HTTPONLY = False
+SESSION_COOKIE_AGE = 86400 # seconds in 1 day
 X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 # django-debug-toolbar settings


### PR DESCRIPTION
Currently, we use the default django session expiration which is 2 weeks, but for compliance it needs to be shortened to a day