### PR TITLE
only send necessary update fields

### DIFF
--- a/ui/shared/components/buttons/EditProjectButton.jsx
+++ b/ui/shared/components/buttons/EditProjectButton.jsx
@@ -14,6 +14,8 @@ const MATCHMAKER_PROJECT_FIELDS = [
   ].map(({ label, ...field }) => ({ ...field, label: `Matchmaker ${label}` })),
 ]
 
+const EDITABLE_FIELD_KEYS = ['projectGuid', ...MATCHMAKER_PROJECT_FIELDS.map(({ name }) => name)]
+
 const EditProjectButton = React.memo(props => (
   props.project && props.project.canEdit ?
     <UpdateButton
@@ -35,7 +37,9 @@ EditProjectButton.propTypes = {
 }
 
 const mapDispatchToProps = {
-  updateProject,
+  updateProject: updates => updateProject(Object.entries(updates).reduce((acc, [k, v]) => (
+    EDITABLE_FIELD_KEYS.includes(k) ? { ...acc, [k]: v } : acc
+  ), {})),
 }
 
 export default connect(null, mapDispatchToProps)(EditProjectButton)


### PR DESCRIPTION
editing large projects is getting a 413 from nginx because we are sending the whole project json which is very large. Instead, we should only send the fields that actually might have been edited