### PR TITLE
Changed to use the default height for mappability tracks.

### DIFF
--- a/ui/shared/components/panel/family/constants.js
+++ b/ui/shared/components/panel/family/constants.js
@@ -380,6 +380,8 @@ export const MAPPABILITY_TRACK_OPTIONS = MAPPABILITY_TRACKS.map((track, i) => {
       url: track.url,
       name: track.value,
       order: 400 + i,
+      ...TRACK_OPTIONS[track.type],
+      height: 50,
       ...track.options,
       ...idx,
     },


### PR DESCRIPTION
Before this change, the height of the mappability tracks was set to `170` by the options of the `COVERAGE_TYPE`. The height is `50` by default if no track-type-based options are applied. The screenshot after the change is:
![image](https://user-images.githubusercontent.com/33550059/138895591-92f1f91f-40b3-47f5-9567-d95c1031c243.png)

BTW. Mappability tracks are references not just for RNAseq. It should always be displayed. Should I change it in this PR?