### PR TITLE
Changed the way to get samples from an ES index.

### DIFF
--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -47,7 +47,7 @@ def add_variants_dataset_handler(request, project_guid):
         if dataset_type not in Sample.DATASET_TYPE_LOOKUP:
             raise ValueError('Invalid dataset type "{}"'.format(dataset_type))
 
-        sample_ids, index_metadata = get_elasticsearch_index_samples(elasticsearch_index, dataset_type=dataset_type)
+        sample_ids, index_metadata = get_elasticsearch_index_samples(elasticsearch_index)
         if not sample_ids:
             raise ValueError('No samples found in the index. Make sure the specified caller type is correct')
         validate_index_metadata(index_metadata, project, elasticsearch_index, dataset_type=dataset_type)


### PR DESCRIPTION
Currently, seqr gets samples from the `samples_num_alt_1` field for `VARIANT` indices and from the `samples` field for `SV` indices. To make it ready for adding genome SVs which don't have the `samples` field, this PR change it to get samples from the first field in the list of ['samples', 'samples_num_alt_1'] and it exists in the index.