### PR TITLE
Single SV search fix

### DIFF
--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -1254,7 +1254,7 @@ class EsUtilsTest(TestCase):
             get_es_variants(results_model, sort='cadd', num_results=2)
         self.assertEqual(str(cm.exception), 'Invalid genes/intervals: chr27:1234-5678, ENSG00012345')
 
-        search_model.search['locus']['rawItems'] = 'DDX11L1, chr2:1234-5678'
+        search_model.search['locus']['rawItems'] = 'DDX11L1, chr2:1234-5678, chr7:100-10100%10'
         with self.assertRaises(InvalidSearchException) as cm:
             get_es_variants(results_model, sort='cadd', num_results=2)
         self.assertEqual(str(cm.exception), 'Invalid variants: chr2-A-C')
@@ -1278,6 +1278,9 @@ class EsUtilsTest(TestCase):
                         {'bool': {'must': [
                             {'range': {'xpos': {'lte': 2000001234}}},
                             {'range': {'xstop': {'gte': 2000005678}}}]}},
+                        {'bool': {'must': [
+                            {'range': {'xpos': {'gte': 7000000001, 'lte': 7000001100}}},
+                            {'range': {'xstop': {'gte': 7000009100, 'lte': 7000011100}}}]}},
                         {'terms': {'geneIds': ['ENSG00000223972']}},
                         {'terms': {'rsid': ['rs9876']}},
                         {'terms': {'variantId': ['2-1234-A-C']}},

--- a/seqr/utils/gene_utils.py
+++ b/seqr/utils/gene_utils.py
@@ -53,7 +53,7 @@ def parse_locus_list_items(request_json):
     gene_ids = set()
     gene_symbols = set()
     for item in raw_items.replace(',', ' ').replace('\t', '<TAB>').split():
-        interval_match = re.match('(?P<chrom>\w+):(?P<start>\d+)-(?P<end>\d+)', item)
+        interval_match = re.match('(?P<chrom>\w+):(?P<start>\d+)-(?P<end>\d+)(%(?P<offset>(\d+)))?', item)
         if not interval_match:
             interval_match = re.match('(?P<chrom>\w+)<TAB>(?P<start>\d+)<TAB>(?P<end>\d+)', item)
         if interval_match:
@@ -62,6 +62,8 @@ def parse_locus_list_items(request_json):
                 interval['chrom'] = interval['chrom'].lstrip('chr')
                 interval['start'] = int(interval['start'])
                 interval['end'] = int(interval['end'])
+                if interval.get('offset'):
+                    interval['offset'] = int(interval['offset']) / 100
                 if interval['start'] > interval['end']:
                     raise ValueError
                 get_xpos(interval['chrom'], interval['start'])

--- a/seqr/utils/xpos_utils.py
+++ b/seqr/utils/xpos_utils.py
@@ -37,7 +37,8 @@ CHROMOSOMES = [
 
 CHROM_TO_CHROM_NUMBER = {chrom: i for i, chrom in enumerate(CHROMOSOMES)}
 CHROM_NUMBER_TO_CHROM = {i: chrom for i, chrom in enumerate(CHROMOSOMES)}
-
+MIN_POS = 1
+MAX_POS = 3e8
 
 def get_xpos(chrom, pos):
     """Compute single number representing this chromosome and position.
@@ -55,7 +56,7 @@ def get_xpos(chrom, pos):
         else:
             chrom = fixed_chrom
 
-    if pos < 1 or pos > 3e8:
+    if pos < MIN_POS or pos > MAX_POS:
         raise ValueError("Invalid position: %s" % (pos,))
 
     return ((1 + CHROM_TO_CHROM_NUMBER[chrom])*int(1e9)) + pos

--- a/ui/shared/components/panel/variants/Annotations.jsx
+++ b/ui/shared/components/panel/variants/Annotations.jsx
@@ -149,7 +149,7 @@ const BaseSearchLinks = React.memo(({ variant, mainTranscript, genesById }) => {
 
   const seqrLinkProps = { genomeVersion: variant.genomeVersion, svType: variant.svType }
   if (variant.svType) {
-    seqrLinkProps.location = `${variant.chrom}:${variant.pos}-${variant.end}`
+    seqrLinkProps.location = `${variant.chrom}:${variant.pos}-${variant.end}%20`
 
     const useLiftover = variant.liftedOverGenomeVersion === GENOME_VERSION_37
     if (variant.genomeVersion === GENOME_VERSION_37 || (useLiftover && variant.liftedOverPos)) {


### PR DESCRIPTION
Updates how the "seqr" search works for SVs to restrict results to those that both start and end within a 20% margin of the start and end of the given  SV, rather than the current search will return any overlapping SV for the whole region.See discussion in the ticket for motivation