### PR TITLE
Admin logging

### DIFF
--- a/reference_data/admin.py
+++ b/reference_data/admin.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
 from django.contrib import admin
 from django.core.exceptions import FieldDoesNotExist
-from reference_data.models import GeneInfo, HumanPhenotypeOntology, dbNSFPGene, GeneConstraint, TranscriptInfo, Omim
+from reference_data.models import GeneInfo, HumanPhenotypeOntology, dbNSFPGene, GeneConstraint, TranscriptInfo, Omim, \
+    GeneCopyNumberSensitivity, PrimateAI, MGI
 
 
 def get_gene_symbol(obj):
@@ -16,7 +17,10 @@ get_gene_id.short_description = 'Gene Id'
 get_gene_id.admin_order_field = 'gene__gene_id'
 
 
-for model_class in [GeneInfo, HumanPhenotypeOntology, dbNSFPGene, GeneConstraint, TranscriptInfo, Omim]:
+for model_class in [
+    GeneInfo, HumanPhenotypeOntology, dbNSFPGene, GeneConstraint, TranscriptInfo, Omim, GeneCopyNumberSensitivity,
+    PrimateAI, MGI,
+]:
     @admin.register(model_class)
     class SpecificModelAdmin(admin.ModelAdmin):
         search_fields = deepcopy(model_class._meta.json_fields if hasattr(model_class._meta, 'json_fields') else [])

--- a/seqr/admin.py
+++ b/seqr/admin.py
@@ -31,11 +31,11 @@ for model_class in [
         list_per_page = 2000
 
 @admin.register(admin.models.LogEntry)
-class SpecificModelAdmin(admin.ModelAdmin):
+class LogEntryModelAdmin(admin.ModelAdmin):
     search_fields = ['object_id', 'object_repr', 'change_message']
     list_display = ['object_id', 'object_repr', 'get_change_message', 'content_type', 'action_time', 'user']
 
-    def has_add_permission(self, request, obj=None):
+    def has_add_permission(self, request, obj):
         return False
 
     def has_change_permission(self, request, obj=None):

--- a/seqr/admin.py
+++ b/seqr/admin.py
@@ -18,8 +18,11 @@ for model_class in [
             'guid', 'name', 'display_name', 'family_id', 'individual_id', 'description', 'search_hash', 'id',
         }]
         list_display = deepcopy(model_class._meta.json_fields if getattr(model_class._meta, 'json_fields', None) else search_fields)
+        if 'guid' in list_display:
+            list_display.remove('guid')
+        list_display.insert(0, 'guid')
         if hasattr(model_class._meta, 'internal_json_fields'):
-            list_display = model_class._meta.internal_json_fields + list_display
+            list_display += model_class._meta.internal_json_fields
         if 'created_date' not in list_display:
             list_display.append('created_date')
         if 'last_modified_date' not in list_display:

--- a/seqr/admin.py
+++ b/seqr/admin.py
@@ -26,3 +26,17 @@ for model_class in [
             list_display.append('last_modified_date')
         save_on_top = True
         list_per_page = 2000
+
+@admin.register(admin.models.LogEntry)
+class SpecificModelAdmin(admin.ModelAdmin):
+    search_fields = ['object_id', 'object_repr', 'change_message']
+    list_display = ['object_id', 'object_repr', 'get_change_message', 'content_type', 'action_time', 'user']
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False

--- a/seqr/admin.py
+++ b/seqr/admin.py
@@ -35,7 +35,7 @@ class LogEntryModelAdmin(admin.ModelAdmin):
     search_fields = ['object_id', 'object_repr', 'change_message']
     list_display = ['object_id', 'object_repr', 'get_change_message', 'content_type', 'action_time', 'user']
 
-    def has_add_permission(self, request, obj):
+    def has_add_permission(self, request):
         return False
 
     def has_change_permission(self, request, obj=None):


### PR DESCRIPTION
For compliance purposes, we need a record of all changes to the database made through the django admin. It turns out that the admin by default writes all changes (create, update, and delete) to a table in the database with all the necessary metadata we need. This PR makes that table viewable in the admin itself so we can easily see what changes were made if we are ever asked about it.  I also tweaked some of the existing admin display while I was in there