### PR TITLE
Fix new sample notification

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1035,24 +1035,6 @@
 },
 {
     "model": "seqr.sample",
-    "pk": 141,
-    "fields": {
-        "guid": "S000141_na20878",
-        "created_date": "2017-02-05T06:42:55.397Z",
-        "created_by": null,
-        "last_modified_date": "2017-03-13T09:07:50.193Z",
-
-        "sample_id": "NA20878",
-        "sample_type": "WES",
-        "is_active": false,
-    	"individual": 13,
-        "dataset_type": "VARIANTS",
-        "elasticsearch_index": "1kg.vcf.gz",
-        "loaded_date": "2017-02-05T06:42:55.397Z"
-    }
-},
-{
-    "model": "seqr.sample",
     "pk": 142,
     "fields": {
         "guid": "S000142_na20881",

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         sample_ids, sample_type = validate_index_metadata_and_get_elasticsearch_index_samples(
             elasticsearch_index, genome_version=GENOME_VERSION_GRCh38)
 
-        matched_sample_id_to_sample_record, included_families = match_sample_ids_to_sample_records(
+        samples, included_families = match_sample_ids_to_sample_records(
             project=project,
             user=None,
             sample_ids=sample_ids,
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                 ))
 
         # Lift-over saved variants
-        update_variant_samples(matched_sample_id_to_sample_record.values(), None, elasticsearch_index)
+        update_variant_samples(samples, None, elasticsearch_index)
         saved_variants = get_json_for_saved_variants(list(saved_variant_models_by_guid.values()), add_details=True)
         saved_variants_to_lift = [v for v in saved_variants if v['genomeVersion'] != GENOME_VERSION_GRCh38]
 

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -38,16 +38,14 @@ class Command(BaseCommand):
         sample_ids, sample_type = validate_index_metadata_and_get_elasticsearch_index_samples(
             elasticsearch_index, genome_version=GENOME_VERSION_GRCh38)
 
-        matched_sample_id_to_sample_record, unmatched_samples = match_sample_ids_to_sample_records(
+        matched_sample_id_to_sample_record = match_sample_ids_to_sample_records(
             project=project,
             user=None,
             sample_ids=sample_ids,
             elasticsearch_index=elasticsearch_index,
             sample_type=sample_type,
+            unmatched_error_template='Matches not found for ES sample ids: {sample_ids}.'
         )
-
-        if len(unmatched_samples) > 0:
-            raise CommandError('Matches not found for ES sample ids: {}.'.format(', '.join(unmatched_samples)))
 
         prefetch_related_objects(list(matched_sample_id_to_sample_record.values()), 'individual__family')
         included_families = {sample.individual.family for sample in matched_sample_id_to_sample_record.values()}

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         sample_ids, sample_type = validate_index_metadata_and_get_elasticsearch_index_samples(
             elasticsearch_index, genome_version=GENOME_VERSION_GRCh38)
 
-        samples, included_families = match_sample_ids_to_sample_records(
+        samples, included_families, _ = match_sample_ids_to_sample_records(
             project=project,
             user=None,
             sample_ids=sample_ids,

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
         sample_ids, sample_type = validate_index_metadata_and_get_elasticsearch_index_samples(
             elasticsearch_index, genome_version=GENOME_VERSION_GRCh38)
 
-        matched_sample_id_to_sample_record, _ = match_sample_ids_to_sample_records(
+        matched_sample_id_to_sample_record = match_sample_ids_to_sample_records(
             project=project,
             user=None,
             sample_ids=sample_ids,

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
             sample_ids=sample_ids,
             elasticsearch_index=elasticsearch_index,
             sample_type=sample_type,
-            unmatched_error_template='Matches not found for ES sample ids: {sample_ids}.'
+            raise_unmatched_error_template='Matches not found for ES sample ids: {sample_ids}.'
         )
 
         # Get expected saved variants

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -1,12 +1,11 @@
 import logging
 from collections import defaultdict
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import prefetch_related_objects
 from django.db.models.query_utils import Q
 from pyliftover.liftover import LiftOver
 
 from reference_data.models import GENOME_VERSION_GRCh38
-from seqr.models import Project, SavedVariant, Individual
+from seqr.models import Project, SavedVariant
 from seqr.views.utils.dataset_utils import match_sample_ids_to_sample_records, update_variant_samples, \
     validate_index_metadata_and_get_elasticsearch_index_samples
 from seqr.views.utils.json_to_orm_utils import update_model_from_json
@@ -59,7 +58,7 @@ class Command(BaseCommand):
                 ))
 
         # Lift-over saved variants
-        update_variant_samples(matched_sample_id_to_sample_record, None, elasticsearch_index)
+        update_variant_samples(matched_sample_id_to_sample_record.values(), None, elasticsearch_index)
         saved_variants = get_json_for_saved_variants(list(saved_variant_models_by_guid.values()), add_details=True)
         saved_variants_to_lift = [v for v in saved_variants if v['genomeVersion'] != GENOME_VERSION_GRCh38]
 

--- a/seqr/management/tests/lift_project_to_hg38_tests.py
+++ b/seqr/management/tests/lift_project_to_hg38_tests.py
@@ -109,7 +109,7 @@ class LiftProjectToHg38Test(TestCase):
     def test_command_error_missing_indvididuals(self, mock_get_es_samples, mock_logger):
         mock_get_es_samples.return_value = ['NA19675_1'], SAMPLE_TYPE
 
-        with self.assertRaises(CommandError) as ce:
+        with self.assertRaises(ValueError) as ce:
             call_command('lift_project_to_hg38', '--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
 

--- a/seqr/management/tests/lift_project_to_hg38_tests.py
+++ b/seqr/management/tests/lift_project_to_hg38_tests.py
@@ -92,7 +92,7 @@ class LiftProjectToHg38Test(TestCase):
     def test_command_error_unmatched_sample(self, mock_get_es_samples, mock_logger):
         mock_get_es_samples.return_value = ['ID_NOT_EXIST'], SAMPLE_TYPE
 
-        with self.assertRaises(CommandError) as ce:
+        with self.assertRaises(ValueError) as ce:
             call_command('lift_project_to_hg38', '--project={}'.format(PROJECT_NAME),
                     '--es-index={}'.format(ELASTICSEARCH_INDEX))
 

--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -59,7 +59,7 @@ def add_variants_dataset_handler(request, project_guid):
     loaded_date = timezone.now()
     ignore_extra_samples = request_json.get('ignoreExtraSamplesInCallset')
     try:
-        matched_sample_id_to_sample_record, included_families = match_sample_ids_to_sample_records(
+        samples, included_families = match_sample_ids_to_sample_records(
             project=project,
             user=request.user,
             sample_ids=sample_ids,
@@ -75,7 +75,7 @@ def add_variants_dataset_handler(request, project_guid):
         return create_json_response({'errors': [str(e)]}, status=400)
 
     activated_sample_guids, inactivated_sample_guids = update_variant_samples(
-        matched_sample_id_to_sample_record.values(), request.user, elasticsearch_index, loaded_date, dataset_type, sample_type)
+        samples, request.user, elasticsearch_index, loaded_date, dataset_type, sample_type)
 
     updated_samples = Sample.objects.filter(guid__in=activated_sample_guids)
 
@@ -112,7 +112,7 @@ We have loaded {num_sample} samples from the AnVIL workspace <a href={anvil_url}
                 base_url=BASE_URL,
                 guid=project.guid,
                 project_name=project.name,
-                num_sample=len(matched_sample_id_to_sample_record),
+                num_sample=len(samples),
             ),
             subject='New data available in seqr',
             to=sorted([user.email]),

--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -92,16 +92,19 @@ def add_variants_dataset_handler(request, project_guid):
                 individual__in=updated_individuals, sample_type=sample_type, dataset_type=dataset_type,
             ).exclude(elasticsearch_index=elasticsearch_index)}
         previous_loaded_individuals.update(matched_individual_ids)
-        new_samples = [sample for sample in updated_samples if sample.individual_id not in previous_loaded_individuals]
+        new_sample_ids = [
+            sample.sample_id for sample in updated_samples if sample.individual_id not in previous_loaded_individuals]
         safe_post_to_slack(
             SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL,
-            """{num_sample} new samples are loaded in {base_url}project/{guid}/project_page
+            """{num_sample} new {sample_type}{dataset_type} samples are loaded in {base_url}project/{guid}/project_page
             ```{samples}```
             """.format(
-                num_sample=len(new_samples),
+                num_sample=len(new_sample_ids),
+                sample_type=sample_type,
+                dataset_type='' if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS else ' {}'.format(dataset_type),
                 base_url=BASE_URL,
                 guid=project.guid,
-                samples=', '.join([sample.sample_id for sample in new_samples])
+                samples=', '.join(new_sample_ids)
             ))
     elif project_has_anvil(project):
         user = project.created_by

--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -124,7 +124,7 @@ def add_variants_dataset_handler(request, project_guid):
                 num_sample=len(new_samples),
                 base_url=BASE_URL,
                 guid=project.guid,
-                samples=[sample.sample_id for sample in new_samples]
+                samples=', '.join([sample.sample_id for sample in new_samples])
             ))
     elif project_has_anvil(project):
         user = project.created_by

--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -60,7 +60,7 @@ def add_variants_dataset_handler(request, project_guid):
         return create_json_response({'errors': [str(e)]}, status=400)
 
     loaded_date = timezone.now()
-    matched_sample_id_to_sample_record, new_samples = match_sample_ids_to_sample_records(
+    matched_sample_id_to_sample_record = match_sample_ids_to_sample_records(
         project=project,
         user=request.user,
         sample_ids=sample_ids,
@@ -116,6 +116,7 @@ def add_variants_dataset_handler(request, project_guid):
         request.user, {'analysis_status': Family.ANALYSIS_STATUS_ANALYSIS_IN_PROGRESS}, guid__in=family_guids_to_update)
 
     if project_has_analyst_access(project):
+        new_samples = []
         safe_post_to_slack(
             SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL,
             """{num_sample} new samples are loaded in {base_url}project/{guid}/project_page

--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -69,7 +69,7 @@ def add_variants_dataset_handler(request, project_guid):
             sample_id_to_individual_id_mapping=sample_id_to_individual_id_mapping,
             loaded_date=loaded_date,
             raise_no_match_error=ignore_extra_samples,
-            unmatched_error_template=None if ignore_extra_samples else 'Matches not found for ES sample ids: {sample_ids}. Uploading a mapping file for these samples, or select the "Ignore extra samples in callset" checkbox to ignore.'
+            raise_unmatched_error_template=None if ignore_extra_samples else 'Matches not found for ES sample ids: {sample_ids}. Uploading a mapping file for these samples, or select the "Ignore extra samples in callset" checkbox to ignore.'
         )
     except ValueError as e:
         return create_json_response({'errors': [str(e)]}, status=400)

--- a/seqr/views/apis/dataset_api.py
+++ b/seqr/views/apis/dataset_api.py
@@ -1,7 +1,4 @@
 import json
-from collections import defaultdict
-
-from django.db.models import prefetch_related_objects
 from django.utils import timezone
 
 from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL, ANVIL_UI_URL, BASE_URL
@@ -77,8 +74,12 @@ def add_variants_dataset_handler(request, project_guid):
     except ValueError as e:
         return create_json_response({'errors': [str(e)]}, status=400)
 
-    inactivate_sample_guids = update_variant_samples(
-        matched_sample_id_to_sample_record, request.user, elasticsearch_index, loaded_date, dataset_type, sample_type)
+    activated_sample_guids, inactivated_sample_guids = update_variant_samples(
+        matched_sample_id_to_sample_record.values(), request.user, elasticsearch_index, loaded_date, dataset_type, sample_type)
+
+    matched_sample_id_to_sample_record.update({
+        sample.sample_id: sample for sample in Sample.objects.filter(guid__in=activated_sample_guids)
+    })
 
     family_guids_to_update = [
         family.guid for family in included_families if family.analysis_status == Family.ANALYSIS_STATUS_WAITING_FOR_DATA
@@ -119,16 +120,16 @@ We have loaded {num_sample} samples from the AnVIL workspace <a href={anvil_url}
             to=sorted([user.email]),
         )
 
-    response_json = _get_samples_json(matched_sample_id_to_sample_record, inactivate_sample_guids, project_guid)
+    response_json = _get_samples_json(matched_sample_id_to_sample_record, inactivated_sample_guids, project_guid)
     response_json['familiesByGuid'] = {family_guid: {'analysisStatus': Family.ANALYSIS_STATUS_ANALYSIS_IN_PROGRESS}
                                        for family_guid in family_guids_to_update}
 
     return create_json_response(response_json)
 
 
-def _get_samples_json(matched_sample_id_to_sample_record, inactivate_sample_guids, project_guid):
+def _get_samples_json(matched_sample_id_to_sample_record, inactivated_sample_guids, project_guid):
     updated_sample_json = get_json_for_samples(list(matched_sample_id_to_sample_record.values()), project_guid=project_guid)
-    sample_response = {sample_guid: {'isActive': False} for sample_guid in inactivate_sample_guids}
+    sample_response = {sample_guid: {'isActive': False} for sample_guid in inactivated_sample_guids}
     sample_response.update({s['sampleGuid']: s for s in updated_sample_json})
     response = {
         'samplesByGuid': sample_response

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -139,7 +139,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '2 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```[\'NA20878\', \'NA19678_1\']```\n            '.format(
+            '2 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19678_1, NA20878```\n            '.format(
                 guid=PROJECT_GUID
             ))
 
@@ -189,7 +189,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```[\'NA19675_1\']```\n            '.format(
+            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19675_1```\n            '.format(
                 guid=PROJECT_GUID
             ))
 
@@ -233,7 +233,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```[\'NA19675_1\']```\n            '.format(
+            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19675_1```\n            '.format(
                 guid=PROJECT_GUID
             ))
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -141,7 +141,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA20878```\n            '.format(
+            '1 new WES samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA20878```\n            '.format(
                 guid=PROJECT_GUID
             ))
 
@@ -191,7 +191,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19675_1```\n            '.format(
+            '1 new WES SV samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19675_1```\n            '.format(
                 guid=PROJECT_GUID
             ))
 
@@ -235,7 +235,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19675_1```\n            '.format(
+            '1 new WGS samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19675_1```\n            '.format(
                 guid=PROJECT_GUID
             ))
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -93,10 +93,9 @@ class DatasetAPITest(object):
         replaced_sample_guid = 'S98765432101234567890_NA19678_'
         self.assertSetEqual(
             set(response_json['samplesByGuid'].keys()),
-            {existing_index_sample_guid, existing_sample_guid, existing_old_index_sample_guid, replaced_sample_guid, new_sample_guid}
+            {existing_sample_guid, existing_old_index_sample_guid, replaced_sample_guid, new_sample_guid}
         )
         self.assertDictEqual(response_json['individualsByGuid'], {
-            'I000001_na19675': {'sampleGuids': [existing_index_sample_guid]},
             'I000002_na19678': {'sampleGuids': mock.ANY},
             'I000003_na19679': {'sampleGuids': [existing_sample_guid]},
             'I000013_na20878': {'sampleGuids': [new_sample_guid]},
@@ -124,17 +123,20 @@ class DatasetAPITest(object):
             {True},
             {sample['isActive'] for sample in updated_samples}
         )
+        self.assertSetEqual(
+            {datetime.now().strftime('%Y-%m-%d')},
+            {sample['loadedDate'][:10] for sample in updated_samples}
+        )
         self.assertDictEqual(response_json['samplesByGuid'][existing_old_index_sample_guid], {'isActive': False})
 
-        # Only the new/updated samples should have an updated loaded date
-        self.assertTrue(response_json['samplesByGuid'][existing_index_sample_guid]['loadedDate'].startswith('2017-02-05'))
-        today = datetime.now().strftime('%Y-%m-%d')
-        self.assertTrue(response_json['samplesByGuid'][existing_sample_guid]['loadedDate'].startswith(today))
-        self.assertTrue(response_json['samplesByGuid'][replaced_sample_guid]['loadedDate'].startswith(today))
-
         updated_sample_models = Sample.objects.filter(guid__in=[sample['sampleGuid'] for sample in updated_samples])
-        self.assertEqual(len(updated_sample_models), 4)
+        self.assertEqual(len(updated_sample_models), 3)
         self.assertSetEqual({INDEX_NAME}, {sample.elasticsearch_index for sample in updated_sample_models})
+
+        existing_index_sample_model = Sample.objects.get(guid=existing_index_sample_guid)
+        self.assertEqual(existing_index_sample_model.sample_type, 'WES')
+        self.assertTrue(existing_index_sample_model.is_active)
+        self.assertTrue(str(existing_index_sample_model.loaded_date).startswith('2017-02-05'))
 
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -66,12 +66,13 @@ class DatasetAPITest(object):
         self.assertFalse(existing_sample.is_active)
         existing_sample_guid = existing_sample.guid
         self.assertEqual(Sample.objects.filter(sample_id='NA19678_1').count(), 0)
+        self.assertEqual(Sample.objects.filter(sample_id='NA20878').count(), 0)
 
         mock_random.return_value = 98765432101234567890
 
         urllib3_responses.add_json('/{}/_mapping'.format(INDEX_NAME), MAPPING_JSON)
         urllib3_responses.add_json('/{}/_search?size=0'.format(INDEX_NAME), {'aggregations': {
-            'sample_ids': {'buckets': [{'key': 'NA19675'}, {'key': 'NA19679'}, {'key': 'NA19678_1'}]}
+            'sample_ids': {'buckets': [{'key': 'NA19675'}, {'key': 'NA19679'}, {'key': 'NA19678_1'}, {'key': 'NA20878'}]}
         }}, method=urllib3_responses.POST)
         MOCK_FILE_ITER.return_value = StringIO('NA19678_1,NA19678\n')
 
@@ -88,22 +89,27 @@ class DatasetAPITest(object):
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'samplesByGuid', 'individualsByGuid', 'familiesByGuid'})
 
