### PR TITLE
Project context cleanup

### DIFF
--- a/seqr/models.py
+++ b/seqr/models.py
@@ -789,6 +789,14 @@ class VariantFunctionalData(ModelWithGUID):
          )),
     )
 
+    FUNCTIONAL_DATA_TAG_TYPES = [{
+        'category': category,
+        'name': name,
+        'metadataTitle': json.loads(tag_json).get('metadata_title', 'Notes'),
+        'color': json.loads(tag_json)['color'],
+        'description': json.loads(tag_json).get('description'),
+    } for category, tags in FUNCTIONAL_DATA_CHOICES for name, tag_json in tags]
+
     saved_variants = models.ManyToManyField('SavedVariant')
     functional_data_tag = models.TextField(choices=FUNCTIONAL_DATA_CHOICES)
     metadata = models.TextField(null=True)

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -3,18 +3,17 @@ APIs for updating project metadata, as well as creating or deleting projects
 """
 
 import json
-from django.db.models import Count, Q
+from django.db.models import Count
 from django.utils import timezone
 
 from matchmaker.models import MatchmakerSubmission
-from seqr.models import Project, Family, Individual, Sample, IgvSample, VariantTag, VariantNote, VariantTagType, \
-    SavedVariant, ProjectCategory
+from seqr.models import Project, Family, Individual, Sample, IgvSample, VariantTag, VariantNote, SavedVariant, \
+    ProjectCategory
 from seqr.utils.gene_utils import get_genes
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.json_to_orm_utils import update_project_from_json, create_model_from_json
 from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_for_saved_variants, \
-    get_json_for_variant_functional_data_tag_types,  get_json_for_project_collaborator_list, \
-    _get_json_for_models, get_json_for_matchmaker_submissions
+    get_json_for_project_collaborator_list, get_json_for_matchmaker_submissions
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
     check_user_created_object_permissions, pm_required, user_is_analyst, login_and_policies_required
 from seqr.views.utils.project_context_utils import get_projects_child_entities

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -7,18 +7,17 @@ from django.db.models import Count, Q
 from django.utils import timezone
 
 from matchmaker.models import MatchmakerSubmission
-from seqr.models import Project, Family, Individual, Sample, IgvSample, VariantTag, VariantFunctionalData, \
-    VariantNote, VariantTagType, SavedVariant, AnalysisGroup, LocusList, ProjectCategory
+from seqr.models import Project, Family, Individual, Sample, IgvSample, VariantTag, VariantNote, VariantTagType, \
+    SavedVariant, ProjectCategory
 from seqr.utils.gene_utils import get_genes
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.json_to_orm_utils import update_project_from_json, create_model_from_json
-from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_for_samples, _get_json_for_families, \
-    _get_json_for_individuals, get_json_for_saved_variants, get_json_for_analysis_groups, \
-    get_json_for_variant_functional_data_tag_types, get_json_for_locus_lists, \
-    get_json_for_project_collaborator_list, _get_json_for_models, get_json_for_matchmaker_submissions
+from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_for_saved_variants, \
+    get_json_for_variant_functional_data_tag_types,  get_json_for_project_collaborator_list, \
+    _get_json_for_models, get_json_for_matchmaker_submissions
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
-    check_user_created_object_permissions, pm_required, user_is_analyst, has_case_review_permissions, \
-    login_and_policies_required
+    check_user_created_object_permissions, pm_required, user_is_analyst, login_and_policies_required
+from seqr.views.utils.project_context_utils import get_projects_child_entities
 from settings import ANALYST_PROJECT_CATEGORY
 
 
@@ -136,7 +135,11 @@ def project_page_data(request, project_guid):
     update_project_from_json(project, {'last_accessed_date': timezone.now()}, request.user)
 
     is_analyst = user_is_analyst(request.user)
-    response = _get_project_child_entities(project, request.user, is_analyst)
+    response = get_projects_child_entities([project], request.user, is_analyst=is_analyst)
+
+    for i in response['individualsByGuid'].values():
+        i['mmeSubmissionGuid'] = None
+    response['mmeSubmissionsByGuid'] = _retrieve_mme_submissions(project, response['individualsByGuid'])
 
     project_json = _get_json_for_project(project, request.user, is_analyst=is_analyst)
     project_json['collaborators'] = get_json_for_project_collaborator_list(request.user, project)
@@ -158,107 +161,8 @@ def project_page_data(request, project_guid):
     return create_json_response(response)
 
 
-def _get_project_child_entities(project, user, is_analyst):
-    has_case_review_perm = has_case_review_permissions(project, user)
-
-    families_by_guid = _retrieve_families(project.guid, is_analyst, has_case_review_perm)
-    individuals_by_guid, individual_models = _retrieve_individuals(project.guid, is_analyst, has_case_review_perm)
-    for individual_guid, individual in individuals_by_guid.items():
-        families_by_guid[individual['familyGuid']]['individualGuids'].add(individual_guid)
-    samples_by_guid = _retrieve_samples(
-        project.guid, individuals_by_guid, Sample.objects.filter(individual__in=individual_models))
-    igv_samples_by_guid = _retrieve_samples(
-        project.guid, individuals_by_guid, IgvSample.objects.filter(individual__in=individual_models),
-        sample_guid_key='igvSampleGuids')
-    mme_submissions_by_guid = _retrieve_mme_submissions(individuals_by_guid, individual_models)
-    analysis_groups_by_guid = _retrieve_analysis_groups(project)
-    locus_lists = get_json_for_locus_lists(LocusList.objects.filter(projects__id=project.id), user, is_analyst=is_analyst)
-    locus_lists_by_guid = {locus_list['locusListGuid']: locus_list for locus_list in locus_lists}
-    return {
-        'familiesByGuid': families_by_guid,
-        'individualsByGuid': individuals_by_guid,
-        'samplesByGuid': samples_by_guid,
-        'igvSamplesByGuid': igv_samples_by_guid,
-        'locusListsByGuid': locus_lists_by_guid,
-        'analysisGroupsByGuid': analysis_groups_by_guid,
-        'mmeSubmissionsByGuid': mme_submissions_by_guid,
-    }
-
-
-def _retrieve_families(project_guid, is_analyst, has_case_review_perm):
-    """Retrieves family-level metadata for the given project.
-
-    Args:
-        project_guid (string): project_guid
-        user (Model): for checking permissions to view certain fields
-    Returns:
-        dictionary: families_by_guid
-    """
-    family_models = Family.objects.filter(project__guid=project_guid)
-
-    families = _get_json_for_families(
-        family_models, project_guid=project_guid, is_analyst=is_analyst, has_case_review_perm=has_case_review_perm)
-
-    families_by_guid = {}
-    for family in families:
-        family_guid = family['familyGuid']
-        family['individualGuids'] = set()
-        families_by_guid[family_guid] = family
-
-    return families_by_guid
-
-
-def _retrieve_individuals(project_guid, is_analyst, has_case_review_perm):
-    """Retrieves individual-level metadata for the given project.
-
-    Args:
-        project_guid (string): project_guid
-    Returns:
-        dictionary: individuals_by_guid
-    """
-
-    individual_models = Individual.objects.filter(family__project__guid=project_guid)
-
-    individuals = _get_json_for_individuals(
-        individual_models, project_guid=project_guid, add_hpo_details=True, is_analyst=is_analyst,
-        has_case_review_perm=has_case_review_perm)
-
-    individuals_by_guid = {}
-    for i in individuals:
-        i['sampleGuids'] = set()
-        i['igvSampleGuids'] = set()
-        i['mmeSubmissionGuid'] = None
-        individual_guid = i['individualGuid']
-        individuals_by_guid[individual_guid] = i
-
-    return individuals_by_guid, individual_models
-
-
-def _retrieve_samples(project_guid, individuals_by_guid, sample_models, sample_guid_key='sampleGuids'):
-    """Retrieves sample metadata for the given project.
-
-        Args:
-            project_guid (string): project_guid
-            individuals_by_guid (dict): maps each individual_guid to a dictionary with individual info.
-                This method adds a "sampleGuids" list to each of these dictionaries.
-        Returns:
-            2-tuple with dictionaries: (samples_by_guid, sample_batches_by_guid)
-        """
-    samples = get_json_for_samples(sample_models, project_guid=project_guid)
-
-    samples_by_guid = {}
-    for s in samples:
-        sample_guid = s['sampleGuid']
-        samples_by_guid[sample_guid] = s
-
-        individual_guid = s['individualGuid']
-        individuals_by_guid[individual_guid][sample_guid_key].add(sample_guid)
-
-    return samples_by_guid
-
-
-def _retrieve_mme_submissions(individuals_by_guid, individual_models):
-    models = MatchmakerSubmission.objects.filter(individual__in=individual_models)
+def _retrieve_mme_submissions(project, individuals_by_guid):
+    models = MatchmakerSubmission.objects.filter(individual__family__project=project)
 
     submissions = get_json_for_matchmaker_submissions(models, additional_model_fields=['genomic_features'])
 
@@ -273,12 +177,6 @@ def _retrieve_mme_submissions(individuals_by_guid, individual_models):
         individuals_by_guid[individual_guid]['mmeSubmissionGuid'] = guid
 
     return submissions_by_guid
-
-
-def _retrieve_analysis_groups(project):
-    group_models = AnalysisGroup.objects.filter(project=project)
-    groups = get_json_for_analysis_groups(group_models, project_guid=project.guid)
-    return {group['analysisGroupGuid']: group for group in groups}
 
 
 def _get_json_for_variant_tag_types(project):

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -128,6 +128,17 @@ class ProjectAPITest(object):
         self.assertSetEqual(
             {tag['variantGuid'] for tag in discovery_tags},
             {'SV0000001_2103343353_r0390_100', 'SV0000002_1248367227_r0390_100'})
+        note_tag_type = response_json['projectsByGuid'][PROJECT_GUID]['variantTagTypes'][-1]
+        self.assertDictEqual(note_tag_type, {
+            'variantTagTypeGuid': 'notes',
+            'name': 'Has Notes',
+            'category': 'Notes',
+            'description': '',
+            'color': 'grey',
+            'order': 100,
+            'numTags': 1,
+            'numTagsPerFamily': {'F000002_2': 1},
+        })
         self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953', 'ENSG00000186092'})
         family_fields = {'individualGuids'}
         family_fields.update(FAMILY_FIELDS)

--- a/seqr/views/apis/summary_data_api.py
+++ b/seqr/views/apis/summary_data_api.py
@@ -4,11 +4,11 @@ from matchmaker.matchmaker_utils import get_mme_genes_phenotypes_for_submissions
     parse_mme_gene_variants, get_mme_metrics
 from matchmaker.models import MatchmakerSubmission
 from seqr.views.apis.saved_variant_api import _add_locus_lists
-from seqr.models import Family, LocusList, VariantTagType, SavedVariant, Individual
+from seqr.models import Family, LocusList, VariantTagType, SavedVariant, Individual,VariantFunctionalData
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import _get_json_for_individuals, get_json_for_saved_variants_with_tags, \
-    get_json_for_variant_functional_data_tag_types, get_json_for_projects, _get_json_for_families, \
-    get_json_for_locus_lists, _get_json_for_models, get_json_for_matchmaker_submissions
+    _get_json_for_models, get_json_for_matchmaker_submissions, get_json_for_projects, _get_json_for_families, \
+    get_json_for_locus_lists
 from seqr.views.utils.permissions_utils import analyst_required, user_is_analyst, get_project_guids_user_can_view, \
     login_and_policies_required
 from seqr.views.utils.variant_utils import saved_variant_genes
@@ -97,7 +97,6 @@ def saved_variants_page(request, tag):
     locus_lists_by_guid = _add_locus_lists(list(project_models_by_guid.values()), genes, include_all_lists=True)
 
     projects_json = get_json_for_projects(list(project_models_by_guid.values()), user=request.user, add_project_category_guids_field=False)
-    functional_tag_types = get_json_for_variant_functional_data_tag_types()
 
     variant_tag_types = VariantTagType.objects.filter(Q(project__in=project_models_by_guid.values()) | Q(project__isnull=True))
     prefetch_related_objects(variant_tag_types, 'project')
@@ -111,7 +110,7 @@ def saved_variants_page(request, tag):
         project_json.update({
             'locusListGuids': list(locus_lists_by_guid.keys()),
             'variantTagTypes': sorted(project_variant_tags, key=lambda variant_tag_type: variant_tag_type['order'] or 0),
-            'variantFunctionalTagTypes': functional_tag_types,
+            'variantFunctionalTagTypes': VariantFunctionalData.FUNCTIONAL_DATA_TAG_TYPES,
         })
 
     families_json = _get_json_for_families(list(families), user=request.user, add_individual_guids_field=True)

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -304,8 +304,7 @@ class VariantSearchAPITest(object):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertDictEqual(response_json, {
-            'projectsByGuid': {}, 'familiesByGuid': {}, 'individualsByGuid': {}, 'samplesByGuid': {},
-            'igvSamplesByGuid': {}, 'locusListsByGuid': {}, 'analysisGroupsByGuid': {}, 'variantTagsByGuid': mock.ANY,
+            'locusListsByGuid': {}, 'variantTagsByGuid': mock.ANY,
             'variantNotesByGuid': mock.ANY, 'variantFunctionalDataByGuid': {}, 'genesById': mock.ANY,
             'savedVariantsByGuid': mock.ANY, 'searchedVariants': VARIANTS, 'search': {
                 'search': SEARCH,
@@ -482,10 +481,7 @@ class VariantSearchAPITest(object):
             {'searchHash': 'djd29394hfw2njr2hod2', 'searchParams': {'allProjectFamilies': True, 'search': SEARCH}}))
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
-        self.assertDictEqual(response_json, {
-            'savedSearchesByGuid': mock.ANY, 'projectsByGuid': {}, 'familiesByGuid': {}, 'individualsByGuid': {},
-            'samplesByGuid': {}, 'igvSamplesByGuid': {}, 'locusListsByGuid': {}, 'analysisGroupsByGuid': {},
-        })
+        self.assertDictEqual(response_json, {'savedSearchesByGuid': mock.ANY})
         self.assertEqual(len(response_json['savedSearchesByGuid']), 3)
 
 
@@ -631,7 +627,7 @@ class AnvilVariantSearchAPITest(AnvilAuthenticationTestCase, VariantSearchAPITes
         self.mock_list_workspaces.assert_has_calls(calls)
         self.mock_get_ws_access_level.assert_called_with(self.collaborator_user,
             'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-        self.assertEqual(self.mock_get_ws_access_level.call_count, 11)
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 9)
         self.mock_get_ws_acl.assert_not_called()
 
     def test_query_all_project_families_variants(self, *args):
@@ -640,11 +636,11 @@ class AnvilVariantSearchAPITest(AnvilAuthenticationTestCase, VariantSearchAPITes
 
     def test_search_context(self):
         super(AnvilVariantSearchAPITest, self).test_search_context()
-        assert_no_list_ws_has_al(self, 27)
+        assert_no_list_ws_has_al(self, 21)
 
     def test_query_single_variant(self, *args):
         super(AnvilVariantSearchAPITest, self).test_query_single_variant(*args)
-        assert_no_list_ws_has_al(self, 5)
+        assert_no_list_ws_has_al(self, 4)
 
     def test_saved_search(self):
         super(AnvilVariantSearchAPITest, self).test_saved_search()
@@ -675,11 +671,11 @@ class MixSavedVariantSearchAPITest(MixAuthenticationTestCase, VariantSearchAPITe
 
     def test_search_context(self):
         super(MixSavedVariantSearchAPITest, self).test_search_context()
-        assert_no_list_ws_has_al(self, 20)
+        assert_no_list_ws_has_al(self, 14)
 
     def test_query_single_variant(self, *args):
         super(MixSavedVariantSearchAPITest, self).test_query_single_variant(*args)
-        assert_no_list_ws_has_al(self, 4)
+        assert_no_list_ws_has_al(self, 3)
 
     def test_saved_search(self):
         super(MixSavedVariantSearchAPITest, self).test_saved_search()

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -14,6 +14,13 @@ def get_projects_child_entities(projects, user, is_analyst=None):
     if is_analyst is None:
         is_analyst = user_is_analyst(user)
 
+    response = _fetch_child_entities(projects, project_guid, user, is_analyst, has_case_review_perm)
+
+    _add_tag_types(response['projectsByGuid'], project_guid)
+
+    return response
+
+def _fetch_child_entities(projects, project_guid, user, is_analyst, has_case_review_perm):
     projects_by_guid = {p['projectGuid']: p for p in get_json_for_projects(projects, user)}
 
     family_models = Family.objects.filter(project__in=projects)
@@ -39,77 +46,6 @@ def get_projects_child_entities(projects, user, is_analyst=None):
     locus_lists_by_guid = {
         ll['locusListGuid']: ll for ll in get_json_for_locus_lists(locus_lists_models, user, is_analyst=is_analyst)}
 
-    functional_data_tag_types = get_json_for_variant_functional_data_tag_types()
-
-    variant_tag_types_models = VariantTagType.objects.filter(Q(project__in=projects) | Q(project__isnull=True))
-    variant_tag_types = _get_json_for_models(variant_tag_types_models)
-
-    project_locus_lists = defaultdict(list)
-    project_tag_types = defaultdict(list)
-    if project_guid:
-        project_locus_lists[project_guid] = list(locus_lists_by_guid.keys())
-        project_tag_types[project_guid] = variant_tag_types
-    else:
-        project_id_to_guid = {project.id: project.guid for project in projects}
-        family_id_to_guid = {family.id: family.guid for family in family_models}
-        individual_id_to_guid = {individual.id: individual.guid for individual in individual_models}
-        family_guid_to_project_guid = {}
-        individual_guid_to_project_guid = {}
-        for family in families:
-            project_guid = project_id_to_guid[family.pop('projectId')]
-            family['projectGuid'] = project_guid
-            family_guid_to_project_guid[family['familyGuid']] = project_guid
-        for individual in individuals:
-            family_guid = family_id_to_guid[individual.pop('familyId')]
-            project_guid = family_guid_to_project_guid[family_guid]
-            individual['familyGuid'] = family_guid
-            individual['projectGuid'] = project_guid
-            individual_guid_to_project_guid[individual['individualGuid']] = project_guid
-        for sample in samples:
-            individual_guid = individual_id_to_guid[sample.pop('individualId')]
-            sample['individualGuid'] = individual_guid
-            sample['projectGuid'] = individual_guid_to_project_guid[individual_guid]
-        for sample in igv_samples:
-            individual_guid = individual_id_to_guid[sample.pop('individualId')]
-            sample['individualGuid'] = individual_guid
-            sample['projectGuid'] = individual_guid_to_project_guid[individual_guid]
-        for group in analysis_groups:
-            group['projectGuid'] = project_id_to_guid[group.pop('projectId')]
-
-        prefetch_related_objects(locus_lists_models, 'projects')
-        for locus_list in locus_lists_models:
-            for project in locus_list.projects.all():
-                project_locus_lists[project.guid].append(locus_list.guid)
-
-        prefetch_related_objects(variant_tag_types_models, 'project')
-        variant_tag_types_by_guid = {vtt['variantTagTypeGuid']: vtt for vtt in variant_tag_types}
-        for vtt in variant_tag_types_models:
-            project_guid = vtt.project.guid if vtt.project else None
-            project_tag_types[project_guid].append(variant_tag_types_by_guid[vtt.guid])
-
-    for project_guid, project_json in projects_by_guid.items():
-        project_json.update({
-            'locusListGuids': project_locus_lists[project_guid],
-            'variantTagTypes': project_tag_types[project_guid] + project_tag_types[None],
-            'variantFunctionalTagTypes': functional_data_tag_types,
-        })
-
-    individual_guids_by_family = defaultdict(list)
-    for individual in individuals:
-        individual_guids_by_family[individual['familyGuid']].append(individual['individualGuid'])
-    for family in families:
-         family['individualGuids'] = individual_guids_by_family[family['familyGuid']]
-
-    sample_guids_by_individual = defaultdict(list)
-    for sample in samples:
-        sample_guids_by_individual[sample['individualGuid']].append(sample['sampleGuid'])
-    igv_sample_guids_by_individual = defaultdict(list)
-    for sample in igv_samples:
-        igv_sample_guids_by_individual[sample['individualGuid']].append(sample['sampleGuid'])
-    for individual in individuals:
-        individual['sampleGuids'] = sample_guids_by_individual[individual['individualGuid']]
-        individual['igvSampleGuids'] = igv_sample_guids_by_individual[individual['individualGuid']]
-
     response = {
         'projectsByGuid': projects_by_guid,
         'familiesByGuid': {f['familyGuid']: f for f in families},
@@ -120,4 +56,85 @@ def get_projects_child_entities(projects, user, is_analyst=None):
         'analysisGroupsByGuid': {ag['analysisGroupGuid']: ag for ag in analysis_groups},
     }
 
+    if project_guid:
+        response['projectsByGuid'][project_guid]['locusListGuids'] = list(response['locusListsByGuid'].keys())
+    else:
+        _add_parent_ids(response, projects, family_models, individual_models, locus_lists_models)
+
+    _add_child_ids(response)
+
     return response
+
+def _add_parent_ids(response, projects, family_models, individual_models, locus_lists_models):
+    project_id_to_guid = {project.id: project.guid for project in projects}
+    family_id_to_guid = {family.id: family.guid for family in family_models}
+    individual_id_to_guid = {individual.id: individual.guid for individual in individual_models}
+    family_guid_to_project_guid = {}
+    individual_guid_to_project_guid = {}
+    for family in response['familiesByGuid'].values():
+        project_guid = project_id_to_guid[family.pop('projectId')]
+        family['projectGuid'] = project_guid
+        family_guid_to_project_guid[family['familyGuid']] = project_guid
+    for individual in response['individualsByGuid'].values():
+        family_guid = family_id_to_guid[individual.pop('familyId')]
+        project_guid = family_guid_to_project_guid[family_guid]
+        individual['familyGuid'] = family_guid
+        individual['projectGuid'] = project_guid
+        individual_guid_to_project_guid[individual['individualGuid']] = project_guid
+    for sample in response['samplesByGuid'].values():
+        individual_guid = individual_id_to_guid[sample.pop('individualId')]
+        sample['individualGuid'] = individual_guid
+        sample['projectGuid'] = individual_guid_to_project_guid[individual_guid]
+    for sample in response['igvSamplesByGuid'].values():
+        individual_guid = individual_id_to_guid[sample.pop('individualId')]
+        sample['individualGuid'] = individual_guid
+        sample['projectGuid'] = individual_guid_to_project_guid[individual_guid]
+    for group in response['analysisGroupsByGuid'].values():
+        group['projectGuid'] = project_id_to_guid[group.pop('projectId')]
+
+    for project in response['projectsByGuid'].values():
+        project['locusListGuids'] = []
+    prefetch_related_objects(locus_lists_models, 'projects')
+    for locus_list in locus_lists_models:
+        for project in locus_list.projects.all():
+            response['projectsByGuid'][project.guid]['locusListGuids'].append(locus_list.guid)
+
+def _add_child_ids(response):
+    sample_guids_by_individual = defaultdict(list)
+    for sample in response['samplesByGuid'].values():
+        sample_guids_by_individual[sample['individualGuid']].append(sample['sampleGuid'])
+    igv_sample_guids_by_individual = defaultdict(list)
+    for sample in response['igvSamplesByGuid'].values():
+        igv_sample_guids_by_individual[sample['individualGuid']].append(sample['sampleGuid'])
+
+    individual_guids_by_family = defaultdict(list)
+    for individual in response['individualsByGuid'].values():
+        individual['sampleGuids'] = sample_guids_by_individual[individual['individualGuid']]
+        individual['igvSampleGuids'] = igv_sample_guids_by_individual[individual['individualGuid']]
+        individual_guids_by_family[individual['familyGuid']].append(individual['individualGuid'])
+
+    for family in response['familiesByGuid'].values():
+        family['individualGuids'] = individual_guids_by_family[family['familyGuid']]
+
+
+def _add_tag_types(projects_by_guid, project_guid):
+    functional_data_tag_types = get_json_for_variant_functional_data_tag_types()
+
+    variant_tag_types_models = VariantTagType.objects.filter(Q(project__guid__in=projects_by_guid.keys()) | Q(project__isnull=True))
+    variant_tag_types = _get_json_for_models(variant_tag_types_models)
+
+    project_tag_types = defaultdict(list)
+    if project_guid:
+        project_tag_types[project_guid] = variant_tag_types
+    else:
+        prefetch_related_objects(variant_tag_types_models, 'project')
+        variant_tag_types_by_guid = {vtt['variantTagTypeGuid']: vtt for vtt in variant_tag_types}
+        for vtt in variant_tag_types_models:
+            project_guid = vtt.project.guid if vtt.project else None
+            project_tag_types[project_guid].append(variant_tag_types_by_guid[vtt.guid])
+
+    for project_guid, project_json in projects_by_guid.items():
+        project_json.update({
+            'variantTagTypes': project_tag_types[project_guid] + project_tag_types[None],
+            'variantFunctionalTagTypes': functional_data_tag_types,
+        })

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
 from django.db.models import Q, prefetch_related_objects
 
-from seqr.models import Family, Individual, Sample, IgvSample, AnalysisGroup, LocusList, VariantTagType
-from seqr.views.utils.orm_to_json_utils import _get_json_for_families, _get_json_for_individuals, \
-    get_json_for_analysis_groups, get_json_for_samples, get_json_for_locus_lists, get_json_for_projects, \
-    get_json_for_variant_functional_data_tag_types, _get_json_for_models
+from seqr.models import Family, Individual, Sample, IgvSample, AnalysisGroup, LocusList, VariantTagType,\
+    VariantFunctionalData
+from seqr.views.utils.orm_to_json_utils import _get_json_for_families, _get_json_for_individuals, _get_json_for_models, \
+    get_json_for_analysis_groups, get_json_for_samples, get_json_for_locus_lists, get_json_for_projects
 from seqr.views.utils.permissions_utils import has_case_review_permissions, user_is_analyst
 
 
@@ -118,8 +118,6 @@ def _add_child_ids(response):
 
 
 def _add_tag_types(projects_by_guid, project_guid):
-    functional_data_tag_types = get_json_for_variant_functional_data_tag_types()
-
     variant_tag_types_models = VariantTagType.objects.filter(Q(project__guid__in=projects_by_guid.keys()) | Q(project__isnull=True))
     variant_tag_types = _get_json_for_models(variant_tag_types_models)
 
@@ -136,5 +134,5 @@ def _add_tag_types(projects_by_guid, project_guid):
     for project_guid, project_json in projects_by_guid.items():
         project_json.update({
             'variantTagTypes': project_tag_types[project_guid] + project_tag_types[None],
-            'variantFunctionalTagTypes': functional_data_tag_types,
+            'variantFunctionalTagTypes': VariantFunctionalData.FUNCTIONAL_DATA_TAG_TYPES,
         })

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -1,0 +1,95 @@
+from collections import defaultdict
+from django.db.models import prefetch_related_objects
+
+from seqr.models import Family, Individual, Sample, IgvSample, AnalysisGroup, LocusList
+from seqr.views.utils.orm_to_json_utils import _get_json_for_families, _get_json_for_individuals, \
+    get_json_for_analysis_groups, get_json_for_samples, get_json_for_locus_lists
+from seqr.views.utils.permissions_utils import has_case_review_permissions, user_is_analyst
+
+
+def get_projects_child_entities(projects, user, is_analyst=None):
+    project_guid = projects[0].guid if len(projects) == 1 else None
+    has_case_review_perm = has_case_review_permissions(projects[0], user)
+    if is_analyst is None:
+        is_analyst = user_is_analyst(user)
+
+    family_models = Family.objects.filter(project__in=projects)
+    families = _get_json_for_families(
+        family_models, user, project_guid=project_guid, skip_nested=True,
+        is_analyst=is_analyst, has_case_review_perm=has_case_review_perm)
+
+    individual_models = Individual.objects.filter(family__in=family_models)
+    individuals = _get_json_for_individuals(
+        individual_models, user=user, project_guid=project_guid, add_hpo_details=True, skip_nested=True,
+        is_analyst=is_analyst, has_case_review_perm=has_case_review_perm)
+
+    sample_models = Sample.objects.filter(individual__in=individual_models)
+    samples = get_json_for_samples(sample_models, project_guid=project_guid, skip_nested=True)
+
+    igv_sample_models = IgvSample.objects.filter(individual__in=individual_models)
+    igv_samples = get_json_for_samples(igv_sample_models, project_guid=project_guid, skip_nested=True)
+
+    analysis_group_models = AnalysisGroup.objects.filter(project__in=projects)
+    analysis_groups = get_json_for_analysis_groups(analysis_group_models, project_guid=project_guid, skip_nested=True)
+
+    locus_lists_models = LocusList.objects.filter(projects__in=projects)
+    locus_lists_by_guid = {
+        ll['locusListGuid']: ll for ll in get_json_for_locus_lists(locus_lists_models, user, is_analyst=is_analyst)}
+    if not project_guid:
+        prefetch_related_objects(locus_lists_models, 'projects')
+        for locus_list in locus_lists_models:
+            locus_lists_by_guid[locus_list.guid]['projectGuids'] = [p.guid for p in locus_list.projects.all()]
+
+    if not project_guid:
+        project_id_to_guid = {project.id: project.guid for project in projects}
+        family_id_to_guid = {family.id: family.guid for family in family_models}
+        individual_id_to_guid = {individual.id: individual.guid for individual in individual_models}
+        family_guid_to_project_guid = {}
+        individual_guid_to_project_guid = {}
+        for family in families:
+            project_guid = project_id_to_guid[family.pop('projectId')]
+            family['projectGuid'] = project_guid
+            family_guid_to_project_guid[family['familyGuid']] = project_guid
+        for individual in individuals:
+            family_guid = family_id_to_guid[individual.pop('familyId')]
+            project_guid = family_guid_to_project_guid[family_guid]
+            individual['familyGuid'] = family_guid
+            individual['projectGuid'] = project_guid
+            individual_guid_to_project_guid[individual['individualGuid']] = project_guid
+        for sample in samples:
+            individual_guid = individual_id_to_guid[sample.pop('individualId')]
+            sample['individualGuid'] = individual_guid
+            sample['projectGuid'] = individual_guid_to_project_guid[individual_guid]
+        for sample in igv_samples:
+            individual_guid = individual_id_to_guid[sample.pop('individualId')]
+            sample['individualGuid'] = individual_guid
+            sample['projectGuid'] = individual_guid_to_project_guid[individual_guid]
+        for group in analysis_groups:
+            group['projectGuid'] = project_id_to_guid[group.pop('projectId')]
+
+    individual_guids_by_family = defaultdict(list)
+    for individual in individuals:
+        individual_guids_by_family[individual['familyGuid']].append(individual['individualGuid'])
+    for family in families:
+         family['individualGuids'] = individual_guids_by_family[family['familyGuid']]
+
+    sample_guids_by_individual = defaultdict(list)
+    for sample in samples:
+        sample_guids_by_individual[sample['individualGuid']].append(sample['sampleGuid'])
+    igv_sample_guids_by_individual = defaultdict(list)
+    for sample in igv_samples:
+        igv_sample_guids_by_individual[sample['individualGuid']].append(sample['sampleGuid'])
+    for individual in individuals:
+        individual['sampleGuids'] = sample_guids_by_individual[individual['individualGuid']]
+        individual['igvSampleGuids'] = igv_sample_guids_by_individual[individual['individualGuid']]
+
+    response = {
+        'familiesByGuid': {f['familyGuid']: f for f in families},
+        'individualsByGuid': {i['individualGuid']: i for i in individuals},
+        'samplesByGuid': {s['sampleGuid']: s for s in samples},
+        'igvSamplesByGuid': {s['sampleGuid']: s for s in igv_samples},
+        'locusListsByGuid': locus_lists_by_guid,
+        'analysisGroupsByGuid': {ag['analysisGroupGuid']: ag for ag in analysis_groups},
+    }
+
+    return response

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
-from django.db.models import prefetch_related_objects
+from django.db.models import Q, prefetch_related_objects
 
-from seqr.models import Family, Individual, Sample, IgvSample, AnalysisGroup, LocusList
+from seqr.models import Family, Individual, Sample, IgvSample, AnalysisGroup, LocusList, VariantTagType
 from seqr.views.utils.orm_to_json_utils import _get_json_for_families, _get_json_for_individuals, \
-    get_json_for_analysis_groups, get_json_for_samples, get_json_for_locus_lists
+    get_json_for_analysis_groups, get_json_for_samples, get_json_for_locus_lists, get_json_for_projects, \
+    get_json_for_variant_functional_data_tag_types, _get_json_for_models
 from seqr.views.utils.permissions_utils import has_case_review_permissions, user_is_analyst
 
 
@@ -12,6 +13,8 @@ def get_projects_child_entities(projects, user, is_analyst=None):
     has_case_review_perm = has_case_review_permissions(projects[0], user)
     if is_analyst is None:
         is_analyst = user_is_analyst(user)
+
+    projects_by_guid = {p['projectGuid']: p for p in get_json_for_projects(projects, user)}
 
     family_models = Family.objects.filter(project__in=projects)
     families = _get_json_for_families(
@@ -35,12 +38,18 @@ def get_projects_child_entities(projects, user, is_analyst=None):
     locus_lists_models = LocusList.objects.filter(projects__in=projects)
     locus_lists_by_guid = {
         ll['locusListGuid']: ll for ll in get_json_for_locus_lists(locus_lists_models, user, is_analyst=is_analyst)}
-    if not project_guid:
-        prefetch_related_objects(locus_lists_models, 'projects')
-        for locus_list in locus_lists_models:
-            locus_lists_by_guid[locus_list.guid]['projectGuids'] = [p.guid for p in locus_list.projects.all()]
 
-    if not project_guid:
+    functional_data_tag_types = get_json_for_variant_functional_data_tag_types()
+
+    variant_tag_types_models = VariantTagType.objects.filter(Q(project__in=projects) | Q(project__isnull=True))
+    variant_tag_types = _get_json_for_models(variant_tag_types_models)
+
+    project_locus_lists = defaultdict(list)
+    project_tag_types = defaultdict(list)
+    if project_guid:
+        project_locus_lists[project_guid] = list(locus_lists_by_guid.keys())
+        project_tag_types[project_guid] = variant_tag_types
+    else:
         project_id_to_guid = {project.id: project.guid for project in projects}
         family_id_to_guid = {family.id: family.guid for family in family_models}
         individual_id_to_guid = {individual.id: individual.guid for individual in individual_models}
@@ -67,6 +76,24 @@ def get_projects_child_entities(projects, user, is_analyst=None):
         for group in analysis_groups:
             group['projectGuid'] = project_id_to_guid[group.pop('projectId')]
 
+        prefetch_related_objects(locus_lists_models, 'projects')
+        for locus_list in locus_lists_models:
+            for project in locus_list.projects.all():
+                project_locus_lists[project.guid].append(locus_list.guid)
+
+        prefetch_related_objects(variant_tag_types_models, 'project')
+        variant_tag_types_by_guid = {vtt['variantTagTypeGuid']: vtt for vtt in variant_tag_types}
+        for vtt in variant_tag_types_models:
+            project_guid = vtt.project.guid if vtt.project else None
+            project_tag_types[project_guid].append(variant_tag_types_by_guid[vtt.guid])
+
+    for project_guid, project_json in projects_by_guid.items():
+        project_json.update({
+            'locusListGuids': project_locus_lists[project_guid],
+            'variantTagTypes': project_tag_types[project_guid] + project_tag_types[None],
+            'variantFunctionalTagTypes': functional_data_tag_types,
+        })
+
     individual_guids_by_family = defaultdict(list)
     for individual in individuals:
         individual_guids_by_family[individual['familyGuid']].append(individual['individualGuid'])
@@ -84,6 +111,7 @@ def get_projects_child_entities(projects, user, is_analyst=None):
         individual['igvSampleGuids'] = igv_sample_guids_by_individual[individual['individualGuid']]
 
     response = {
+        'projectsByGuid': projects_by_guid,
         'familiesByGuid': {f['familyGuid']: f for f in families},
         'individualsByGuid': {i['individualGuid']: i for i in individuals},
         'samplesByGuid': {s['sampleGuid']: s for s in samples},


### PR DESCRIPTION
Moves  functionality for getting all the project details and child entities from 2 separate sets of functions in the project api and variant search api into a shared utility that is used by both. No changes to functionality, but will make changes in an upcoming PR easier to implement/ read