### PR TITLE
Remove dbgap_submission

### DIFF
--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -52,7 +52,7 @@ def seqr_stats(request):
 
 
 SUBJECT_TABLE_COLUMNS = [
-    'entity:subject_id', 'subject_id', 'prior_testing', 'project_id', 'pmid_id', 'dbgap_submission', 'dbgap_study_id',
+    'entity:subject_id', 'subject_id', 'prior_testing', 'project_id', 'pmid_id', 'dbgap_study_id',
     'dbgap_subject_id', 'multiple_datasets', 'family_id', 'paternal_id', 'maternal_id', 'twin_id',
     'proband_relationship', 'sex', 'ancestry', 'ancestry_detail', 'age_at_last_observation', 'phenotype_group',
     'disease_id', 'disease_description', 'affected_status', 'congenital_status', 'age_of_onset', 'hpo_present',


### PR DESCRIPTION
The column `dbgap_submission` is simply removed as the request in #1866. 