### PR TITLE
WIP: Deprecate gke init in servctl

### DIFF
--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -6,7 +6,7 @@ from pprint import pformat
 import time
 
 from deploy.servctl_utils.other_command_utils import get_disk_names
-from deploy.servctl_utils.kubectl_utils import is_pod_running, get_node_name, \
+from deploy.servctl_utils.kubectl_utils import is_pod_running, \
     wait_until_pod_is_running as sleep_until_pod_is_running, wait_until_pod_is_ready as sleep_until_pod_is_ready, \
     wait_for_resource, wait_for_not_resource
 from deploy.servctl_utils.yaml_settings_utils import process_jinja_template, load_settings

--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -495,29 +495,3 @@ def delete_pod(component_label, settings, custom_yaml_filename=None):
     logger.info("waiting for \"%s\" to exit Running status" % component_label)
     while is_pod_running(component_label, deployment_target):
         time.sleep(5)
-
-
-def create_vpc(gcloud_project, network_name):
-    run(" ".join([
-        #"gcloud compute networks create seqr-project-custom-vpc --project=%(GCLOUD_PROJECT)s --mode=custom"
-        "gcloud compute networks create %(network_name)s",
-        "--project=%(gcloud_project)s",
-        "--subnet-mode=auto"
-    ]) % locals(), errors_to_ignore=["already exists"])
-
-    # add recommended firewall rules to enable ssh, etc.
-    run(" ".join([
-        "gcloud compute firewall-rules create custom-vpc-allow-tcp-udp-icmp",
-        "--project %(gcloud_project)s",
-        "--network %(network_name)s",
-        "--allow tcp,udp,icmp",
-        "--source-ranges 10.0.0.0/8",
-    ]) % locals(), errors_to_ignore=["already exists"])
-
-    run(" ".join([
-        "gcloud compute firewall-rules create custom-vpc-allow-ports",
-        "--project %(gcloud_project)s",
-        "--network %(network_name)s",
-        "--allow tcp:22,tcp:3389,icmp",
-        "--source-ranges 10.0.0.0/8",
-    ]) % locals(), errors_to_ignore=["already exists"])

--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -340,13 +340,13 @@ def deploy(deployment_target, components, output_dir=None, runtime_settings={}):
     if not components:
         raise ValueError("components list is empty")
 
-    if components and "init-cluster" not in components:
+    if components:
         run('deploy/kubectl_helpers/utils/check_context.sh {}'.format(deployment_target.replace('gcloud-', '')))
 
     settings = prepare_settings_for_deployment(deployment_target, output_dir, runtime_settings)
 
     # make sure namespace exists
-    if "init-cluster" not in components and not runtime_settings.get("ONLY_PUSH_TO_REGISTRY"):
+    if not runtime_settings.get("ONLY_PUSH_TO_REGISTRY"):
         create_namespace(settings)
 
     if components[0] == 'secrets':

--- a/deploy/servctl_utils/kubectl_utils.py
+++ b/deploy/servctl_utils/kubectl_utils.py
@@ -149,14 +149,3 @@ def get_resource_name(name_label, resource_type, deployment_target=None, pod_num
         errors_to_ignore=["array index out of bounds: index 0"],
         verbose=False,
     )
-
-
-def get_node_name():
-    """Returns kubernetes cluster node name. If there are multiple nodes, it returns the 1st one."""
-
-    return _get_resource_info(
-        resource_type="nodes",
-        json_path="{.items[0].metadata.name}",
-        errors_to_ignore=["array index out of bounds: index 0"],
-        verbose=True,
-    )


### PR DESCRIPTION
Removes servctl code that's no longer needed when terraform is managing GKE. This mainly includes the `deploy_init_cluster()` method, and the methods that it calls:

- `create_vpc`
- `_init_cluster_gcloud`
- `_init_gcloud_disks`
- `kubectl_utils.get_node_name`

Closes https://github.com/broadinstitute/seqr-private/issues/1050