### PR TITLE
Fix airtable access

### DIFF
--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -3,6 +3,7 @@
 import logging
 import json
 
+from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.models import User
 from django.shortcuts import redirect
 
@@ -15,13 +16,14 @@ from seqr.views.utils.pedigree_info_utils import parse_pedigree_table
 from seqr.views.utils.individual_utils import add_or_update_individuals_and_families
 from seqr.utils.communication_utils import send_html_email
 from seqr.utils.file_utils import does_file_exist
-from seqr.views.utils.permissions_utils import google_auth_required, check_workspace_perm
-from settings import BASE_URL
+from seqr.views.utils.permissions_utils import is_anvil_authenticated, check_workspace_perm
+from settings import BASE_URL, GOOGLE_LOGIN_REQUIRED_URL
 
 logger = logging.getLogger(__name__)
 
+anvil_auth_required = user_passes_test(is_anvil_authenticated, login_url=GOOGLE_LOGIN_REQUIRED_URL)
 
-@google_auth_required
+@anvil_auth_required
 def anvil_workspace_page(request, namespace, name):
     """
     This view will be requested from AnVIL, it validates the workspace and project before loading data.
@@ -41,7 +43,7 @@ def anvil_workspace_page(request, namespace, name):
         return redirect('/create_project_from_workspace/{}/{}'.format(namespace, name))
 
 
-@google_auth_required
+@anvil_auth_required
 def create_project_from_workspace(request, namespace, name):
     """
     Create a project when a cooperator requests to load data from an AnVIL workspace.

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -7,10 +7,9 @@ from django.db.models import Value
 
 from seqr.models import Project, ProjectCategory, CAN_VIEW, CAN_EDIT
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated, user_get_workspace_acl, list_anvil_workspaces,\
-    anvil_enabled, user_get_workspace_access_level, is_google_authenticated, WRITER_ACCESS_LEVEL, OWNER_ACCESS_LEVEL,\
+    anvil_enabled, user_get_workspace_access_level, WRITER_ACCESS_LEVEL, OWNER_ACCESS_LEVEL,\
     PROJECT_OWNER_ACCESS_LEVEL, CAN_SHARE_PERM
-from settings import API_LOGIN_REQUIRED_URL, ANALYST_USER_GROUP, PM_USER_GROUP, ANALYST_PROJECT_CATEGORY, \
-    GOOGLE_LOGIN_REQUIRED_URL
+from settings import API_LOGIN_REQUIRED_URL, ANALYST_USER_GROUP, PM_USER_GROUP, ANALYST_PROJECT_CATEGORY
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,6 @@ def user_is_pm(user):
 analyst_required = user_passes_test(user_is_analyst, login_url=API_LOGIN_REQUIRED_URL)
 data_manager_required = user_passes_test(user_is_data_manager, login_url=API_LOGIN_REQUIRED_URL)
 pm_required = user_passes_test(user_is_pm, login_url=API_LOGIN_REQUIRED_URL)
-google_auth_required = user_passes_test(is_google_authenticated, login_url=GOOGLE_LOGIN_REQUIRED_URL)
 
 def _has_analyst_access(project):
     return project.projectcategory_set.filter(name=ANALYST_PROJECT_CATEGORY).exists()

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -89,7 +89,7 @@ def _get_call_args(path, headers=None, root_url=None):
 
 def _safe_get_social(user):
     if not google_auth_enabled() or not hasattr(user, 'social_auth'):
-        return False
+        return None
 
     social = user.social_auth.filter(provider=SOCIAL_AUTH_PROVIDER)
     return social.first() if social else None

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -55,20 +55,10 @@ def anvil_enabled():
 
 
 def is_google_authenticated(user):
-    if not google_auth_enabled() or not hasattr(user, 'social_auth'):
-        return False
-
-    social = _safe_get_social(user)
-    if social and social.extra_data:
-        return social.extra_data.get('access_token', '') != ''
-
-    return False
+    bool(_safe_get_social(user))
 
 
 def remove_token(user):
