### PR TITLE
fix link in anvil email

### DIFF
--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -120,7 +120,7 @@ def create_project_from_workspace(request, namespace, name):
 def _send_load_data_email(project, updated_individuals, data_path, user):
     email_content = """
         {user} requested to load data from AnVIL workspace "{namespace}/{name}" at "{path}" to seqr project
-        <a href="{base_url}/project/{guid}/project_page">{project_name}</a> (guid: {guid})
+        <a href="{base_url}project/{guid}/project_page">{project_name}</a> (guid: {guid})
 
         The sample IDs to load are attached.    
         """.format(

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -71,7 +71,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, '/login/google-oauth2?next=/workspace/my-seqr-billing/anvil-1kg%2520project%2520n%25C3%25A5me%2520with%2520uni%25C3%25A7%25C3%25B8de')
 
-    @mock.patch('seqr.views.apis.anvil_workspace_api.BASE_URL', 'http://testserver')
+    @mock.patch('seqr.views.apis.anvil_workspace_api.BASE_URL', 'http://testserver/')
     @mock.patch('seqr.views.apis.anvil_workspace_api.logger')
     @mock.patch('seqr.views.apis.anvil_workspace_api.load_uploaded_file')
     @mock.patch('seqr.views.apis.anvil_workspace_api.add_service_account')


### PR DESCRIPTION
BASE_URL always has a trailing slash