### PR TITLE
Anvil tweaks

### DIFF
--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -1,8 +1,8 @@
 import logging
 from slacker import Slacker
 from settings import SLACK_TOKEN, BASE_URL
-from django.core.mail import EmailMessage
-from django.contrib.auth.models import User
+from django.core.mail import EmailMultiAlternatives
+from django.utils.html import strip_tags
 
 logger = logging.getLogger(__name__)
 
@@ -45,23 +45,10 @@ def send_welcome_email(user, referrer):
     user.email_user('Set up your seqr account', email_content, fail_silently=False)
 
 
-def send_load_data_email(project, data, data_path):
-    email_content = """
-    Data from AnVIL workspace "{namespace}/{name}" at "{path}" needs to be loaded to seqr project
-    <a href="{base_url}/project/{guid}/project_page">{project_name}</a> (guid: {guid})
-
-    The sample IDs to load are attached.    
-    """.format(
-        path=data_path,
-        namespace=project.workspace_namespace,
-        name=project.workspace_name,
-        base_url=BASE_URL,
-        guid=project.guid,
-        project_name=project.name,
+def send_html_email(email_body, **kwargs):
+    email_message = EmailMultiAlternatives(
+        body=strip_tags(email_body),
+        **kwargs,
     )
-    mail = EmailMessage(
-        subject='AnVIL data loading request',
-        body=email_content,
-        to=[dm.email for dm in User.objects.filter(is_staff=True)],
-        attachments=[('{}_sample_ids.tsv'.format(project.guid), data)])
-    mail.send()
+    email_message.attach_alternative(email_body, 'text/html')
+    email_message.send()

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -77,8 +77,7 @@ def create_project_from_workspace(request, namespace, name):
 
     # Validate the data path
     bucket_name = workspace_meta['workspace']['bucketName']
-    slash = '' if request_json['dataPath'].startswith('/') else '/'
-    data_path = 'gs://{bucket}{slash}{path}'.format(bucket=bucket_name, slash=slash, path=request_json['dataPath'])
+    data_path = 'gs://{bucket}/{path}'.format(bucket=bucket_name.rstrip('/'), path=request_json['dataPath'].lstrip('/'))
     if not does_file_exist(data_path):
         error = 'Data file or path {} is not found.'.format(request_json['dataPath'])
         return create_json_response({'error': error}, status=400, reason=error)

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -68,11 +68,11 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, '/login/google-oauth2?next=/workspace/my-seqr-billing/anvil-1kg%2520project%2520n%25C3%25A5me%2520with%2520uni%25C3%25A7%25C3%25B8de')
 
-    @mock.patch('seqr.utils.communication_utils.BASE_URL', 'http://testserver')
+    @mock.patch('seqr.views.apis.anvil_workspace_api.BASE_URL', 'http://testserver')
     @mock.patch('seqr.views.apis.anvil_workspace_api.logger')
     @mock.patch('seqr.views.apis.anvil_workspace_api.load_uploaded_file')
     @mock.patch('seqr.views.apis.anvil_workspace_api.add_service_account')
-    @mock.patch('seqr.utils.communication_utils.EmailMessage')
+    @mock.patch('seqr.utils.communication_utils.EmailMultiAlternatives')
     @mock.patch('seqr.views.apis.anvil_workspace_api.does_file_exist')
     def test_create_project_from_workspace(self, mock_file_exist, mock_email, mock_add_service_account,
                                            mock_load_file, mock_api_logger, mock_utils_logger):
@@ -141,17 +141,24 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
             [project.genome_version, project.description, project.workspace_namespace, project.workspace_name],
             ['38', 'A test project', TEST_WORKSPACE_NAMESPACE, TEST_NO_PROJECT_WORKSPACE_NAME])
         mock_add_service_account.assert_called_with(user, TEST_WORKSPACE_NAMESPACE, TEST_NO_PROJECT_WORKSPACE_NAME)
