### PR TITLE
Changed the genotype and SV type info displays.

### DIFF
--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -362,7 +362,7 @@ def _process_saved_variants(saved_variants_by_family, family_individual_affected
             discovery_notes = 'The following variants are part of the {variant_type} variant {parent}: {nested}'.format(
                 variant_type='complex structural' if parent_mnv.get('svType') else 'multinucleotide',
                 parent='{} ({})'.format(parent_name, ', '.join(parent_details)) if parent_details else parent_name,
-                nested=', '.join([_get_nested_variant_name(v) for v in nested_mnvs]))
+                nested=', '.join(sorted([_get_nested_variant_name(v) for v in nested_mnvs])))
             for variant in nested_mnvs:
                 variant['discovery_notes'] = discovery_notes
             saved_variants.remove(parent_mnv)

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -388,12 +388,12 @@ class ReportAPITest(AuthenticationTestCase):
         self.assertIn('\t'.join([
             'HG00733', 'HG00733', 'HG00733', 'OR4G11P', 'Known', 'Unknown / Other', 'Heterozygous', 'GRCh38.p12', '19',
             '1912633', 'G', 'T', '-', '-', 'ENST00000371839', '-', '-', '-',
-            'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, p.Ala196Leu): 19-1912634-C-T, 19-1912633-G-T']),
+            'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, p.Ala196Leu): 19-1912633-G-T, 19-1912634-C-T']),
             discovery_file)
         self.assertIn('\t'.join([
             'HG00733', 'HG00733', 'HG00733', 'OR4G11P', 'Known', 'Unknown / Other', 'Heterozygous', 'GRCh38.p12', '19',
             '1912634', 'C', 'T', '-', '-', 'ENST00000371839', '-', '-', '-',
-            'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, p.Ala196Leu): 19-1912634-C-T, 19-1912633-G-T']),
+            'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, p.Ala196Leu): 19-1912633-G-T, 19-1912634-C-T']),
             discovery_file)
 
         # Test non-broad analysts do not have access

