### PR TITLE
update num nodes for loading pool

### DIFF
--- a/deploy/kubernetes/shared-settings.yaml
+++ b/deploy/kubernetes/shared-settings.yaml
@@ -13,7 +13,7 @@ NODE_POOLS:
     machine_type: n1-highmem-8
     labels: nodeType=data
 #  es-loading-nodes:
-#    num_nodes: 2
+#    num_nodes: 3
 
 DISKS: seqr-static-files, es-data
 


### PR DESCRIPTION
This does not change anything in our live deployments, but when I need to spin up a loading cluster I uncomment and use this configuration, and RGP has gotten big enough that we now need 3 nodes instead of 2, so it would be helpful to keep that committed in code so I don't need to remember it