+
+        email_body = """
+        test_user_manager@test.com requested to load data from AnVIL workspace "{namespace}/{name}" at "gs://test_bucket/test_path" to seqr project
+        {{project_name}} (guid: {guid})
+
+        The sample IDs to load are attached.    
+        """.format(namespace=TEST_WORKSPACE_NAMESPACE, name=TEST_NO_PROJECT_WORKSPACE_NAME, guid=project.guid)
         mock_email.assert_called_with(
             subject='AnVIL data loading request',
-            body="""
-    Data from AnVIL workspace "{namespace}/{name}" at "gs://test_bucket/test_path" needs to be loaded to seqr project
-    <a href="http://testserver/project/{guid}/project_page">{name}</a> (guid: {guid})
-
-    The sample IDs to load are attached.    
-    """.format(namespace=TEST_WORKSPACE_NAMESPACE, name=TEST_NO_PROJECT_WORKSPACE_NAME, guid=project.guid),
+            body=email_body.format(project_name=TEST_NO_PROJECT_WORKSPACE_NAME),
             to=['test_superuser@test.com', 'test_data_manager@test.com'],
             attachments=[('{}_sample_ids.tsv'.format(project.guid), 'NA19675\nNA19678\nHG00735')]
         )
+        html_project_name = '<a href="http://testserver/project/{guid}/project_page">{name}</a>'.format(
+                name=TEST_NO_PROJECT_WORKSPACE_NAME, guid=project.guid)
+        mock_email.return_value.attach_alternative.assert_called_with(
+            email_body.format(project_name=html_project_name), 'text/html')
+        mock_email.return_value.send.assert_called()
 
         # Test project exist
         url = reverse(create_project_from_workspace, args=[TEST_WORKSPACE_NAMESPACE, TEST_NO_PROJECT_WORKSPACE_NAME])

--- a/seqr/views/apis/users_api.py
+++ b/seqr/views/apis/users_api.py
@@ -6,6 +6,7 @@ from anymail.exceptions import AnymailError
 from django.contrib.auth import login, authenticate
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User, Group
+from django.core.exceptions import PermissionDenied
 
 from seqr.models import UserPolicy
 from seqr.utils.communication_utils import send_welcome_email
