### PR TITLE
remove login from readiness check

### DIFF
--- a/deploy/docker/seqr/readiness_probe
+++ b/deploy/docker/seqr/readiness_probe
@@ -1,1 +1,1 @@
-curl http://localhost:${SEQR_SERVICE_PORT}/login | grep -i "html" >& /readiness_probe.log
+curl http://localhost:${SEQR_SERVICE_PORT} | grep -i "html" >& /readiness_probe.log


### PR DESCRIPTION
After updating seqr to no longer support a login page when google auth is enabled, the readiness probe fails