### PR TITLE
use kubernetes django secret key by default

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -183,17 +183,19 @@ AUTHENTICATION_BACKENDS = (
 )
 
 # set the secret key
-SECRET_FILE = os.path.join(BASE_DIR, 'django_key')
-try:
-    SECRET_KEY = open(SECRET_FILE).read().strip()
-except IOError:
+SECRET_KEY = os.environ.get('DJANGO_KEY')
+if not SECRET_KEY:
+    SECRET_FILE = os.path.join(BASE_DIR, 'django_key')
     try:
-        SECRET_KEY = ''.join(random.SystemRandom().choice(string.printable) for i in range(50))
-        with open(SECRET_FILE, 'w') as f:
-            f.write(SECRET_KEY)
-    except IOError as e:
-        logger.warning('Unable to generate {}: {}'.format(os.path.abspath(SECRET_FILE), e))
-        SECRET_KEY = os.environ.get("DJANGO_KEY", "-placeholder-key-")
+        SECRET_KEY = open(SECRET_FILE).read().strip()
+    except IOError:
+        try:
+            SECRET_KEY = ''.join(random.SystemRandom().choice(string.printable) for i in range(50))
+            with open(SECRET_FILE, 'w') as f:
+                f.write(SECRET_KEY)
+        except IOError as e:
+            logger.error('Unable to generate {}: {}'.format(os.path.abspath(SECRET_FILE), e))
+            SECRET_KEY = "-placeholder-key-"
 
 ROOT_URLCONF = 'seqr.urls'
 

--- a/settings.py
+++ b/settings.py
@@ -187,7 +187,8 @@ SECRET_KEY = os.environ.get('DJANGO_KEY')
 if not SECRET_KEY:
     SECRET_FILE = os.path.join(BASE_DIR, 'django_key')
     try:
-        SECRET_KEY = open(SECRET_FILE).read().strip()
+        with open(SECRET_FILE) as f:
+            SECRET_KEY = f.read().strip()
     except IOError:
         SECRET_KEY = ''.join(random.SystemRandom().choice(string.printable) for i in range(50))
         with open(SECRET_FILE, 'w') as f:

--- a/settings.py
+++ b/settings.py
@@ -189,13 +189,9 @@ if not SECRET_KEY:
     try:
         SECRET_KEY = open(SECRET_FILE).read().strip()
     except IOError:
-        try:
-            SECRET_KEY = ''.join(random.SystemRandom().choice(string.printable) for i in range(50))
-            with open(SECRET_FILE, 'w') as f:
-                f.write(SECRET_KEY)
-        except IOError as e:
-            logger.error('Unable to generate {}: {}'.format(os.path.abspath(SECRET_FILE), e))
-            SECRET_KEY = "-placeholder-key-"
+        SECRET_KEY = ''.join(random.SystemRandom().choice(string.printable) for i in range(50))
+        with open(SECRET_FILE, 'w') as f:
+            f.write(SECRET_KEY)
 
 ROOT_URLCONF = 'seqr.urls'
 


### PR DESCRIPTION
django uses a `SECRET_KEY` setting that is used as part of the hashing to determining whether or not a session is valid. Users have been complaining recently of being frequently logged out of seqr and there are a ton of "Session data corrupted" warning logs. Django makes it clear that resetting the `SECRET_KEY` invalidates all active sessions, so you are supposed to keep this a constant. We have a `django_key` secret in our deployment that gets assigned to the `DJANGO_KEY` environment variable which will persist across seqr deployments. However, for some reason seqr defaults to getting the key from a file, and if that file is missing it generates a new key, only using the env variable if that fails. While we need to keep the file generation method for local users (who will need a key generated the first time they deploy seqr) we should start off by using the environment variable corresponding to the kubernetes secret