### PR TITLE
tweak logs for better debugging

### DIFF
--- a/seqr/utils/logging_utils.py
+++ b/seqr/utils/logging_utils.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+from settings import DEPLOYMENT_TYPE
+
 class JsonLogFormatter(logging.Formatter):
 
     def usesTime(self):
@@ -22,10 +24,10 @@ class JsonLogFormatter(logging.Formatter):
         if hasattr(record, 'db_update'):
             log_json['dbUpdate'] = record.db_update
 
-        if hasattr(record, 'traceback'):
+        if getattr(record, 'traceback', None):
             log_json['traceback'] = record.traceback
 
-        if record.levelname == 'ERROR':
+        if record.levelname == 'ERROR' and DEPLOYMENT_TYPE != 'dev':
             # Allows GCP Error to detect that this is an error log
             log_json['@type'] = 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent'
 

--- a/settings.py
+++ b/settings.py
@@ -225,7 +225,8 @@ ANYMAIL = {
     "POSTMARK_SERVER_TOKEN": os.environ.get('POSTMARK_SERVER_TOKEN', 'postmark-server-token-placeholder'),
 }
 
-if os.environ.get('DEPLOYMENT_TYPE') in {'prod', 'dev'}:
+DEPLOYMENT_TYPE = os.environ.get('DEPLOYMENT_TYPE')
+if DEPLOYMENT_TYPE in {'prod', 'dev'}:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
     DEBUG = False


### PR DESCRIPTION
We get a lot of noisy error alerts for dev that we don't want, so this disables them. Also, stops logging a null traceback which makes logs harder to read