### PR TITLE
Better permission denied error

### DIFF
--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -213,7 +213,7 @@ class ReportAPITest(AuthenticationTestCase):
         self.check_analyst_login(url)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 
@@ -232,7 +232,7 @@ class ReportAPITest(AuthenticationTestCase):
         self.check_analyst_login(url)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 
@@ -250,7 +250,7 @@ class ReportAPITest(AuthenticationTestCase):
         self.check_analyst_login(non_project_url)
 
         response = self.client.get(non_project_url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 
@@ -304,7 +304,8 @@ class ReportAPITest(AuthenticationTestCase):
         self.check_analyst_login(url)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['error'], 'User has insufficient permission')
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 
@@ -401,7 +402,8 @@ class ReportAPITest(AuthenticationTestCase):
         self.check_analyst_login(url)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()['error'], 'User has insufficient permission')
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -71,7 +71,7 @@ class SummaryDataAPITest(object):
         self.check_analyst_login(url)
 
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 403)
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 

--- a/seqr/views/apis/superuser_api_tests.py
+++ b/seqr/views/apis/superuser_api_tests.py
@@ -26,7 +26,8 @@ class SuperusersAPITest(AuthenticationTestCase):
 
     def test_admin(self):
         url = 'http://localhost/admin/'
-        self.check_superuser_login(url, login_redirect_url='/admin/login/', policy_redirect_url='/admin/login/')
+        self.check_superuser_login(url, login_redirect_url='/admin/login/', policy_redirect_url='/admin/login/',
+                                   permission_denied_error=302)
 
         response = self.client.get(url)
         self.assertContains(response, 'Django administration', status_code=200)

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -34,14 +34,17 @@ def _has_current_policies(user):
 
 
 # User access decorators
-_current_policies_required = user_passes_test(_has_current_policies, login_url=API_POLICY_REQUIRED_URL)
+def _check_active(user):
+    if not user.is_active:
+        raise PermissionDenied('User is no longer active')
+    return True
 
-def _active_required(view_func, login_url=API_LOGIN_REQUIRED_URL):
-    return user_passes_test(lambda user: user.is_active, login_url=login_url)(view_func)
+_active_required = user_passes_test(_check_active)
+_current_policies_required = user_passes_test(_has_current_policies, login_url=API_POLICY_REQUIRED_URL)
 
 def login_active_required(wrapped_func=None, login_url=API_LOGIN_REQUIRED_URL):
     def decorator(view_func):
-        return login_required(_active_required(view_func, login_url=login_url), login_url=login_url)
+        return login_required(_active_required(view_func), login_url=login_url)
     if wrapped_func:
         return decorator(wrapped_func)
     return decorator

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -34,9 +34,9 @@ def _has_current_policies(user):
 
 
 # User access decorators
-def _require_permission(test_func, error='User has insufficient permission'):
+def _require_permission(user_permission_test_func, error='User has insufficient permission'):
     def test_user(user):
-        if not test_func(user):
+        if not user_permission_test_func(user):
             raise PermissionDenied(error)
         return True
     return test_user
@@ -54,9 +54,9 @@ def login_active_required(wrapped_func=None, login_url=API_LOGIN_REQUIRED_URL):
 def login_and_policies_required(view_func):
     return login_active_required(_current_policies_required(view_func))
 
-def _user_has_policies_and_passes_test(test_func):
+def _user_has_policies_and_passes_test(user_permission_test_func):
     def decorator(view_func):
-        return login_and_policies_required(user_passes_test(_require_permission(test_func))(view_func))
+        return login_and_policies_required(user_passes_test(_require_permission(user_permission_test_func))(view_func))
     return decorator
 
 analyst_required = _user_has_policies_and_passes_test(user_is_analyst)

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -34,12 +34,14 @@ def _has_current_policies(user):
 
 
 # User access decorators
-def _check_active(user):
-    if not user.is_active:
-        raise PermissionDenied('User is no longer active')
-    return True
+def _require_permission(test_func, error='User has insufficient permission'):
+    def test_user(user):
+        if not test_func(user):
+            raise PermissionDenied(error)
+        return True
+    return test_user
 
-_active_required = user_passes_test(_check_active)
+_active_required = user_passes_test(_require_permission(lambda user: user.is_active, error='User is no longer active'))
 _current_policies_required = user_passes_test(_has_current_policies, login_url=API_POLICY_REQUIRED_URL)
 
 def login_active_required(wrapped_func=None, login_url=API_LOGIN_REQUIRED_URL):
@@ -54,7 +56,7 @@ def login_and_policies_required(view_func):
 
 def _user_has_policies_and_passes_test(test_func):
     def decorator(view_func):
-        return _active_required(_current_policies_required(user_passes_test(test_func, login_url=API_LOGIN_REQUIRED_URL)(view_func)))
+        return login_and_policies_required(user_passes_test(_require_permission(test_func))(view_func))
     return decorator
 
 analyst_required = _user_has_policies_and_passes_test(user_is_analyst)
@@ -62,8 +64,7 @@ data_manager_required = _user_has_policies_and_passes_test(user_is_data_manager)
 pm_required = _user_has_policies_and_passes_test(user_is_pm)
 pm_or_data_manager_required = _user_has_policies_and_passes_test(
     lambda user: user_is_data_manager(user) or user_is_pm(user))
-superuser_required = _user_has_policies_and_passes_test(lambda user: user .is_superuser)
-
+superuser_required = _user_has_policies_and_passes_test(lambda user: user.is_superuser)
 
 
 def _has_analyst_access(project):

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -127,8 +127,8 @@ class AuthenticationTestCase(TestCase):
 
         self.client.force_login(self.inactive_user)
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, login_required_url)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json().get('error'), 'User is no longer active')
 
         self.client.force_login(self.no_policy_user)
         if permission_level == self.NO_POLICY_USER:


### PR DESCRIPTION
Instead of redirecting logged in users to the login page when they try to access something they don't have permission for, return a 403 error instead