### PR TITLE
fix: Fixed welcome email URL for first time users setting their password

### DIFF
--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -37,7 +37,7 @@ def send_welcome_email(user, referrer):
         )
         setup_message += ' Once you are registered in AnVIL, you will be able to access seqr at {}'.format(BASE_URL)
     else:
-        setup_message = 'Please click this link to set up your account:\n    {}users/set_password/{}'.format(
+        setup_message = 'Please click this link to set up your account:\n    {}login/set_password/{}'.format(
             BASE_URL, user.password)
 
     email_content = """

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -255,7 +255,7 @@ class LocalUsersAPITest(AuthenticationTestCase, UsersAPITest):
     fixtures = ['users', '1kg_project']
     COLLABORATOR_NAMES = {'test_user_manager', 'test_user_collaborator'}
     LOCAL_COLLABORATOR_NAMES = COLLABORATOR_NAMES
-    EMAIL_SETUP_MESSAGE = 'Please click this link to set up your account:\n    /users/set_password/{password_token}'
+    EMAIL_SETUP_MESSAGE = 'Please click this link to set up your account:\n    /login/set_password/{password_token}'
 
     @mock.patch('django.contrib.auth.models.send_mail')
     def _test_forgot_password(self, url, mock_send_mail): # pylint: disable=arguments-differ


### PR DESCRIPTION
Fix associated to change [b32a8fd4f8a52be14f0c3d17289eb631f1381b0e](https://github.com/broadinstitute/seqr/commit/b32a8fd4f8a52be14f0c3d17289eb631f1381b0e)

(cherry picked from commit 8b8616a429bfc1a944ecae4060add61bad95a195)