-        new_sample_guid = 'S98765432101234567890_NA19678_'
+        new_sample_guid = 'S98765432101234567890_NA20878'
+        replaced_sample_guid = 'S98765432101234567890_NA19678_'
         self.assertSetEqual(
             set(response_json['samplesByGuid'].keys()),
-            {existing_index_sample_guid, existing_sample_guid, existing_old_index_sample_guid, new_sample_guid}
+            {existing_index_sample_guid, existing_sample_guid, existing_old_index_sample_guid, replaced_sample_guid, new_sample_guid}
         )
         self.assertDictEqual(response_json['individualsByGuid'], {
             'I000001_na19675': {'sampleGuids': [existing_index_sample_guid]},
             'I000002_na19678': {'sampleGuids': mock.ANY},
             'I000003_na19679': {'sampleGuids': [existing_sample_guid]},
+            'I000013_na20878': {'sampleGuids': [new_sample_guid]},
         })
         self.assertSetEqual(
             set(response_json['individualsByGuid']['I000002_na19678']['sampleGuids']),
-            {new_sample_guid, existing_old_index_sample_guid}
+            {replaced_sample_guid, existing_old_index_sample_guid}
         )
 
-        self.assertDictEqual(response_json['familiesByGuid'], {'F000001_1': {'analysisStatus': 'I'}})
+        self.assertDictEqual(response_json['familiesByGuid'], {
+            'F000001_1': {'analysisStatus': 'I'},
+            'F000009_9': {'analysisStatus': 'I'},
+        })
         updated_family = Family.objects.get(guid='F000001_1')
         self.assertEqual(updated_family.analysis_status, 'I')
         self.assertIsNone(updated_family.analysis_status_last_modified_date)
