### PR TITLE
limit download variants to under max variants

### DIFF
--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -1215,6 +1215,13 @@ class EsUtilsTest(TestCase):
         self.assertEqual(len(variants), 5)
         self.assertListEqual(variants, PARSED_VARIANTS + PARSED_VARIANTS + PARSED_VARIANTS[:1])
 
+        # test does not re-fetch once all loaded
+        urllib3_responses.reset()
+        mock_max_variants.__int__.return_value = 1
+        variants, _ = get_es_variants(results_model, page=1, num_results=2, load_all=True)
+        self.assertEqual(len(variants), 5)
+        self.assertListEqual(variants, PARSED_VARIANTS + PARSED_VARIANTS + PARSED_VARIANTS[:1])
+
     @urllib3_responses.activate
     def test_filtered_get_es_variants(self):
         setup_responses()

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -6,7 +6,7 @@ import logging
 from settings import ELASTICSEARCH_SERVICE_HOSTNAME, ELASTICSEARCH_SERVICE_PORT, ELASTICSEARCH_CREDENTIALS, ELASTICSEARCH_PROTOCOL, ES_SSL_CONTEXT
 from seqr.models import Sample
 from seqr.utils.redis_utils import safe_redis_get_json, safe_redis_set_json
-from seqr.utils.elasticsearch.constants import XPOS_SORT_KEY
+from seqr.utils.elasticsearch.constants import XPOS_SORT_KEY, MAX_VARIANTS
 from seqr.utils.elasticsearch.es_gene_agg_search import EsGeneAggSearch
 from seqr.utils.elasticsearch.es_search import EsSearch
 from seqr.utils.gene_utils import parse_locus_list_items
@@ -88,13 +88,17 @@ def get_es_variants_for_variant_tuples(families, xpos_ref_alt_tuples):
     return get_es_variants_for_variant_ids(families, variant_ids, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
 
 
-def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, skip_genotype_filter=False, **kwargs):
+def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, skip_genotype_filter=False, load_all=False, **kwargs):
     cache_key = 'search_results__{}__{}'.format(search_model.guid, sort or XPOS_SORT_KEY)
     previous_search_results = safe_redis_get_json(cache_key) or {}
+    total_results = previous_search_results.get('total_results')
 
-    previously_loaded_results, search_kwargs = es_search_cls.process_previous_results(previous_search_results,  **kwargs)
+    previously_loaded_results, search_kwargs = es_search_cls.process_previous_results(previous_search_results, load_all=load_all, **kwargs)
     if previously_loaded_results is not None:
         return previously_loaded_results, previous_search_results.get('total_results')
+
+    if load_all and total_results and int(total_results) >= int(MAX_VARIANTS):
+        raise InvalidSearchException('Too many variants to load. Please refine your search and try again')
 
     search = search_model.variant_search.search
 


### PR DESCRIPTION
Currently this kind of search fails with an opaque Internal Server Error, so adding error handling to provide better user experience