### PR TITLE
Dashboard download client side

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -50,9 +50,7 @@ from seqr.views.apis.saved_variant_api import \
     update_variant_main_transcript, \
     update_saved_variant_json
 
-from seqr.views.apis.dashboard_api import \
-    dashboard_page_data, \
-    export_projects_table_handler
+from seqr.views.apis.dashboard_api import dashboard_page_data
 
 from seqr.views.apis.gene_api import \
     gene_info, \
@@ -163,7 +161,6 @@ api_endpoints = {
     'family/(?P<family_guid>[\w.|-]+)/update_pedigree_image': update_family_pedigree_image,
 
     'dashboard': dashboard_page_data,
-    'dashboard/export_projects_table': export_projects_table_handler,
 
     'project/(?P<project_guid>[^/]+)/details': project_page_data,
 

--- a/seqr/views/apis/dashboard_api.py
+++ b/seqr/views/apis/dashboard_api.py
@@ -7,7 +7,6 @@ import logging
 from django.db import models
 
 from seqr.models import ProjectCategory, Sample, Family, Project
-from seqr.views.utils.export_utils import export_table
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_projects
 from seqr.views.utils.permissions_utils import get_project_guids_user_can_view, login_and_policies_required
@@ -99,55 +98,3 @@ def _retrieve_project_categories_by_guid(project_guids):
         project_categories_by_guid[project_category.guid] = project_category.json()
 
     return project_categories_by_guid
-
-
-@login_and_policies_required
-def export_projects_table_handler(request):
-    file_format = request.GET.get('file_format', 'tsv')
-
-    projects_by_guid = _get_projects_json(request.user)
-    project_categories_by_guid = _retrieve_project_categories_by_guid(projects_by_guid.keys())
-
-    header = [
-        'Project',
-        'Description',
-        'Categories',
-        'Created Date',
-        'Families',
-        'Individuals',
-        'Tagged Variants',
-        'WES Samples',
-        'WGS Samples',
-        'RNA Samples',
-    ]
-
-    header.extend([label for key, label in Family.ANALYSIS_STATUS_CHOICES if key != 'S'])
-
-    rows = []
-    for project in sorted(projects_by_guid.values(), key=lambda project: project.get('name') or project.get('deprecatedProjectId')):
-        project_categories = ', '.join(sorted(
-            [project_categories_by_guid[category_guid]['name'] for category_guid in project.get('projectCategoryGuids')]
-        ))
-
-        row = [
-            project.get('name') or project.get('deprecatedProjectId'),
-            project.get('description'),
-            project_categories,
-            project.get('createdDate'),
-            project.get('numFamilies'),
-            project.get('numIndividuals'),
-            project.get('numVariantTags'),
-            project.get('sampleTypeCounts', {}).get(Sample.SAMPLE_TYPE_WES, 0),
-            project.get('sampleTypeCounts', {}).get(Sample.SAMPLE_TYPE_WGS, 0),
-            project.get('sampleTypeCounts', {}).get(Sample.SAMPLE_TYPE_RNA, 0),
-        ]
-
-        row.extend([project.get('analysisStatusCounts', {}).get(key, 0) for key, _ in Family.ANALYSIS_STATUS_CHOICES if key != 'S'])
-
-        rows.append(row)
-
-    try:
-        response = export_table('projects', header, rows, file_format)
-    except ValueError as e:
-        response = create_json_response({'error': str(e)}, status=400)
-    return response

--- a/ui/pages/Dashboard/components/CategoryIndicator.jsx
+++ b/ui/pages/Dashboard/components/CategoryIndicator.jsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { connect } from 'react-redux'
 import randomMC from 'random-material-color'
 import styled from 'styled-components'
 import { Icon } from 'semantic-ui-react'
 
-import { getProjectCategoriesByGuid } from 'redux/selectors'
 import EditProjectCategoriesModal from './EditProjectCategoriesModal'
 
 const getColor = categoryNames => (
@@ -17,11 +15,9 @@ const ComputedColoredIcon = styled(({ categoryNames, ...props }) => <Icon {...pr
   color: ${props => getColor(props.categoryNames)} !important;
 `
 
-const CategoryIndicator = React.memo(({ project, projectCategoriesByGuid }) => {
-  const categoryNames = project.projectCategoryGuids.map(guid => (projectCategoriesByGuid[guid] && projectCategoriesByGuid[guid].name) || guid)
-
-  const popup = categoryNames.length > 0 ? {
-    content: categoryNames.map(name => <div key={name}>{name}</div>),
+const CategoryIndicator = React.memo(({ project }) => {
+  const popup = project.projectCategories.length > 0 ? {
+    content: project.projectCategories.map(name => <div key={name}>{name}</div>),
     header: 'Categories',
     position: 'top center',
     size: 'small',
@@ -32,7 +28,7 @@ const CategoryIndicator = React.memo(({ project, projectCategoriesByGuid }) => {
       project={project}
       trigger={
         <a role="button" tabIndex="0" style={{ cursor: 'pointer' }}>
-          <ComputedColoredIcon name={`${categoryNames.length === 0 ? 'outline ' : ''}star`} categoryNames={categoryNames} />
+          <ComputedColoredIcon name={`${project.projectCategories.length === 0 ? 'outline ' : ''}star`} categoryNames={project.projectCategories} />
         </a>
       }
       popup={popup}
@@ -43,12 +39,7 @@ const CategoryIndicator = React.memo(({ project, projectCategoriesByGuid }) => {
 
 CategoryIndicator.propTypes = {
   project: PropTypes.object.isRequired,
-  projectCategoriesByGuid: PropTypes.object.isRequired,
 }
 
-export { CategoryIndicator as CategoryIndicatorComponent }
-
-const mapStateToProps = state => ({ projectCategoriesByGuid: getProjectCategoriesByGuid(state) })
-
-export default connect(mapStateToProps)(CategoryIndicator)
+export default CategoryIndicator
 

--- a/ui/pages/Dashboard/components/CategoryIndicator.test.js
+++ b/ui/pages/Dashboard/components/CategoryIndicator.test.js
@@ -13,7 +13,7 @@ test('shallow-render with categories without crashing', () => {
    */
 
   const props = {
-    project: getVisibleProjects(STATE1).find(({ guid }) => guid === 'R0237_1000_genomes_demo'),
+    project: getVisibleProjects(STATE1).find(({ projectGuid }) => projectGuid === 'R0237_1000_genomes_demo'),
   }
 
   shallow(<CategoryIndicator {...props} />)
@@ -25,7 +25,7 @@ test('shallow-render without categories without crashing', () => {
    */
 
   const props = {
-    project: getVisibleProjects(STATE1).find(({ guid }) => guid === 'R0202_tutorial'),
+    project: getVisibleProjects(STATE1).find(({ projectGuid }) => projectGuid === 'R0202_tutorial'),
   }
 
   shallow(<CategoryIndicator {...props} />)

--- a/ui/pages/Dashboard/components/CategoryIndicator.test.js
+++ b/ui/pages/Dashboard/components/CategoryIndicator.test.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { shallow, configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
-import { getProjectsByGuid, getProjectCategoriesByGuid } from 'redux/selectors'
-import { CategoryIndicatorComponent } from './CategoryIndicator'
+import CategoryIndicator from './CategoryIndicator'
+import { getVisibleProjects } from '../selectors'
 import { STATE1 } from '../fixtures'
 
 configure({ adapter: new Adapter() })
@@ -13,11 +13,10 @@ test('shallow-render with categories without crashing', () => {
    */
 
   const props = {
-    project: getProjectsByGuid(STATE1).R0237_1000_genomes_demo,
-    projectCategoriesByGuid: getProjectCategoriesByGuid(STATE1),
+    project: getVisibleProjects(STATE1).find(({ guid }) => guid === 'R0237_1000_genomes_demo'),
   }
 
-  shallow(<CategoryIndicatorComponent {...props} />)
+  shallow(<CategoryIndicator {...props} />)
 })
 
 test('shallow-render without categories without crashing', () => {
@@ -26,9 +25,8 @@ test('shallow-render without categories without crashing', () => {
    */
 
   const props = {
-    project: getProjectsByGuid(STATE1).R0202_tutorial,
-    projectCategoriesByGuid: getProjectCategoriesByGuid(STATE1),
+    project: getVisibleProjects(STATE1).find(({ guid }) => guid === 'R0202_tutorial'),
   }
 
-  shallow(<CategoryIndicatorComponent {...props} />)
+  shallow(<CategoryIndicator {...props} />)
 })

--- a/ui/pages/Dashboard/components/ProjectsTable.jsx
+++ b/ui/pages/Dashboard/components/ProjectsTable.jsx
@@ -8,7 +8,6 @@ import { Popup, Icon } from 'semantic-ui-react'
 
 import { fetchProjects } from 'redux/rootReducer'
 import { getProjectsIsLoading, getUser, getGoogleLoginEnabled } from 'redux/selectors'
-import ExportTableButton from 'shared/components/buttons/ExportTableButton'
 import HorizontalStackedBar from 'shared/components/graph/HorizontalStackedBar'
 import DataTable from 'shared/components/table/DataTable'
 import DataLoader from 'shared/components/DataLoader'
@@ -22,10 +21,6 @@ import CategoryIndicator from './CategoryIndicator'
 import ProjectEllipsisMenu from './ProjectEllipsisMenu'
 import { getVisibleProjects } from '../selectors'
 
-
-const RightAligned = styled.span`
-  float: right;
-`
 
 const ProjectTableContainer = styled.div`
   th {
@@ -48,13 +43,13 @@ const ProjectTableContainer = styled.div`
   }
 `
 
-const PROJECT_EXPORT_URLS = [{ name: 'Projects', url: '/api/dashboard/export_projects_table' }]
-
 const COLUMNS = [
   {
     name: 'projectCategoryGuids',
     width: 1,
     format: project => <CategoryIndicator project={project} />,
+    downloadColumn: 'Categories',
+    noFormatExport: true, //TODO
   },
   {
     name: 'name',
@@ -67,18 +62,22 @@ const COLUMNS = [
         { project.description }
       </div>
     ),
+    noFormatExport: true,
   },
   {
     name: 'anvil',
     width: 1,
     content: 'AnVIL',
-    format: project => (project.workspaceName ?
-      <Popup
-        content={`AnVIL workspace: ${project.workspaceNamespace}/${project.workspaceName}`}
-        position="top center"
-        trigger={<Icon name="fire" />}
-      /> : null
-    ),
+    format: (project, isExport) => {
+      if (!project.workspaceName) {
+        return null
+      }
+      const workspace = `${project.workspaceNamespace}/${project.workspaceName}`
+      return (
+        isExport ? workspace :
+        <Popup content={`AnVIL workspace: ${workspace}`} position="top center" trigger={<Icon name="fire" />} />
+      )
+    },
   },
   {
     name: 'createdDate',
@@ -86,17 +85,20 @@ const COLUMNS = [
     content: 'Created',
     textAlign: 'right',
     format: project => new Timeago().format(project.createdDate),
+    noFormatExport: true,
   },
   {
     name: 'numFamilies',
     width: 1,
     content: 'Fam.',
+    downloadColumn: 'Families',
     textAlign: 'right',
   },
   {
     name: 'numIndividuals',
     width: 1,
     content: 'Indiv.',
+    downloadColumn: 'Individuals',
     textAlign: 'right',
   },
   {
@@ -104,15 +106,25 @@ const COLUMNS = [
     width: 1,
     content: 'Samples',
     textAlign: 'right',
-    format: project => project.sampleTypeCounts && Object.entries(project.sampleTypeCounts).map(
-      ([sampleType, numSamples], i) => {
-        const color = (sampleType === SAMPLE_TYPE_EXOME && '#73AB3D') || (sampleType === SAMPLE_TYPE_GENOME && '#4682b4') || 'black'
-        return (
-          <div key={sampleType}>
-            <span style={{ color }}>{numSamples} <b>{sampleType}</b></span>
-            {(i < project.sampleTypeCounts.length - 1) ? ', ' : null}
-          </div>)
-      }),
+    format: (project, isExport) => {
+      if (!project.sampleTypeCounts) {
+        return null
+      }
+      if (isExport) {
+        return Object.entries(project.sampleTypeCounts).map(([sampleType, numSamples]) =>
+          `${sampleType}: ${numSamples}`,
+        ).join(', ')
+      }
+      return Object.entries(project.sampleTypeCounts).map(
+        ([sampleType, numSamples], i) => {
+          const color = (sampleType === SAMPLE_TYPE_EXOME && '#73AB3D') || (sampleType === SAMPLE_TYPE_GENOME && '#4682b4') || 'black'
+          return (
+            <div key={sampleType}>
+              <span style={{ color }}>{numSamples} <b>{sampleType}</b></span>
+              {(i < project.sampleTypeCounts.length - 1) ? ', ' : null}
+            </div>)
+        })
+    },
   },
   {
     name: 'numVariantTags',
@@ -124,25 +136,31 @@ const COLUMNS = [
     name: 'analysisStatusCounts',
     width: 1,
     content: 'Analysis',
+    downloadColumn: 'Analysis Status',
     textAlign: 'right',
-    format: project => project.analysisStatusCounts && (
-      <HorizontalStackedBar
-        title="Family Analysis Status"
-        data={FAMILY_ANALYSIS_STATUS_OPTIONS.reduce(
-          (acc, d) => (
-            project.analysisStatusCounts[d.value] ?
-              [...acc, { ...d, count: project.analysisStatusCounts[d.value] }] :
-              acc
-          ), [])}
-        height={12}
-      />
-    ),
+    format: (project, isExport) => {
+      if (!project.analysisStatusCounts) {
+        return null
+      }
+      const statusData = FAMILY_ANALYSIS_STATUS_OPTIONS.reduce(
+        (acc, d) => (
+          project.analysisStatusCounts[d.value] ?
+            [...acc, { ...d, count: project.analysisStatusCounts[d.value] }] :
+            acc
+        ), [])
+      if (isExport) {
+        return statusData.map(({ name, count }) => `${name}: ${count}`).join(', ')
+      }
+      return <HorizontalStackedBar title="Family Analysis Status" data={statusData} height={12} />
+    },
   },
   {
-    name: 'edit',
+    name: 'canEdit',
     width: 1,
     textAlign: 'right',
     format: project => project.canEdit && <ProjectEllipsisMenu project={project} />,
+    downloadColumn: 'Can Edit',
+    noFormatExport: true,
   },
 ]
 
@@ -153,6 +171,7 @@ SUPERUSER_COLUMNS.splice(3, 0, {
   content: 'Last Accessed',
   textAlign: 'right',
   format: project => (project.lastAccessedDate ? new Timeago().format(project.lastAccessedDate) : ''),
+  noFormatExport: true,
 })
 
 const COLUMNS_NO_ANVIL = [...COLUMNS]
@@ -175,10 +194,6 @@ const ProjectsTable = React.memo(({ visibleProjects, loading, load, user, google
       <HorizontalSpacer width={10} />
       <InlineHeader size="medium" content="Projects:" />
       <FilterSelector />
-      <RightAligned>
-        <ExportTableButton downloads={PROJECT_EXPORT_URLS} />
-        <HorizontalSpacer width={45} />
-      </RightAligned>
       <VerticalSpacer height={10} />
       <DataTable
         striped
@@ -191,6 +206,8 @@ const ProjectsTable = React.memo(({ visibleProjects, loading, load, user, google
         data={visibleProjects}
         columns={getColumns(googleLoginEnabled, user.isAnvil, user.isSuperuser)}
         footer={user.isPm ? <CreateProjectButton /> : null}
+        downloadTableType="Projects"
+        downloadFileName="projects"
       />
     </ProjectTableContainer>
   </DataLoader>,

--- a/ui/pages/Dashboard/components/ProjectsTable.jsx
+++ b/ui/pages/Dashboard/components/ProjectsTable.jsx
@@ -45,11 +45,11 @@ const ProjectTableContainer = styled.div`
 
 const COLUMNS = [
   {
-    name: 'projectCategoryGuids',
+    name: 'projectCategories',
     width: 1,
     format: project => <CategoryIndicator project={project} />,
     downloadColumn: 'Categories',
-    noFormatExport: true, //TODO
+    noFormatExport: true,
   },
   {
     name: 'name',

--- a/ui/pages/Dashboard/selectors.js
+++ b/ui/pages/Dashboard/selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect'
 
-import { getProjectsByGuid } from 'redux/selectors'
+import { getProjectsByGuid, getProjectCategoriesByGuid } from 'redux/selectors'
 import { SHOW_ALL } from './constants'
 
 
@@ -23,10 +23,16 @@ export const createProjectFilter = (projectsByGuid, projectFilter) => {
  */
 export const getVisibleProjects = createSelector(
   getProjectsByGuid,
+  getProjectCategoriesByGuid,
   getProjectFilter,
-  (projectsByGuid, projectFilter) => {
+  (projectsByGuid, projectCategoriesByGuid, projectFilter) => {
     const filterFunc = createProjectFilter(projectsByGuid, projectFilter)
     const visibleProjectGuids = Object.keys(projectsByGuid).filter(filterFunc)
-    return visibleProjectGuids.map(projectGuid => projectsByGuid[projectGuid])
+    return visibleProjectGuids.map((projectGuid) => {
+      const project = projectsByGuid[projectGuid]
+      const projectCategories = project.projectCategoryGuids.map(guid =>
+        (projectCategoriesByGuid[guid] && projectCategoriesByGuid[guid].name) || guid)
+      return { ...project, projectCategories }
+    })
   },
 )

--- a/ui/shared/components/table/DataTable.jsx
+++ b/ui/shared/components/table/DataTable.jsx
@@ -172,7 +172,7 @@ class DataTable extends React.PureComponent {
       sortedData = sortedData.slice((activePage - 1) * rowsPerPage, activePage * rowsPerPage)
     }
 
-    const processedColumns = columns.map(({ formFieldProps, ...columnProps }) => (
+    const processedColumns = columns.map(({ formFieldProps, downloadColumn, ...columnProps }) => (
       formFieldProps ?
         {
           ...columnProps,


### PR DESCRIPTION
Currently we have a server-side endpoint to download the project dashboard data, but moving the download code to be based off of the client side table is a) more consistent with how almost every download in seqr works and b) easier to maintain and less fragile