-    if not google_auth_enabled():
-        return
-
     social = _safe_get_social(user)
     if social and social.extra_data:
         social.extra_data.pop('access_token', None)
@@ -77,7 +67,14 @@ def remove_token(user):
 
 
 def is_anvil_authenticated(user):
-    return anvil_enabled() and is_google_authenticated(user)
+    if not anvil_enabled():
+        return False
+
+    social = _safe_get_social(user)
+    if social and social.extra_data:
+        return social.extra_data.get('access_token', '') != ''
+
+    return False
 
 
 def _get_call_args(path, headers=None, root_url=None):
@@ -91,6 +88,9 @@ def _get_call_args(path, headers=None, root_url=None):
 
 
 def _safe_get_social(user):
+    if not google_auth_enabled() or not hasattr(user, 'social_auth'):
+        return False
+
     social = user.social_auth.filter(provider=SOCIAL_AUTH_PROVIDER)
     return social.first() if social else None
 

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -55,7 +55,7 @@ def anvil_enabled():
 
 
 def is_google_authenticated(user):
-    bool(_safe_get_social(user))
+    return bool(_safe_get_social(user))
 
 
 def remove_token(user):

--- a/seqr/views/utils/terra_api_utils_tests.py
+++ b/seqr/views/utils/terra_api_utils_tests.py
@@ -153,6 +153,7 @@ class TerraApiUtilsCallsCase(TestCase):
         mock_logger.reset_mock()
         responses.replace(responses.GET, url, status=401)
         r = user_get_workspace_acl(user, 'my-seqr-billing', 'my-seqr-workspace')
+        self.assertDictEqual(r, {})
 
         mock_logger.warning.assert_called_with(
             'Error: called Terra API: GET /api/workspaces/my-seqr-billing/my-seqr-workspace/acl got status: 401 with a reason: Unauthorized')

--- a/seqr/views/utils/terra_api_utils_tests.py
+++ b/seqr/views/utils/terra_api_utils_tests.py
@@ -16,10 +16,7 @@ LIST_WORKSPACE_RESPONSE = '[{"accessLevel": "PROJECT_OWNER", "public": false, "w
 {"accessLevel": "READER","public": true, "workspace": {"attributes": {"tag:tags": {"itemsType": "AttributeValue","items": ["differential-expression","tutorial"]},"description": "[DEGenome](https://github.com/eweitz/degenome) transforms differential expression data into inputs for [exploratory genome analysis with Ideogram.js](https://eweitz.github.io/ideogram/differential-expression?annots-url=https://www.googleapis.com/storage/v1/b/degenome/o/GLDS-4_array_differential_expression_ideogram_annots.json).  \\n\\nTry the [Notebook tutorial](https://app.terra.bio/#workspaces/degenome/degenome/notebooks/launch/degenome-tutorial.ipynb), where you can step through using DEGenome to analyze expression for mice flown in space!"},"authorizationDomain": [],"bucketName": "fc-2706d493-5fce-4fb2-9993-457c30364a06","createdBy": "test2@test.com","createdDate": "2020-01-14T10:21:14.575Z","isLocked": false,"lastModified": "2020-02-01T13:28:27.309Z","name": "degenome","namespace": "degenome","workflowCollectionName": "2706d493-5fce-4fb2-9993-457c30364a06","workspaceId": "2706d493-5fce-4fb2-9993-457c30364a06"},"workspaceSubmissionStats": {"runningSubmissionsCount": 0}},\
 {"accessLevel": "PROJECT_OWNER","public": false, "workspace": {"attributes": {"description": "A workspace for seqr project"},"authorizationDomain": [],"bucketName": "fc-6a048145-c134-4004-a009-42824f826ee8","createdBy": "test3@test.com","createdDate": "2020-09-09T15:12:30.142Z","isLocked": false,"lastModified": "2020-09-09T15:12:30.145Z","name": "seqr-project 1000 Genomes Demo","namespace": "my-seqr-billing","workflowCollectionName": "6a048145-c134-4004-a009-42824f826ee8","workspaceId": "6a048145-c134-4004-a009-42824f826ee8"},"workspaceSubmissionStats": {"runningSubmissionsCount": 0}}]'
 