@@ -124,16 +130,16 @@ class DatasetAPITest(object):
         self.assertTrue(response_json['samplesByGuid'][existing_index_sample_guid]['loadedDate'].startswith('2017-02-05'))
         today = datetime.now().strftime('%Y-%m-%d')
         self.assertTrue(response_json['samplesByGuid'][existing_sample_guid]['loadedDate'].startswith(today))
-        self.assertTrue(response_json['samplesByGuid'][new_sample_guid]['loadedDate'].startswith(today))
+        self.assertTrue(response_json['samplesByGuid'][replaced_sample_guid]['loadedDate'].startswith(today))
 
         updated_sample_models = Sample.objects.filter(guid__in=[sample['sampleGuid'] for sample in updated_samples])
-        self.assertEqual(len(updated_sample_models), 3)
+        self.assertEqual(len(updated_sample_models), 4)
         self.assertSetEqual({INDEX_NAME}, {sample.elasticsearch_index for sample in updated_sample_models})
 
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```[\'NA19678_1\']```\n            '.format(
+            '2 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```[\'NA20878\', \'NA19678_1\']```\n            '.format(
                 guid=PROJECT_GUID
             ))
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -141,7 +141,7 @@ class DatasetAPITest(object):
         mock_send_email.assert_not_called()
         mock_send_slack.assert_called_with(
             'seqr-data-loading',
-            '2 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA19678_1, NA20878```\n            '.format(
+            '1 new samples are loaded in https://seqr.broadinstitute.org/project/{guid}/project_page\n            ```NA20878```\n            '.format(
                 guid=PROJECT_GUID
             ))
 

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -279,8 +279,8 @@ class ReportAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'rows', 'errors'})
-        self.assertListEqual(response_json['errors'], ['No data loaded for family: no_individuals. Skipping...'])
-        self.assertEqual(len(response_json['rows']), 10)
+        self.assertListEqual(response_json['errors'], ['No data loaded for family: 9. Skipping...', 'No data loaded for family: no_individuals. Skipping...'])
+        self.assertEqual(len(response_json['rows']), 9)
         self.assertIn(EXPECTED_DISCOVERY_SHEET_ROW, response_json['rows'])
 
         # test compound het reporting

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -101,7 +101,7 @@ def match_sample_ids_to_sample_records(
     """Goes through the given list of sample_ids and finds existing Sample records of the given
     sample_type and dataset_type with ids from the list. For sample_ids that aren't found to have existing Sample
     records, it looks for Individual records that have an individual_id that exactly equals one of the sample_ids in
-    the list or is contained in the optional sample_id_to_individual_id_mapping and creates new Sample records for these.
+    the list or is contained in the optional sample_id_to_individual_id_mapping and creates new Sample records for these
 
     Args:
         project (object): Django ORM project model
@@ -112,12 +112,14 @@ def match_sample_ids_to_sample_records(
         elasticsearch_index (string): an optional string specifying the index where the dataset is loaded
         sample_id_to_individual_id_mapping (object): Mapping between sample ids and their corresponding individual ids
         loaded_date (object): datetime object
+        raise_no_match_error (bool): whether to raise an exception if no sample matches are found
+        unmatched_error_template (string): optional template to use to raise an exception if samples are unmatched
 
     Returns:
         tuple:
-            [0] dict: sample_id_to_sample_record containing the matching Sample records (including any
-            newly-created ones)
-            [1] array: array of the sample_ids of any samples that were created
+            [0] array: matching Sample records (including any newly-created ones)
+            [1] array: Family records with matched samples
+            [2] array: ids of Individuals with exact-matching existing samples
     """
 
     samples = _find_matching_sample_records(

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -126,12 +126,11 @@ def match_sample_ids_to_sample_records(
     logger.debug(str(len(samples)) + " exact sample record matches", user)
 
     remaining_sample_ids = set(sample_ids) - {sample.sample_id for sample in samples}
+    matched_individual_ids = {sample.individual_id for sample in samples}
     if len(remaining_sample_ids) > 0:
-        already_matched_individual_ids = {sample.individual.individual_id for sample in samples}
-
         remaining_individuals_dict = {
             i.individual_id: i for i in
-            Individual.objects.filter(family__project=project).exclude(individual_id__in=already_matched_individual_ids)
+            Individual.objects.filter(family__project=project).exclude(id__in=matched_individual_ids)
         }
 
         # find Individual records with exactly-matching individual_ids
@@ -174,7 +173,7 @@ def match_sample_ids_to_sample_records(
 
     included_families = _validate_samples_families(samples, sample_type, dataset_type)
 
-    return samples, included_families
+    return samples, included_families, matched_individual_ids
 
 
 def _find_matching_sample_records(project, sample_ids, sample_type, dataset_type, elasticsearch_index):

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -96,7 +96,7 @@ def match_sample_ids_to_sample_records(
         sample_id_to_individual_id_mapping=None,
         loaded_date=None,
         raise_no_match_error=False,
-        unmatched_error_template=None,
+        raise_unmatched_error_template=None,
 ):
     """Goes through the given list of sample_ids and finds existing Sample records of the given
     sample_type and dataset_type with ids from the list. For sample_ids that aren't found to have existing Sample
@@ -113,7 +113,7 @@ def match_sample_ids_to_sample_records(
         sample_id_to_individual_id_mapping (object): Mapping between sample ids and their corresponding individual ids
         loaded_date (object): datetime object
         raise_no_match_error (bool): whether to raise an exception if no sample matches are found
-        unmatched_error_template (string): optional template to use to raise an exception if samples are unmatched
+        raise_unmatched_error_template (string): optional template to use to raise an exception if samples are unmatched, will not raise if not provided
 
     Returns:
         tuple:
@@ -155,8 +155,8 @@ def match_sample_ids_to_sample_records(
                 'None of the individuals or samples in the project matched the {} expected sample id(s)'.format(
                     len(sample_ids)
                 ))
-        if unmatched_error_template and remaining_sample_ids:
-            raise ValueError(unmatched_error_template.format(sample_ids=(', '.join(remaining_sample_ids))))
+        if raise_unmatched_error_template and remaining_sample_ids:
+            raise ValueError(raise_unmatched_error_template.format(sample_ids=(', '.join(remaining_sample_ids))))
 
         # create new Sample records for Individual records that matches
         new_samples = [

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -178,7 +178,7 @@ def match_sample_ids_to_sample_records(
 
     included_families = _validate_samples_families(list(sample_id_to_sample_record.values()), sample_type, dataset_type)
 
-    return sample_id_to_sample_record, included_families
+    return sample_id_to_sample_record.values(), included_families
 
 
 def _find_matching_sample_records(project, sample_ids, sample_type, dataset_type, elasticsearch_index):

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -128,7 +128,6 @@ def match_sample_ids_to_sample_records(
     logger.debug(str(len(sample_id_to_sample_record)) + " exact sample record matches", user)
 
     remaining_sample_ids = set(sample_ids) - set(sample_id_to_sample_record.keys())
-    new_samples = []
     if len(remaining_sample_ids) > 0:
         already_matched_individual_ids = {
             sample.individual.individual_id for sample in sample_id_to_sample_record.values()
@@ -171,7 +170,7 @@ def match_sample_ids_to_sample_records(
             })
             log_model_bulk_update(logger, new_samples, user, 'create')
 
-    return sample_id_to_sample_record, new_samples
+    return sample_id_to_sample_record
 
 
 def find_matching_sample_records(project, sample_ids, sample_type, dataset_type, elasticsearch_index):


### PR DESCRIPTION
We should only send a slack update for samples if data has never been loaded for that individual before, not just if the sample models itself is new. Also cleans up the `match_sample_ids_to_sample_records` a bit and moves shared behavior into the shared utility function