--- a/ui/shared/components/panel/variants/Annotations.jsx
+++ b/ui/shared/components/panel/variants/Annotations.jsx
@@ -251,9 +251,9 @@ const Annotations = React.memo(({ variant }) => {
           trigger={
             <ButtonLink size={svType && 'big'}>
               {svType ? (SVTYPE_LOOKUP[svType] || svType) : mainTranscript.majorConsequence.replace(/_/g, ' ')}
-              {svType && svTypeDetail && SVTYPE_DETAILS[svType] &&
+              {svType && svTypeDetail &&
               <Popup trigger={<Icon name="info circle" size="small" corner="top right" />}
-                content={SVTYPE_DETAILS[svType][svTypeDetail]}
+                content={(SVTYPE_DETAILS[svType] || {})[svTypeDetail] || svTypeDetail}
                 position="top center"
               />}
             </ButtonLink>

--- a/ui/shared/components/panel/variants/Annotations.jsx
+++ b/ui/shared/components/panel/variants/Annotations.jsx
@@ -12,7 +12,7 @@ import { ButtonLink } from '../../StyledComponents'
 import { getOtherGeneNames } from '../genes/GeneDetail'
 import Transcripts, { TranscriptLink } from './Transcripts'
 import { LocusListLabels } from './VariantGene'
-import { GENOME_VERSION_37, getVariantMainTranscript } from '../../../utils/constants'
+import { GENOME_VERSION_37, getVariantMainTranscript, SVTYPE_TEXT_MAPPING, CPX_SVTYPE_DETAILS } from '../../../utils/constants'
 
 
 const SequenceContainer = styled.span`
@@ -250,8 +250,11 @@ const Annotations = React.memo(({ variant }) => {
           size="large"
           trigger={
             <ButtonLink size={svType && 'big'}>
-              {svType || mainTranscript.majorConsequence.replace(/_/g, ' ')}
-              {svType && svTypeDetail && `:${svTypeDetail}`}
+              {(svType && SVTYPE_TEXT_MAPPING[svType]) || mainTranscript.majorConsequence.replace(/_/g, ' ')}
+              {svType && svTypeDetail &&
+              <Popup trigger={<span>&nbsp;<Icon name="info circle" size="small" position="top right" /></span>}
+                content={CPX_SVTYPE_DETAILS[svType.concat('_', svTypeDetail)]}
+              />}
             </ButtonLink>
           }
           popup={transcriptPopupProps}

--- a/ui/shared/components/panel/variants/Annotations.jsx
+++ b/ui/shared/components/panel/variants/Annotations.jsx
@@ -12,7 +12,7 @@ import { ButtonLink } from '../../StyledComponents'
 import { getOtherGeneNames } from '../genes/GeneDetail'
 import Transcripts, { TranscriptLink } from './Transcripts'
 import { LocusListLabels } from './VariantGene'
-import { GENOME_VERSION_37, getVariantMainTranscript, SVTYPE_TEXT_MAPPING, CPX_SVTYPE_DETAILS } from '../../../utils/constants'
+import { GENOME_VERSION_37, getVariantMainTranscript, SVTYPE_LOOKUP, SVTYPE_DETAILS } from '../../../utils/constants'
 
 
 const SequenceContainer = styled.span`
@@ -250,10 +250,11 @@ const Annotations = React.memo(({ variant }) => {
           size="large"
           trigger={
             <ButtonLink size={svType && 'big'}>
-              {(svType && SVTYPE_TEXT_MAPPING[svType]) || mainTranscript.majorConsequence.replace(/_/g, ' ')}
-              {svType && svTypeDetail &&
-              <Popup trigger={<span>&nbsp;<Icon name="info circle" size="small" position="top right" /></span>}
-                content={CPX_SVTYPE_DETAILS[svType.concat('_', svTypeDetail)]}
+              {svType ? (SVTYPE_LOOKUP[svType] || svType) : mainTranscript.majorConsequence.replace(/_/g, ' ')}
+              {svType && svTypeDetail && SVTYPE_DETAILS[svType] &&
+              <Popup trigger={<Icon name="info circle" size="small" corner="top right" />}
+                content={SVTYPE_DETAILS[svType][svTypeDetail]}
+                position="top center"
               />}
             </ButtonLink>
           }

--- a/ui/shared/components/panel/variants/VariantIndividuals.jsx
+++ b/ui/shared/components/panel/variants/VariantIndividuals.jsx
@@ -111,7 +111,7 @@ const svGenotype = (genotype, isHemiX) => {
   }
   return (
     <span>
-      {genotype.numAlt > 0 ? <b><i>X</i></b> : '-'}/{isHemiX || genotype.numAlt < 2 ? '-' : <b><i>X</i></b>}
+      {genotype.numAlt > 0 ? <b><i>alt</i></b> : 'ref'}/{isHemiX || genotype.numAlt < 2 ? 'ref' : <b><i>alt</i></b>}
       {isAltCn && <span><br />CN: <b><i>{genotype.cn}</i></b></span>}
     </span>
   )

--- a/ui/shared/components/panel/variants/VariantIndividuals.jsx
+++ b/ui/shared/components/panel/variants/VariantIndividuals.jsx
@@ -111,7 +111,7 @@ const svGenotype = (genotype, isHemiX) => {
   }
   return (
     <span>
-      {genotype.numAlt > 0 ? <b><i>alt</i></b> : 'ref'}/{isHemiX || genotype.numAlt < 2 ? 'ref' : <b><i>alt</i></b>}
+      {isHemiX || genotype.numAlt < 2 ? 'ref' : <b><i>alt</i></b>}/{genotype.numAlt > 0 ? <b><i>alt</i></b> : 'ref'}
       {isAltCn && <span><br />CN: <b><i>{genotype.cn}</i></b></span>}
     </span>
   )

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -861,6 +861,31 @@ export const VEP_CONSEQUENCE_ORDER_LOOKUP = ORDERED_VEP_CONSEQUENCES.reduce((acc
   ({ ...acc, [consequence.value]: i }),
 {})
 
+export const SVTYPE_TEXT_MAPPING = ORDERED_VEP_CONSEQUENCES.reduce((acc, consequence) =>
+  ((consequence.group && consequence.group === VEP_GROUP_SV) ? { ...acc, [consequence.value]: consequence.text } : acc),
+{})
+
+export const CPX_SVTYPE_DETAILS = {
+  CPX_INS_iDEL: 'Insertion with deletion at insertion site',
+  CPX_INVdel: 'Complex inversion with 3\' flanking deletion',
+  CPX_INVdup: 'Complex inversion with 3\' flanking duplication',
+  CPX_dDUP: 'Dispersed duplication',
+  CPX_dDUP_iDEL: 'Dispersed duplication with deletion at insertion site',
+  CPX_delINV: 'Complex inversion with 5\' flanking deletion',
+  CPX_delINVdel: 'Complex inversion with 5\' and 3\' flanking deletions',
+  CPX_delINVdup: 'Complex inversion with 5\' flanking deletion and 3\' flanking duplication',
+  CPX_dupINV: 'Complex inversion with 5\' flanking duplication',
+  CPX_dupINVdel: 'Complex inversion with 5\' flanking duplication and 3\' flanking deletion',
+  CPX_dupINVdup: 'Complex inversion with 5\' and 3\' flanking duplications',
+  CPX_piDUP_FR: 'Palindromic inverted tandem duplication, forward-reverse orientation',
+  CPX_piDUP_RF: 'Palindromic inverted tandem duplication, reverse-forward orientation',
+  INS_ME: 'Mobile element',
+  'INS_ME:ALU': 'Alu element insertion',
+  'INS_ME:LINE1': 'LINE1 element insertion',
+  'INS_ME:SVA': 'SVA element insertion',
+  'INS_ME:UNK': 'Unspecified origin insertion',
+}
+
 export const SHOW_ALL = 'ALL'
 export const NOTE_TAG_NAME = 'Has Notes'
 export const EXCLUDED_TAG_NAME = 'Excluded'

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -508,6 +508,102 @@ export const VEP_GROUP_SV = 'structural'
 export const VEP_GROUP_SV_CONSEQUENCES = 'structural_consequence'
 
 
+const VEP_SV_TYPES = [
+  {
+    description: 'A large deletion',
+    text: 'Deletion',
+    value: 'DEL',
+  },
+  {
+    description: 'A large duplication',
+    text: 'Duplication',
+    value: 'DUP',
+  },
+  {
+    description: 'A translocation variant',
+    text: 'Translocation',
+    value: 'BND',
+  },
+  {
+    description: 'A copy number polymorphism variant',
+    text: 'Copy Number',
+    value: 'CNV',
+  },
+  {
+    description: 'A Complex Structural Variant',
+    text: 'Complex SV',
+    value: 'CPX',
+  },
+  {
+    description: 'A reciprocal chromosomal translocation',
+    text: 'Reciprocal Translocation',
+    value: 'CTX',
+  },
+  {
+    description: 'A large insertion',
+    text: 'Insertion',
+    value: 'INS',
+  },
+  {
+    description: 'A large inversion',
+    text: 'Inversion',
+    value: 'INV',
+  },
+]
+
+const VEP_SV_CONSEQUENCES = [
+  {
+    description: 'A loss of function effect',
+    text: 'Loss of function',
+    value: 'LOF',
+  },
+  {
+    description: 'A loss of function effect via intragenic exonic duplication',
+    text: 'Loss of function via Duplication',
+    value: 'DUP_LOF',
+  },
+  {
+    description: 'A copy-gain effect',
+    text: 'Copy Gain',
+    value: 'COPY_GAIN',
+  },
+  {
+    description: 'A duplication partially overlapping the gene',
+    text: 'Duplication Partial',
+    value: 'DUP_PARTIAL',
+  },
+  {
+    description: 'A multiallelic SV predicted to have a Loss of function, Loss of function via Duplication, Copy Gain, or Duplication Partial effect',
+    text: 'Multiallelic SV',
+    value: 'MSV_EXON_OVR',
+  },
+  {
+    description: 'An SV contained entirely within an intron',
+    text: 'Intronic',
+    value: 'INTRONIC',
+  },
+  {
+    description: 'An inversion entirely spanning the gene',
+    text: 'Inversion Span',
+    value: 'INV_SPAN',
+  },
+  {
+    description: 'An SV which disrupts an untranslated region',
+    text: 'UTR',
+    value: 'UTR',
+  },
+  {
+    description: 'An SV that does not overlap coding sequence',
+    text: 'Intergenic',
+    value: 'INTERGENIC',
+  },
+  {
+    description: 'An SV which disrupts a promoter sequence (within 1kb)',
+    text: 'Promoter',
+    value: 'PROMOTER',
+  },
+]
+
 const ORDERED_VEP_CONSEQUENCES = [
   {
     description: 'A feature ablation whereby the deleted region includes a transcript feature',
@@ -543,114 +639,8 @@ const ORDERED_VEP_CONSEQUENCES = [
     group: VEP_GROUP_FRAMESHIFT,
     so: 'SO:0001589',
   },
-  {
-    description: 'A large deletion',
-    text: 'Deletion',
-    value: 'DEL',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A large duplication',
-    text: 'Duplication',
-    value: 'DUP',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A translocation variant',
-    text: 'Translocation',
-    value: 'BND',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A copy number polymorphism variant',
-    text: 'Copy Number',
-    value: 'CNV',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A Complex Structural Variant',
-    text: 'Complex SV',
-    value: 'CPX',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A reciprocal chromosomal translocation',
-    text: 'Reciprocal Translocation',
-    value: 'CTX',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A large insertion',
-    text: 'Insertion',
-    value: 'INS',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A large inversion',
-    text: 'Inversion',
-    value: 'INV',
-    group: VEP_GROUP_SV,
-  },
-  {
-    description: 'A loss of function effect',
-    text: 'Loss of function',
-    value: 'LOF',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'A loss of function effect via intragenic exonic duplication',
-    text: 'Loss of function via Duplication',
-    value: 'DUP_LOF',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'A copy-gain effect',
-    text: 'Copy Gain',
-    value: 'COPY_GAIN',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'A duplication partially overlapping the gene',
-    text: 'Duplication Partial',
-    value: 'DUP_PARTIAL',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'A multiallelic SV predicted to have a Loss of function, Loss of function via Duplication, Copy Gain, or Duplication Partial effect',
-    text: 'Multiallelic SV',
-    value: 'MSV_EXON_OVR',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'An SV contained entirely within an intron',
-    text: 'Intronic',
-    value: 'INTRONIC',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'An inversion entirely spanning the gene',
-    text: 'Inversion Span',
-    value: 'INV_SPAN',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'An SV which disrupts an untranslated region',
-    text: 'UTR',
-    value: 'UTR',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'An SV that does not overlap coding sequence',
-    text: 'Intergenic',
-    value: 'INTERGENIC',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
-  {
-    description: 'An SV which disrupts a promoter sequence (within 1kb)',
-    text: 'Promoter',
-    value: 'PROMOTER',
-    group: VEP_GROUP_SV_CONSEQUENCES,
-  },
+  ...VEP_SV_TYPES.map(v => ({ ...v, group: VEP_GROUP_SV })),
+  ...VEP_SV_CONSEQUENCES.map(v => ({ ...v, group: VEP_GROUP_SV_CONSEQUENCES })),
   {
     description: 'A sequence variant where at least one base of the terminator codon (stop) is changed, resulting in an elongated transcript',
     text: 'Stop lost',
@@ -861,29 +851,31 @@ export const VEP_CONSEQUENCE_ORDER_LOOKUP = ORDERED_VEP_CONSEQUENCES.reduce((acc
   ({ ...acc, [consequence.value]: i }),
 {})
 
-export const SVTYPE_TEXT_MAPPING = ORDERED_VEP_CONSEQUENCES.reduce((acc, consequence) =>
-  ((consequence.group && consequence.group === VEP_GROUP_SV) ? { ...acc, [consequence.value]: consequence.text } : acc),
-{})
+export const SVTYPE_LOOKUP = VEP_SV_TYPES.reduce((acc, { value, text }) => ({ ...acc, [value]: text }), {})
 
-export const CPX_SVTYPE_DETAILS = {
-  CPX_INS_iDEL: 'Insertion with deletion at insertion site',
-  CPX_INVdel: 'Complex inversion with 3\' flanking deletion',
-  CPX_INVdup: 'Complex inversion with 3\' flanking duplication',
-  CPX_dDUP: 'Dispersed duplication',
-  CPX_dDUP_iDEL: 'Dispersed duplication with deletion at insertion site',
-  CPX_delINV: 'Complex inversion with 5\' flanking deletion',
-  CPX_delINVdel: 'Complex inversion with 5\' and 3\' flanking deletions',
-  CPX_delINVdup: 'Complex inversion with 5\' flanking deletion and 3\' flanking duplication',
-  CPX_dupINV: 'Complex inversion with 5\' flanking duplication',
-  CPX_dupINVdel: 'Complex inversion with 5\' flanking duplication and 3\' flanking deletion',
-  CPX_dupINVdup: 'Complex inversion with 5\' and 3\' flanking duplications',
-  CPX_piDUP_FR: 'Palindromic inverted tandem duplication, forward-reverse orientation',
-  CPX_piDUP_RF: 'Palindromic inverted tandem duplication, reverse-forward orientation',
-  INS_ME: 'Mobile element',
-  'INS_ME:ALU': 'Alu element insertion',
-  'INS_ME:LINE1': 'LINE1 element insertion',
-  'INS_ME:SVA': 'SVA element insertion',
-  'INS_ME:UNK': 'Unspecified origin insertion',
+export const SVTYPE_DETAILS = {
+  CPX: {
+    INS_iDEL: 'Insertion with deletion at insertion site',
+    INVdel: 'Complex inversion with 3\' flanking deletion',
+    INVdup: 'Complex inversion with 3\' flanking duplication',
+    dDUP: 'Dispersed duplication',
+    dDUP_iDEL: 'Dispersed duplication with deletion at insertion site',
+    delINV: 'Complex inversion with 5\' flanking deletion',
+    delINVdel: 'Complex inversion with 5\' and 3\' flanking deletions',
+    delINVdup: 'Complex inversion with 5\' flanking deletion and 3\' flanking duplication',
+    dupINV: 'Complex inversion with 5\' flanking duplication',
+    dupINVdel: 'Complex inversion with 5\' flanking duplication and 3\' flanking deletion',
+    dupINVdup: 'Complex inversion with 5\' and 3\' flanking duplications',
+    piDUP_FR: 'Palindromic inverted tandem duplication, forward-reverse orientation',
+    piDUP_RF: 'Palindromic inverted tandem duplication, reverse-forward orientation',
+  },
+  INS: {
+    ME: 'Mobile element',
+    'ME:ALU': 'Alu element insertion',
+    'ME:LINE1': 'LINE1 element insertion',
+    'ME:SVA': 'SVA element insertion',
+    'ME:UNK': 'Unspecified origin insertion',
+  },
 }
 
 export const SHOW_ALL = 'ALL'


### PR DESCRIPTION
Change the SV_TYPE (e.g. BND) displays to descriptive ones (e.g. Translation).  Show the SV_TYPE details if they exist in the hove-over messages.
Also, replace X/- notation with ref/alt.