-
-@mock.patch('seqr.views.utils.terra_api_utils.TERRA_API_ROOT_URL', TEST_TERRA_API_ROOT_URL)
-@mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', TEST_OAUTH2_KEY)
-class TerraApiUtilsCase(TestCase):
+class TerraApiUtilsHelpersCase(TestCase):
     fixtures = ['users', 'social_auth']
 
     @mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
@@ -30,7 +27,7 @@ class TerraApiUtilsCase(TestCase):
 
         remove_token(user)
         r = is_google_authenticated(user)
-        self.assertFalse(r)
+        self.assertTrue(r)
 
         local_user = User.objects.get(username='test_local_user')
         r = is_google_authenticated(local_user)
@@ -40,23 +37,32 @@ class TerraApiUtilsCase(TestCase):
         r = is_google_authenticated(user)
         self.assertFalse(r)
 
-    @mock.patch('seqr.views.utils.terra_api_utils.anvil_enabled')
-    @mock.patch('seqr.views.utils.terra_api_utils.is_google_authenticated')
-    def test_is_anvil_authenticated(self, mock_is_google_authenticated, mock_anvil_enabled):
-        mock_is_google_authenticated.return_value = True
-        mock_anvil_enabled.return_value = True
+    @mock.patch('seqr.views.utils.terra_api_utils.TERRA_API_ROOT_URL')
+    @mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
+    def test_is_anvil_authenticated(self, mock_social_auth_key, mock_terra_url):
+        mock_social_auth_key.__bool__.return_value = False
+        mock_terra_url.__bool__.return_value = True
         user = User.objects.get(username='test_user')
+        r = is_anvil_authenticated(user)
+        self.assertFalse(r)
+
+        mock_social_auth_key.__bool__.return_value = True
+        mock_terra_url.__bool__.return_value = False
+        r = is_anvil_authenticated(user)
+        self.assertFalse(r)
+
+        mock_terra_url.__bool__.return_value = True
         r = is_anvil_authenticated(user)
         self.assertTrue(r)
 
-        mock_is_google_authenticated.return_value = False
+        remove_token(user)
         r = is_anvil_authenticated(user)
         self.assertFalse(r)
 
-        mock_is_google_authenticated.return_value = True
-        mock_anvil_enabled.return_value = False
-        r = is_anvil_authenticated(user)
-        self.assertFalse(r)
+@mock.patch('seqr.views.utils.terra_api_utils.TERRA_API_ROOT_URL', TEST_TERRA_API_ROOT_URL)
+@mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', TEST_OAUTH2_KEY)
+class TerraApiUtilsCallsCase(TestCase):
+    fixtures = ['users', 'social_auth']
 
     @responses.activate
     @mock.patch('seqr.views.utils.terra_api_utils.logger')
@@ -147,7 +153,7 @@ class TerraApiUtilsCase(TestCase):
         mock_logger.reset_mock()
         responses.replace(responses.GET, url, status=401)
         r = user_get_workspace_acl(user, 'my-seqr-billing', 'my-seqr-workspace')
-        self.assertDictEqual(r, {})
+
         mock_logger.warning.assert_called_with(
             'Error: called Terra API: GET /api/workspaces/my-seqr-billing/my-seqr-workspace/acl got status: 401 with a reason: Unauthorized')
         self.assertEqual(len(mock_logger.method_calls), 1)


### PR DESCRIPTION
There are endpoints that need to check that  user has ever logged in with google (i.e has a valid google account) but recent changes added a check for access token. Since AnVIL isn't live yet, obviously no one has an access token set and this is making it impossible for users to access these pages. This change the is_google_authenticated helper back to its original purpose, and beefs up the is_anvil_authenticated helper and uses that in more places