### PR TITLE
Ensure no missing samples in the VCF

### DIFF
--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -63,26 +63,3 @@ def _google_bucket_file_iter(gs_path, byte_range=None, raw_content=False, user=N
         if not raw_content:
             line = line.decode('utf-8')
         yield line
-
-
-def get_vcf_filename(vcf_path):
-    if vcf_path.endswith('.vcf') or vcf_path.endswith('.vcf.gz') or vcf_path.endswith('.vcf.bgz'):
-        return vcf_path
-    process = subprocess.Popen('gsutil ls ' + vcf_path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
-    if process.wait() != 0:
-        return None
-    for line in process.stdout:
-        file = line.decode('utf-8').strip()
-        if file.endswith('.vcf') or file.endswith('.vcf.gz') or file.endswith('.vcf.bgz'):
-            return file
-    return None
-
-
-def get_vcf_samples(vcf_path):
-    vcf_filename = get_vcf_filename(vcf_path)
-    if not vcf_filename:
-        return {}
-    for line in file_iter(vcf_filename, byte_range=(0, 65536)):
-        if line.startswith('#CHROM'):
-            return set(line.rstrip().split('\tFORMAT\t', 2)[1].split('\t') if line.endswith('\n') else [])
-    return {}

--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -64,3 +64,25 @@ def _google_bucket_file_iter(gs_path, byte_range=None, raw_content=False, user=N
             line = line.decode('utf-8')
         yield line
 
+
+def get_vcf_filename(vcf_path):
+    if vcf_path.endswith('.vcf') or vcf_path.endswith('.vcf.gz') or vcf_path.endswith('.vcf.bgz'):
+        return vcf_path
+    process = subprocess.Popen('gsutil ls ' + vcf_path, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+    if process.wait() != 0:
+        return None
+    for line in process.stdout:
+        file = line.decode('utf-8').strip()
+        if file.endswith('.vcf') or file.endswith('.vcf.gz') or file.endswith('.vcf.bgz'):
+            return file
+    return None
+
+
+def get_vcf_samples(vcf_path):
+    vcf_filename = get_vcf_filename(vcf_path)
+    if not vcf_filename:
+        return {}
+    for line in file_iter(vcf_filename, byte_range=(0, 65536)):
+        if line.startswith('#CHROM'):
+            return set(line.rstrip().split('\tFORMAT\t', 2)[1].split('\t') if line.endswith('\n') else [])
+    return {}

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -19,7 +19,7 @@ from seqr.views.utils.terra_api_utils import add_service_account, has_service_ac
 from seqr.views.utils.pedigree_info_utils import parse_pedigree_table
 from seqr.views.utils.individual_utils import add_or_update_individuals_and_families
 from seqr.utils.communication_utils import send_html_email
-from seqr.utils.file_utils import does_file_exist, get_vcf_samples
+from seqr.utils.file_utils import does_file_exist, file_iter
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.views.utils.permissions_utils import is_anvil_authenticated, check_workspace_perm, login_and_policies_required
 from settings import BASE_URL, GOOGLE_LOGIN_REQUIRED_URL, POLICY_REQUIRED_URL, API_POLICY_REQUIRED_URL
@@ -28,12 +28,26 @@ logger = SeqrLogger(__name__)
 
 anvil_auth_required = user_passes_test(is_anvil_authenticated, login_url=GOOGLE_LOGIN_REQUIRED_URL)
 
+BLOCK_SIZE = 65536
+
+
+def get_vcf_samples(vcf_filename):
+    byte_range = None if vcf_filename.endswith('.vcf') else (0, BLOCK_SIZE)
+    for line in file_iter(vcf_filename, byte_range=byte_range):
+        if line[0] != '#':
+            break
+        if line.startswith('#CHROM'):
+            return set(line.rstrip().split('FORMAT\t', 2)[1].split('\t') if line.endswith('\n') else [])
+    return {}
+
+
 def anvil_auth_and_policies_required(wrapped_func=None, policy_url=API_POLICY_REQUIRED_URL):
     def decorator(view_func):
         return login_and_policies_required(anvil_auth_required(view_func), login_url=GOOGLE_LOGIN_REQUIRED_URL, policy_url=policy_url)
     if wrapped_func:
         return decorator(wrapped_func)
     return decorator
+
 
 @anvil_auth_and_policies_required(policy_url=POLICY_REQUIRED_URL)
 def anvil_workspace_page(request, namespace, name):
@@ -94,11 +108,14 @@ def create_project_from_workspace(request, namespace, name):
     # Add the seqr service account to the corresponding AnVIL workspace
     added_account_to_workspace = add_service_account(request.user, namespace, name)
     if added_account_to_workspace:
-        _wait_for_service_account_access(request.user,namespace, name)
+        _wait_for_service_account_access(request.user, namespace, name)
 
     # Validate the data path
     bucket_name = workspace_meta['workspace']['bucketName']
     data_path = 'gs://{bucket}/{path}'.format(bucket=bucket_name.rstrip('/'), path=request_json['dataPath'].lstrip('/'))
+    if not (data_path.endswith('.vcf') or data_path.endswith('.vcf.gz') or data_path.endswith('.vcf.bgz')):
+        error = 'The data file must have a postfix of ".vcf", ".vcf.gz", or ".vcf.bgz".'
+        return create_json_response({'error': error}, status=400, reason=error)
     if not does_file_exist(data_path, user=request.user):
         error = 'Data file or path {} is not found.'.format(request_json['dataPath'])
         return create_json_response({'error': error}, status=400, reason=error)
@@ -112,10 +129,14 @@ def create_project_from_workspace(request, namespace, name):
 
     # Validate the VCF to see if it contains all the required samples
     samples = get_vcf_samples(data_path)
+    if not samples:
+        return create_json_response(
+            {'error': 'Bad VCF file or no sample found in the data file.'}, status=400)
+
     missing_samples = [record['individualId'] for record in pedigree_records if record['individualId'] not in samples]
     if missing_samples:
         return create_json_response(
-            {'errors': 'There are missing samples in the data: {}'.format(', '.join(missing_samples))}, status=400)
+            {'error': 'The following samples are included in the pedigree file but are missing from the VCF: {}'.format(', '.join(missing_samples))}, status=400)
 
     # Create a new Project in seqr
     project_args = {

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -37,7 +37,8 @@ def get_vcf_samples(vcf_filename):
         if line[0] != '#':
             break
         if line.startswith('#CHROM'):
-            return set(line.rstrip().split('FORMAT\t', 2)[1].split('\t'))
+            header = line.rstrip().split('FORMAT\t', 2)
+            return set(header[1].split('\t')) if len(header) == 2 else {}
     return {}
 
 

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -37,7 +37,7 @@ def get_vcf_samples(vcf_filename):
         if line[0] != '#':
             break
         if line.startswith('#CHROM'):
-            return set(line.rstrip().split('FORMAT\t', 2)[1].split('\t') if line.endswith('\n') else [])
+            return set(line.rstrip().split('FORMAT\t', 2)[1].split('\t'))
     return {}
 
 
@@ -114,7 +114,7 @@ def create_project_from_workspace(request, namespace, name):
     bucket_name = workspace_meta['workspace']['bucketName']
     data_path = 'gs://{bucket}/{path}'.format(bucket=bucket_name.rstrip('/'), path=request_json['dataPath'].lstrip('/'))
     if not (data_path.endswith('.vcf') or data_path.endswith('.vcf.gz') or data_path.endswith('.vcf.bgz')):
-        error = 'The data file must have a postfix of ".vcf", ".vcf.gz", or ".vcf.bgz".'
+        error = 'Invalid VCF file format - file path must end with .vcf, .vcf.gz, or .vcf.bgz'
         return create_json_response({'error': error}, status=400, reason=error)
     if not does_file_exist(data_path, user=request.user):
         error = 'Data file or path {} is not found.'.format(request_json['dataPath'])
@@ -131,7 +131,7 @@ def create_project_from_workspace(request, namespace, name):
     samples = get_vcf_samples(data_path)
     if not samples:
         return create_json_response(
-            {'error': 'Bad VCF file or no sample found in the data file.'}, status=400)
+            {'error': 'No samples found in the provided VCF. This may be due to a malformed file'}, status=400)
 
     missing_samples = [record['individualId'] for record in pedigree_records if record['individualId'] not in samples]
     if missing_samples:

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -1,7 +1,6 @@
 """APIs for management of projects related to AnVIL workspaces."""
 import json
 import time
-import subprocess
 
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.models import User

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -152,13 +152,13 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         response = self.client.post(url, content_type='application/json',
                                     data=json.dumps(REQUEST_BODY_BAD_DATA_PATH))
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['error'], 'The data file must have a postfix of ".vcf", ".vcf.gz", or ".vcf.bgz".')
+        self.assertEqual(response.json()['error'], 'Invalid VCF file format - file path must end with .vcf, .vcf.gz, or .vcf.bgz')
 
         mock_file_exist.return_value = True
         mock_file_iter.return_value = ['##fileformat=VCFv4.2\n', '#CHROM	POS	ID	REF	ALT	QUAL']  # incomplete header line
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['error'], 'Bad VCF file or no sample found in the data file.')
+        self.assertEqual(response.json()['error'], 'No samples found in the provided VCF. This may be due to a malformed file')
 
         # Test valid operation
         mock_sleep.reset_mock()

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -86,7 +86,8 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
     @mock.patch('seqr.views.apis.anvil_workspace_api.add_service_account')
     @mock.patch('seqr.utils.communication_utils.EmailMultiAlternatives')
     @mock.patch('seqr.views.apis.anvil_workspace_api.does_file_exist')
-    def test_create_project_from_workspace(self, mock_file_exist, mock_email, mock_add_service_account,
+    @mock.patch('seqr.views.apis.anvil_workspace_api.get_vcf_samples')
+    def test_create_project_from_workspace(self, mock_samples, mock_file_exist, mock_email, mock_add_service_account,
                                            mock_has_service_account, mock_load_file, mock_api_logger, mock_sleep,
                                            mock_utils_logger):
         # Requesting to load data from a workspace without an existing project
@@ -151,6 +152,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         mock_has_service_account.reset_mock()
         mock_add_service_account.return_value = False
         mock_file_exist.return_value = True
+        mock_samples.return_value = ['NA19675', 'NA19678', 'HG00735']
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
         self.assertEqual(response.status_code, 200)
         project = Project.objects.get(workspace_namespace=TEST_WORKSPACE_NAMESPACE, workspace_name=TEST_NO_PROJECT_WORKSPACE_NAME)

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -164,7 +164,8 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         mock_sleep.reset_mock()
         mock_has_service_account.reset_mock()
         mock_add_service_account.return_value = False
-        mock_file_iter.return_value = ['##fileformat=VCFv4.2\n', '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA19675	NA19678	HG00735\n']
+        mock_file_iter.return_value = ['##fileformat=VCFv4.2\n', '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA19675	NA19678	HG00735\n',
+                                       'chr1	1000	test\n']
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
         self.assertEqual(response.status_code, 200)
         project = Project.objects.get(workspace_namespace=TEST_WORKSPACE_NAMESPACE, workspace_name=TEST_NO_PROJECT_WORKSPACE_NAME)

--- a/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
+++ b/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
@@ -81,7 +81,7 @@ const SAMPLE_TYPE_FIELD = {
 const DATA_BUCK_FIELD = {
   name: 'dataPath',
   label: 'Path to the Joint Called VCF',
-  labelHelp: 'File path for a joint called VCF available in the AnVIL workspace\'s "Files" folder.',
+  labelHelp: 'File path for a joint called VCF available in the workspace "Files".',
   placeholder: '/path-under-Files-of-the-workspace',
   validate: validators.required,
 }

--- a/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
+++ b/ui/pages/AnvilWorkspace/components/LoadWorkspaceDataForm.jsx
@@ -81,7 +81,7 @@ const SAMPLE_TYPE_FIELD = {
 const DATA_BUCK_FIELD = {
   name: 'dataPath',
   label: 'Path to the Joint Called VCF',
-  labelHelp: 'File path for a joint called VCF available in the workspace "Files". If the VCF is split, provide the path to the directory containing the split VCF',
+  labelHelp: 'File path for a joint called VCF available in the AnVIL workspace\'s "Files" folder.',
   placeholder: '/path-under-Files-of-the-workspace',
   validate: validators.required,
 }


### PR DESCRIPTION
I finally come up with a solution without using any 3rd-party tools. Just load the VCF header line and retrieve the sample IDs in the line, and then compare the individual IDs to those sample IDs to find out if there are any missing IDs.
The delay is around 4 seconds which includes two almost equal parts: one is to get the VCF file name, another is to get the samples from the VCF file. If the user provides a VCF file name directly in the `Path to the Joint Called VCF` field, then the delay will be cut in half.