@@ -107,6 +108,9 @@ def update_policies(request):
 @login_required(login_url=API_LOGIN_REQUIRED_URL)
 def create_project_collaborator(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    if project.workspace_name:
+        raise PermissionDenied(
+            'Adding collaborators directly in seqr is disabled. Users can be managed from the associated AnVIL workspace')
 
     request_json = json.loads(request.body)
     if not request_json.get('email'):

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -298,7 +298,7 @@ class AnvilUsersAPITest(AnvilAuthenticationTestCase, UsersAPITest):
         self.mock_list_workspaces.assert_not_called()
         self.mock_get_ws_acl.assert_not_called()
 
-    def test_create_project_collaborator(self, *args):
+    def test_create_project_collaborator(self):
         # Creating project collaborators is only allowed in non-anvil projects, so it always fails for the AnVIL only case
         create_url = reverse(create_project_collaborator, args=[NON_ANVIL_PROJECT_GUID])
         self.check_manager_login(create_url)

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -17,7 +17,7 @@ from seqr.views.utils.json_utils import _to_camel_case
 from seqr.views.utils.permissions_utils import has_project_permissions, has_case_review_permissions, \
     project_has_anvil, get_workspace_collaborator_perms, user_is_analyst, user_is_data_manager, user_is_pm
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated
-from settings import ANALYST_PROJECT_CATEGORY, ANALYST_USER_GROUP, PM_USER_GROUP
+from settings import ANALYST_PROJECT_CATEGORY, ANALYST_USER_GROUP, PM_USER_GROUP, SERVICE_ACCOUNT_FOR_ANVIL
 
 logger = logging.getLogger(__name__)
 
@@ -771,6 +771,8 @@ def get_project_collaborators_by_username(user, project, include_permissions=Tru
         permission_levels = get_workspace_collaborator_perms(user, project.workspace_namespace, project.workspace_name)
         users_by_email = {u.email: u for u in User.objects.filter(email__in = permission_levels.keys())}
         for email, permission in permission_levels.items():
+            if email == SERVICE_ACCOUNT_FOR_ANVIL:
+                continue
             collaborator = users_by_email.get(email)
             if collaborator:
                 collaborators.update({collaborator.username: _get_collaborator_json(collaborator, include_permissions,

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -6,10 +6,9 @@ import logging
 import tempfile
 import openpyxl as xl
 from django.contrib.auth.models import User
-from django.core.mail.message import EmailMultiAlternatives
-from django.utils.html import strip_tags
 
 from settings import PM_USER_GROUP
+from seqr.utils.communication_utils import send_html_email
 from seqr.views.utils.permissions_utils import user_is_pm
 from seqr.models import Individual
 
@@ -390,17 +389,15 @@ def _send_sample_manifest(sample_manifest_rows, kit_id, original_filename, origi
     wb_out.save(temp_original_file.name)
     temp_original_file.seek(0)
 
-    email_message = EmailMultiAlternatives(
+    send_html_email(
+        email_body,
         subject=kit_id + " Merged Sample Pedigree File",
-        body=strip_tags(email_body),
         to=recipients,
         attachments=[
             (sample_manifest_filename, temp_sample_manifest_file.read(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
             (original_table_attachment_filename, temp_original_file.read(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
         ],
     )
-    email_message.attach_alternative(email_body, 'text/html')
-    email_message.send()
 
 
 def _parse_datstat_export_format(rows):

--- a/seqr/views/utils/pedigree_info_utils_tests.py
+++ b/seqr/views/utils/pedigree_info_utils_tests.py
@@ -99,7 +99,7 @@ class PedigreeInfoUtilsTest(TestCase):
 
     @mock.patch('seqr.views.utils.pedigree_info_utils.PM_USER_GROUP', 'project-managers')
     @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
-    @mock.patch('seqr.views.utils.pedigree_info_utils.EmailMultiAlternatives')
+    @mock.patch('seqr.utils.communication_utils.EmailMultiAlternatives')
     def test_parse_sample_manifest(self, mock_email, mock_pm_group):
         header_1 = [
             'Do not modify - Broad use', '', '', 'Please fill in columns D - O', '', '', '', '', '', '', '', '', '',

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -222,7 +222,7 @@ def user_get_workspace_acl(user, workspace_namespace, workspace_name):
     try:
         return _user_anvil_call('get', path, user).get('acl', {})
     # Exceptions are handled to return an empty result for the users who have no permission to access the acl
-    except (TerraNotFoundException, PermissionDenied) as et:
+    except (TerraAPIException, PermissionDenied) as et:
         logger.warning(str(et))
         return {}
 

--- a/seqr/views/utils/terra_api_utils_tests.py
+++ b/seqr/views/utils/terra_api_utils_tests.py
@@ -146,11 +146,11 @@ class TerraApiUtilsCase(TestCase):
 
         mock_logger.reset_mock()
         responses.replace(responses.GET, url, status=401)
-        with self.assertRaises(TerraAPIException) as ec:
-            _ = user_get_workspace_acl(user, 'my-seqr-billing', 'my-seqr-workspace')
-        self.assertEqual(str(ec.exception),
+        r = user_get_workspace_acl(user, 'my-seqr-billing', 'my-seqr-workspace')
+        self.assertDictEqual(r, {})
+        mock_logger.warning.assert_called_with(
             'Error: called Terra API: GET /api/workspaces/my-seqr-billing/my-seqr-workspace/acl got status: 401 with a reason: Unauthorized')
-        self.assertEqual(ec.exception.status_code, 401)
+        self.assertEqual(len(mock_logger.method_calls), 1)
 
         mock_logger.reset_mock()
         responses.replace(responses.GET, url, status=403)

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -156,6 +156,8 @@ TEST_WORKSPACE_NAME1 = 'anvil-project 1000 Genomes Demo'
 TEST_NO_PROJECT_WORKSPACE_NAME = 'anvil-no-project-workspace1'
 TEST_NO_PROJECT_WORKSPACE_NAME2 = 'anvil-no-project-workspace2'
 
+TEST_SERVICE_ACCOUNT = 'test_account@my-seqr.iam.gserviceaccount.com'
+
 ANVIL_WORKSPACES = [{
     'workspace_namespace': TEST_WORKSPACE_NAMESPACE,
     'workspace_name': TEST_WORKSPACE_NAME,
@@ -171,6 +173,12 @@ ANVIL_WORKSPACES = [{
             "accessLevel": "READER",
             "pending": False,
             "canShare": True,
+            "canCompute": True
+        },
+        TEST_SERVICE_ACCOUNT: {
+            "accessLevel": "READER",
+            "pending": False,
+            "canShare": False,
             "canCompute": True
         },
         'test_user_not_registered@test.com': {
@@ -300,6 +308,9 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', TEST_OAUTH2_KEY)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch('seqr.views.utils.orm_to_json_utils.SERVICE_ACCOUNT_FOR_ANVIL', TEST_SERVICE_ACCOUNT)
         patcher.start()
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.terra_api_utils.time')
@@ -822,5 +833,3 @@ GOOGLE_API_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 GOOGLE_ACCESS_TOKEN_URL = 'https://accounts.google.com/o/oauth2/token'
 
 GOOGLE_TOKEN_RESULT = '{"access_token":"ya29.c.EXAMPLE","expires_in":3599,"token_type":"Bearer"}'
-
-TEST_SERVICE_ACCOUNT = 'test_account@my-seqr.iam.gserviceaccount.com'

--- a/ui/pages/Project/components/ProjectCollaborators.test.js
+++ b/ui/pages/Project/components/ProjectCollaborators.test.js
@@ -4,7 +4,7 @@ import Adapter from 'enzyme-adapter-react-16'
 import configureStore from 'redux-mock-store'
 
 import { getUser } from 'redux/selectors'
-import ProjectCollaborators, { AddProjectCollaboratorButton } from './ProjectCollaborators'
+import ProjectCollaborators from './ProjectCollaborators'
 import { STATE_WITH_2_FAMILIES } from '../fixtures'
 
 configure({ adapter: new Adapter() })
@@ -12,9 +12,4 @@ configure({ adapter: new Adapter() })
 test('shallow-render without crashing', () => {
   const store = configureStore()(STATE_WITH_2_FAMILIES)
   shallow(<ProjectCollaborators store={store} />)
-})
-
-test('shallow-render button without crashing', () => {
-  const store = configureStore()(STATE_WITH_2_FAMILIES)
-  shallow(<AddProjectCollaboratorButton store={store} />)
 })

--- a/ui/pages/Project/components/ProjectPageUI.jsx
+++ b/ui/pages/Project/components/ProjectPageUI.jsx
@@ -26,7 +26,7 @@ import {
 import ProjectOverview from './ProjectOverview'
 import AnalysisGroups from './AnalysisGroups'
 import { UpdateAnalysisGroupButton } from './AnalysisGroupButtons'
-import ProjectCollaborators, { AddProjectCollaboratorButton } from './ProjectCollaborators'
+import ProjectCollaborators from './ProjectCollaborators'
 import { GeneLists, AddGeneListsButton } from './GeneLists'
 import FamilyTable from './FamilyTable/FamilyTable'
 import VariantTags from './VariantTags'
@@ -115,10 +115,9 @@ const ProjectPageUI = React.memo((props) => {
           </ProjectSection>
         </Grid.Column>
         <Grid.Column width={4}>
-          <ProjectSection label="Collaborators" editButton={<AddProjectCollaboratorButton />}>
-            <ProjectCollaborators anvilCollaborator={false} />
+          <ProjectSection label="Collaborators">
+            <ProjectCollaborators />
           </ProjectSection>
-          <br /><ProjectCollaborators anvilCollaborator />
         </Grid.Column>
       </Grid.Row>
       <Grid.Row>


### PR DESCRIPTION
Fixes email to send as actual HTML, and disables adding collaborators for AnVIl projects. While we need to keep user management for editing and removing users, one a project has been linked to AnVIL the only way to grant acccess must be through AnVIL itself