### PR TITLE
Create Mnv/ complex SV

### DIFF
--- a/ui/pages/Project/components/CreateVariantButton.jsx
+++ b/ui/pages/Project/components/CreateVariantButton.jsx
@@ -93,7 +93,7 @@ const mapSavedVariantsStateToProps = (state, ownProps) => {
 const SavedVariantField = connect(mapSavedVariantsStateToProps)(SavedVariantToggle)
 
 const SAVED_VARIANT_COLUMNS = [
-  { name: 'genes', content: 'Genes', width: 3, format: val => (val.genes || []).map(({ geneSymbol }) => geneSymbol).join(', ') },
+  { name: 'genes', content: 'Genes', width: 3, format: val => (val.genes || []).map(gene => (gene || {}).geneSymbol).join(', ') },
   VARIANT_POS_COLUMN,
   TAG_COLUMN,
 ]

--- a/ui/pages/Project/components/CreateVariantButton.jsx
+++ b/ui/pages/Project/components/CreateVariantButton.jsx
@@ -5,7 +5,7 @@ import { FormSection } from 'redux-form'
 import { Grid, Divider, Accordion } from 'semantic-ui-react'
 
 import { updateVariantTags } from 'redux/rootReducer'
-import { getUser, getProjectsByGuid, getFamiliesByGuid, getSortedIndividualsByFamily, getSavedVariantsIsLoading } from 'redux/selectors'
+import { getUser, getProjectsByGuid, getFamiliesByGuid, getSortedIndividualsByFamily } from 'redux/selectors'
 
 import UpdateButton from 'shared/components/buttons/UpdateButton'
 import { Select, IntegerInput, LargeMultiselect } from 'shared/components/form/Inputs'
@@ -13,7 +13,6 @@ import { validators, configuredField } from 'shared/components/form/ReduxFormWra
 import { AwesomeBarFormInput } from 'shared/components/page/AwesomeBar'
 import { GENOME_VERSION_FIELD, NOTE_TAG_NAME } from 'shared/utils/constants'
 
-import { loadFamilySavedVariants } from '../reducers'
 import { getTaggedVariantsByFamily } from '../selectors'
 import SelectSavedVariantsTable, { VARIANT_POS_COLUMN, TAG_COLUMN } from './SelectSavedVariantsTable'
 
@@ -85,17 +84,12 @@ const SavedVariantToggle = props =>
 const mapSavedVariantsStateToProps = (state, ownProps) => {
   const familyGuid = getFormFamilyGuid(ownProps)
   return {
-    savedVariants: getTaggedVariantsByFamily(state)[familyGuid],
+    data: getTaggedVariantsByFamily(state)[familyGuid],
     familyGuid,
-    loading: getSavedVariantsIsLoading(state),
   }
 }
 
-const mapSavedVariantsDispatchToProps = {
-  load: loadFamilySavedVariants,
-}
-
-const SavedVariantField = connect(mapSavedVariantsStateToProps, mapSavedVariantsDispatchToProps)(SavedVariantToggle)
+const SavedVariantField = connect(mapSavedVariantsStateToProps)(SavedVariantToggle)
 
 const SAVED_VARIANT_COLUMNS = [
   { name: 'genes', width: 3, format: val => val.genes.map(({ geneSymbol }) => geneSymbol).join(', ') },

--- a/ui/pages/Project/components/CreateVariantButton.jsx
+++ b/ui/pages/Project/components/CreateVariantButton.jsx
@@ -26,8 +26,9 @@ const TRANSCRIPT_ID_FIELD_NAME = 'mainTranscriptId'
 const HGVSC_FIELD_NAME = 'hgvsc'
 const HGVSP_FIELD_NAME = 'hgvsp'
 const TAG_FIELD_NAME = 'tags'
+const VARIANTS_FIELD_NAME = 'variants'
 const FORMAT_RESPONSE_FIELDS = [
-  GENE_ID_FIELD_NAME, HGVSC_FIELD_NAME, HGVSP_FIELD_NAME, TAG_FIELD_NAME,
+  GENE_ID_FIELD_NAME, HGVSC_FIELD_NAME, HGVSP_FIELD_NAME, TAG_FIELD_NAME, VARIANTS_FIELD_NAME,
 ]
 
 const ZygosityInput = React.memo(({ individuals, name, title, individualField, error }) =>
@@ -92,7 +93,7 @@ const mapSavedVariantsStateToProps = (state, ownProps) => {
 const SavedVariantField = connect(mapSavedVariantsStateToProps)(SavedVariantToggle)
 
 const SAVED_VARIANT_COLUMNS = [
-  { name: 'genes', content: 'Genes', width: 3, format: val => val.genes.map(({ geneSymbol }) => geneSymbol).join(', ') },
+  { name: 'genes', content: 'Genes', width: 3, format: val => (val.genes || []).map(({ geneSymbol }) => geneSymbol).join(', ') },
   VARIANT_POS_COLUMN,
   TAG_COLUMN,
 ]
@@ -131,10 +132,10 @@ const START_FIELD = { name: 'pos', label: 'Start Position', ...POS_FIELD }
 const END_FIELD = { name: 'end', label: 'Stop Position', ...POS_FIELD }
 
 const SAVED_VARIANT_FIELD = {
-  name: 'variants',
+  name: VARIANTS_FIELD_NAME,
   idField: 'variantGuid',
   control: SavedVariantField,
-  format: value => (value || []).reduce((acc, variant) =>
+  format: value => (Array.isArray(value) ? value : []).reduce((acc, variant) =>
     ({ ...acc, [variant.variantGuid]: true }), {}),
 }
 
@@ -273,10 +274,12 @@ const mapDispatchToProps = (dispatch, ownProps) => {
         }
       }
 
+      const variants = values[VARIANTS_FIELD_NAME] || []
+
       const formattedValues = {
         familyGuid: ownProps.family.familyGuid,
         tags: values[TAG_FIELD_NAME],
-        variant,
+        variant: [variant, ...variants],
       }
 
       return dispatch(updateVariantTags(formattedValues))

--- a/ui/pages/Project/components/Matchmaker.jsx
+++ b/ui/pages/Project/components/Matchmaker.jsx
@@ -6,8 +6,7 @@ import { Header, Icon, Popup, Label, Grid } from 'semantic-ui-react'
 import styled from 'styled-components'
 
 import {
-  getIndividualsByGuid, getSortedIndividualsByFamily, getUser, getMmeSubmissionsByGuid, getSavedVariantsIsLoading,
-  getFamiliesByGuid,
+  getIndividualsByGuid, getSortedIndividualsByFamily, getUser, getMmeSubmissionsByGuid, getFamiliesByGuid,
 } from 'redux/selectors'
 import DeleteButton from 'shared/components/buttons/DeleteButton'
 import UpdateButton from 'shared/components/buttons/UpdateButton'
@@ -28,7 +27,6 @@ import { camelcaseToTitlecase } from 'shared/utils/stringUtils'
 
 import {
   loadMmeMatches, updateMmeSubmission, updateMmeSubmissionStatus, sendMmeContactEmail, updateMmeContactNotes,
-  loadFamilySavedVariants,
 } from '../reducers'
 import {
   getMatchmakerMatchesLoading,
@@ -39,6 +37,7 @@ import {
   getMatchmakerContactNotes,
   getVariantUniqueId,
 } from '../selectors'
+import SelectSavedVariantsTable from './SelectSavedVariantsTable'
 
 const BreakWordLink = styled.a.attrs({ target: '_blank' })`
   word-break: break-all;
@@ -79,44 +78,16 @@ const GENOTYPE_FIELDS = [
   },
 ]
 
-const BaseEditGenotypesTable = React.memo(({ savedVariants, value, load, loading, familyGuid, onChange }) =>
-  <DataLoader content contentId={familyGuid} load={load} loading={false}>
-    <SelectableTableFormInput
-      idField="variantId"
-      defaultSortColumn="xpos"
-      columns={GENOTYPE_FIELDS}
-      data={savedVariants}
-      value={value}
-      onChange={newValue => onChange(savedVariants.filter(variant => newValue[variant.variantId]))}
-      loading={loading}
-    />
-  </DataLoader>,
-)
-
-BaseEditGenotypesTable.propTypes = {
-  savedVariants: PropTypes.array,
-  value: PropTypes.object,
-  load: PropTypes.func,
-  loading: PropTypes.bool,
-  familyGuid: PropTypes.object,
-  onChange: PropTypes.func,
-}
-
 const mapGenotypesStateToProps = (state, ownProps) => {
   const individualGuid = ownProps.meta.form.split('_-_')[0]
   const { familyGuid } = state.individualsByGuid[individualGuid]
   return {
-    savedVariants: getIndividualTaggedVariants(state, { individualGuid }),
+    data: getIndividualTaggedVariants(state, { individualGuid }),
     familyGuid,
-    loading: getSavedVariantsIsLoading(state),
   }
 }
 
-const mapGenotypeDispatchToProps = {
-  load: loadFamilySavedVariants,
-}
-
-const EditGenotypesTable = connect(mapGenotypesStateToProps, mapGenotypeDispatchToProps)(BaseEditGenotypesTable)
+const EditGenotypesTable = connect(mapGenotypesStateToProps)(SelectSavedVariantsTable)
 
 const PHENOTYPE_FIELDS = [
   { name: 'id', content: 'HPO ID', width: 4 },
@@ -157,6 +128,8 @@ const SUBMISSION_EDIT_FIELDS = [
   {
     name: 'geneVariants',
     component: EditGenotypesTable,
+    idField: 'variantId',
+    columns: GENOTYPE_FIELDS,
     format: value => (value || []).reduce((acc, variant) =>
       ({ ...acc, [variant.variantId || getVariantUniqueId(variant)]: true }), {}),
   },

--- a/ui/pages/Project/components/SelectSavedVariantsTable.jsx
+++ b/ui/pages/Project/components/SelectSavedVariantsTable.jsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Icon } from 'semantic-ui-react'
+
+import { SelectableTableFormInput } from 'shared/components/table/DataTable'
+import DataLoader from 'shared/components/DataLoader'
+import { ColoredLabel } from 'shared/components/StyledComponents'
+
+const variantSummary = variant => (
+  <span>
+    {variant.chrom}:{variant.pos}
+    {variant.alt ? <span> {variant.ref} <Icon fitted name="angle right" /> {variant.alt}</span> : `-${variant.end}`}
+  </span>
+)
+
+export const VARIANT_POS_COLUMN = { name: 'xpos', content: 'Variant', width: 3, format: val => variantSummary(val) }
+
+export const TAG_COLUMN = {
+  name: 'tags',
+  content: 'Tags',
+  width: 8,
+  format: val => val.tags.map(tag =>
+    <ColoredLabel key={tag.tagGuid}size="small" color={tag.color} horizontal content={tag.name} />,
+  ),
+}
+
+const SelectSavedVariantsTable = React.memo(({ savedVariants, load, loading, familyGuid, idField, columns, value, onChange }) =>
+  <DataLoader content contentId={familyGuid} load={load} loading={false}>
+    <SelectableTableFormInput
+      idField={idField}
+      defaultSortColumn="xpos"
+      columns={columns}
+      data={savedVariants}
+      value={value}
+      onChange={newValue => onChange(savedVariants.filter(variant => newValue[variant[idField]]))}
+      loading={loading}
+    />
+  </DataLoader>,
+)
+// TODO use in matchmaker component
+SelectSavedVariantsTable.propTypes = {
+  savedVariants: PropTypes.array,
+  value: PropTypes.object,
+  load: PropTypes.func,
+  loading: PropTypes.bool,
+  familyGuid: PropTypes.string,
+  idField: PropTypes.string,
+  columns: PropTypes.array,
+  onChange: PropTypes.func,
+}
+
+export default SelectSavedVariantsTable

--- a/ui/pages/Project/components/SelectSavedVariantsTable.jsx
+++ b/ui/pages/Project/components/SelectSavedVariantsTable.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { Icon } from 'semantic-ui-react'
 
+import { getSavedVariantsIsLoading } from 'redux/selectors'
 import { SelectableTableFormInput } from 'shared/components/table/DataTable'
 import DataLoader from 'shared/components/DataLoader'
 import { ColoredLabel } from 'shared/components/StyledComponents'
+import { loadFamilySavedVariants } from '../reducers'
 
 const variantSummary = variant => (
   <span>
@@ -24,29 +27,29 @@ export const TAG_COLUMN = {
   ),
 }
 
-const SelectSavedVariantsTable = React.memo(({ savedVariants, load, loading, familyGuid, idField, columns, value, onChange }) =>
+const SelectSavedVariantsTable = React.memo(({ load, loading, familyGuid, ...props }) =>
   <DataLoader content contentId={familyGuid} load={load} loading={false}>
-    <SelectableTableFormInput
-      idField={idField}
-      defaultSortColumn="xpos"
-      columns={columns}
-      data={savedVariants}
-      value={value}
-      onChange={newValue => onChange(savedVariants.filter(variant => newValue[variant[idField]]))}
-      loading={loading}
-    />
+    <SelectableTableFormInput defaultSortColumn="xpos" loading={loading} {...props} />
   </DataLoader>,
 )
 // TODO use in matchmaker component
 SelectSavedVariantsTable.propTypes = {
-  savedVariants: PropTypes.array,
-  value: PropTypes.object,
   load: PropTypes.func,
   loading: PropTypes.bool,
   familyGuid: PropTypes.string,
-  idField: PropTypes.string,
-  columns: PropTypes.array,
-  onChange: PropTypes.func,
 }
 
-export default SelectSavedVariantsTable
+const mapStateToProps = state => ({
+  loading: getSavedVariantsIsLoading(state),
+})
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    load: (contentId) => {
+      return dispatch(loadFamilySavedVariants(contentId))
+    },
+    onChange: newValue => ownProps.onChange(ownProps.data.filter(o => newValue[o[ownProps.idField]])),
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SelectSavedVariantsTable)

--- a/ui/pages/Project/components/SelectSavedVariantsTable.jsx
+++ b/ui/pages/Project/components/SelectSavedVariantsTable.jsx
@@ -32,7 +32,7 @@ const SelectSavedVariantsTable = React.memo(({ load, loading, familyGuid, ...pro
     <SelectableTableFormInput defaultSortColumn="xpos" loading={loading} {...props} />
   </DataLoader>,
 )
-// TODO use in matchmaker component
+
 SelectSavedVariantsTable.propTypes = {
   load: PropTypes.func,
   loading: PropTypes.bool,

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -117,28 +117,44 @@ export const getProjectAnalysisGroupMmeSubmissions = createSelector(
     ), []),
 )
 
+export const getTaggedVariantsByFamily = createSelector(
+  getSavedVariantsByGuid,
+  getGenesById,
+  getVariantTagsByGuid,
+  (savedVariants, genesById, variantTagsByGuid) => {
+    return Object.values(savedVariants).filter(variant => variant.tagGuids.length).reduce((acc, variant) => {
+      const { familyGuids, ...variantDetail } = variant
+      variantDetail.tags = variant.tagGuids.map(tagGuid => variantTagsByGuid[tagGuid])
+      variantDetail.genes = Object.keys(variant.transcripts || {}).map(geneId => genesById[geneId])
+      familyGuids.forEach((familyGuid) => {
+        if (!acc[familyGuid]) {
+          acc[familyGuid] = []
+        }
+        acc[familyGuid].push(variantDetail)
+      })
+      return acc
+    }, {})
+  },
+)
+
 export const getVariantUniqueId = ({ chrom, pos, ref, alt, end, geneId }, variantGeneId) =>
   `${chrom}-${pos}-${ref ? `${ref}-${alt}` : end}-${variantGeneId || geneId}`
 
 export const getIndividualTaggedVariants = createSelector(
-  getSavedVariantsByGuid,
+  getTaggedVariantsByFamily,
   getIndividualsByGuid,
-  getGenesById,
-  getVariantTagsByGuid,
   (state, props) => props.individualGuid,
-  (savedVariants, individualsByGuid, genesById, variantTagsByGuid, individualGuid) => {
+  (taggedVariants, individualsByGuid, individualGuid) => {
     const { familyGuid } = individualsByGuid[individualGuid]
-    return Object.values(savedVariants).filter(
-      o => o.familyGuids.includes(familyGuid) && o.tagGuids.length).reduce((acc, variant) => {
+    return (taggedVariants[familyGuid] || []).reduce((acc, variant) => {
       const variantDetail = {
         ...variant.genotypes[individualGuid],
         ...variant,
-        tags: variant.tagGuids.map(tagGuid => variantTagsByGuid[tagGuid]),
       }
-      return [...acc, ...Object.keys(variant.transcripts || {}).map(geneId => ({
+      return [...acc, ...variant.genes.map(gene => ({
         ...variantDetail,
-        variantId: getVariantUniqueId(variant, geneId),
-        ...genesById[geneId],
+        variantId: getVariantUniqueId(variant, gene.geneId),
+        ...gene,
       }))]
     }, [])
   },

--- a/ui/shared/components/panel/variants/Variants.jsx
+++ b/ui/shared/components/panel/variants/Variants.jsx
@@ -125,17 +125,13 @@ Variant.propTypes = {
 const VariantWithReads = props => <FamilyReads layout={Variant} {...props} />
 
 const CompoundHets = React.memo(({ variants, ...props }) => {
-  const sharedGeneIds = Object.keys(variants[0].transcripts).filter(geneId => geneId in variants[1].transcripts)
+  const sharedGeneIds = variants.slice(1).reduce((acc, v) =>
+    acc.filter(geneId => geneId in (v.transcripts || {})), Object.keys(variants[0].transcripts || {}))
   let mainGeneId = sharedGeneIds[0]
   if (sharedGeneIds.length > 1) {
-    const mainGene1 = getVariantMainGeneId(variants[0])
-    if (sharedGeneIds.includes(mainGene1)) {
-      mainGeneId = mainGene1
-    } else {
-      const mainGene2 = getVariantMainGeneId(variants[1])
-      if (sharedGeneIds.includes(mainGene2)) {
-        mainGeneId = mainGene2
-      }
+    const mainSharedGene = variants.map(v => getVariantMainGeneId(v)).find(geneId => sharedGeneIds.includes(geneId))
+    if (mainSharedGene) {
+      mainGeneId = mainSharedGene
     }
   }
 

--- a/ui/shared/components/panel/variants/selectors.js
+++ b/ui/shared/components/panel/variants/selectors.js
@@ -56,6 +56,10 @@ export const getPairedSelectedSavedVariants = createSelector(
       (acc, variant) => ({ ...acc, [variant.variantGuid]: variant }), {})
     const seenCompoundHets = []
     let pairedVariants = variants.reduce((acc, variant) => {
+      if (seenCompoundHets.includes(variant.variantGuid)) {
+        return acc
+      }
+
       const variantCompoundHetGuids = [...[
         ...variant.tagGuids.map(t => tagsByGuid[t].variantGuids),
         ...variant.noteGuids.map(n => notesByGuid[n].variantGuids),
@@ -64,9 +68,10 @@ export const getPairedSelectedSavedVariants = createSelector(
       new Set())].filter(varGuid => selectedVariantsByGuid[varGuid])
 
       if (variantCompoundHetGuids.length) {
-        seenCompoundHets.push(variant.variantGuid)
-        return acc.concat(variantCompoundHetGuids.filter(varGuid => !seenCompoundHets.includes(varGuid)).map(
-          varGuid => ([variant, selectedVariantsByGuid[varGuid]])))
+        const unseenGuids = variantCompoundHetGuids.filter(varGuid => !seenCompoundHets.includes(varGuid))
+        acc.push([variant, ...unseenGuids.map(varGuid => selectedVariantsByGuid[varGuid])])
+        seenCompoundHets.push(variant.variantGuid, ...unseenGuids)
+        return acc
       }
 
       acc.push(variant)


### PR DESCRIPTION
Creates the ability to associate existing tagged variants with newly created manual variants. For SNVs this is used for multinucleotide variants, for SVs this will be used for complex SVs. Requires adding support for more than 2 "paired" variants (currently we only pair compound hets, which are always exactly 2). See linked ticket for details