### PR TITLE
Clear demo tags

### DIFF
--- a/seqr/management/commands/clear_project_tags.py
+++ b/seqr/management/commands/clear_project_tags.py
@@ -1,0 +1,35 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from seqr.models import Project, SavedVariant, VariantTag, VariantNote, VariantFunctionalData
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('project_prefix')
+
+    def handle(self, *args, **options):
+        projects = Project.objects.filter(name__startswith=options['project_prefix'], projectcategory__name='Demo')
+        if input('Are you sure you want to clear the tags for the following {} projects (y/n): {}\n'.format(
+                projects.count(), ', '.join([p.name for p in projects]))) != 'y':
+            raise CommandError('User aborted')
+
+        total_deleted, all_deletion_counts = VariantTag.bulk_delete(user=None, saved_variants__family__project__in=projects)
+
+        deleted, deletion_counts = VariantNote.bulk_delete(user=None, saved_variants__family__project__in=projects)
+        total_deleted += deleted
+        all_deletion_counts.update(deletion_counts)
+
+        deleted, deletion_counts = VariantFunctionalData.bulk_delete(user=None, saved_variants__family__project__in=projects)
+        total_deleted += deleted
+        all_deletion_counts.update(deletion_counts)
+
+        deleted, deletion_counts = SavedVariant.bulk_delete(user=None, family__project__in=projects)
+        total_deleted += deleted
+        all_deletion_counts.update(deletion_counts)
+
+        logger.info('Deleted {} entities:'.format(total_deleted))
+        for model, count in all_deletion_counts.items():
+            logger.info('    {}: {}'.format(model.lstrip('seqr.'), count))

--- a/seqr/management/tests/clear_project_tags_tests.py
+++ b/seqr/management/tests/clear_project_tags_tests.py
@@ -31,3 +31,9 @@ class TransferFamiliesTest(TestCase):
 
         self.assertEqual(SavedVariant.objects.filter(family__project__guid='R0003_test').count(), 0)
         self.assertEqual(VariantTag.objects.filter(saved_variants__family__project__guid='R0003_test').count(), 0)
+
+        # Test only demo projects can be deleted
+        mock_input.side_effect = 'y'
+        call_command('clear_project_tags', '1kg')
+        mock_input.assert_called_with('Are you sure you want to clear the tags for the following 0 projects (y/n): \n')
+        mock_logger.assert_called_with('Deleted 0 entities:')

--- a/seqr/management/tests/clear_project_tags_tests.py
+++ b/seqr/management/tests/clear_project_tags_tests.py
@@ -17,6 +17,13 @@ class TransferFamiliesTest(TestCase):
             call_command('clear_project_tags', 'Test Reprocessed')
         self.assertEqual(str(ce.exception), 'User aborted')
 
+        # Test only demo projects can be deleted
+        mock_input.side_effect = 'y'
+        call_command('clear_project_tags', '1kg')
+        mock_input.assert_called_with('Are you sure you want to clear the tags for the following 0 projects (y/n): \n')
+        mock_logger.assert_called_with('Deleted 0 entities:')
+
+        # Test success
         mock_input.side_effect = 'y'
         call_command('clear_project_tags', 'Test Reprocessed')
 
@@ -32,8 +39,3 @@ class TransferFamiliesTest(TestCase):
         self.assertEqual(SavedVariant.objects.filter(family__project__guid='R0003_test').count(), 0)
         self.assertEqual(VariantTag.objects.filter(saved_variants__family__project__guid='R0003_test').count(), 0)
 
-        # Test only demo projects can be deleted
-        mock_input.side_effect = 'y'
-        call_command('clear_project_tags', '1kg')
-        mock_input.assert_called_with('Are you sure you want to clear the tags for the following 0 projects (y/n): \n')
-        mock_logger.assert_called_with('Deleted 0 entities:')

--- a/seqr/management/tests/clear_project_tags_tests.py
+++ b/seqr/management/tests/clear_project_tags_tests.py
@@ -1,0 +1,33 @@
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+import mock
+
+from seqr.models import SavedVariant, VariantTag
+
+
+class TransferFamiliesTest(TestCase):
+    fixtures = ['users', '1kg_project']
+
+    @mock.patch('seqr.management.commands.clear_project_tags.logger.info')
+    @mock.patch('seqr.management.commands.clear_project_tags.input')
+    def test_command(self, mock_input, mock_logger):
+        mock_input.side_effect = 'n'
+        with self.assertRaises(CommandError) as ce:
+            call_command('clear_project_tags', 'Test Reprocessed')
+        self.assertEqual(str(ce.exception), 'User aborted')
+
+        mock_input.side_effect = 'y'
+        call_command('clear_project_tags', 'Test Reprocessed')
+
+        mock_input.assert_called_with(
+            'Are you sure you want to clear the tags for the following 1 projects (y/n): Test Reprocessed Project\n')
+        mock_logger.assert_has_calls([
+            mock.call('Deleted 5 entities:'),
+            mock.call('    VariantTag_saved_variants: 2'),
+            mock.call('    VariantTag: 1'),
+            mock.call('    SavedVariant: 2'),
+        ], any_order=True)
+
+        self.assertEqual(SavedVariant.objects.filter(family__project__guid='R0003_test').count(), 0)
+        self.assertEqual(VariantTag.objects.filter(saved_variants__family__project__guid='R0003_test').count(), 0)

--- a/seqr/models.py
+++ b/seqr/models.py
@@ -126,7 +126,7 @@ class ModelWithGUID(models.Model):
         if queryset is None:
             queryset = cls.objects.filter(**filter_kwargs)
         log_model_bulk_update(logger, queryset, user, 'delete')
-        queryset.delete()
+        return queryset.delete()
 
 
 class UserPolicy(models.Model):


### PR DESCRIPTION
Add a command to clear tags from demo projects. This type of request happens with some regularity so we should have an actual command for this, instead of me bulk deleting things in the db