### PR TITLE
Docker Cleanup Part 1

### DIFF
--- a/.cloudbuild/seqr-docker.cloudbuild.yaml
+++ b/.cloudbuild/seqr-docker.cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  dir: 'deploy/docker/seqr'
+  args: [ 'build', '.', '-t', 'seqr-docker-cleanup-testing:$COMMIT_SHA']
+- name: 'gcr.io/cloud-builders/docker'
+  dir: 'deploy/docker/seqr'
+  args: [ 'tag', 'seqr-docker-cleanup-testing:$COMMIT_SHA', 'us-central1-docker.pkg.dev/tgg-sre-testing/seqr-testing/seqr-docker-cleanup-testing:$COMMIT_SHA']
+
+images:
+  - 'us-central1-docker.pkg.dev/tgg-sre-testing/seqr-testing/seqr-docker-cleanup-testing:$COMMIT_SHA'
+
+timeout: 900s

--- a/.cloudbuild/seqr-docker.cloudbuild.yaml
+++ b/.cloudbuild/seqr-docker.cloudbuild.yaml
@@ -1,12 +1,12 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   dir: 'deploy/docker/seqr'
-  args: [ 'build', '.', '-t', 'seqr-docker-cleanup-testing:$COMMIT_SHA']
+  args: [ 'build', '.', '-t', 'seqr:$COMMIT_SHA' ]
 - name: 'gcr.io/cloud-builders/docker'
   dir: 'deploy/docker/seqr'
-  args: [ 'tag', 'seqr-docker-cleanup-testing:$COMMIT_SHA', 'us-central1-docker.pkg.dev/tgg-sre-testing/seqr-testing/seqr-docker-cleanup-testing:$COMMIT_SHA']
+  args: [ 'tag', 'seqr:$COMMIT_SHA', 'gcr.io/seqr-project/seqr:$COMMIT_SHA']
 
 images:
-  - 'us-central1-docker.pkg.dev/tgg-sre-testing/seqr-testing/seqr-docker-cleanup-testing:$COMMIT_SHA'
+  - 'gcr.io/seqr-project/seqr:$COMMIT_SHA'
 
 timeout: 900s

--- a/.github/workflows/docker-lint.yaml
+++ b/.github/workflows/docker-lint.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - deploy/docker/seqr/Dockerfile
       - .hadolint.yaml
+      - .github/workflows/docker-lint.yaml
   # pull_request:
   #   types: [opened, synchronize, reopened]
 

--- a/.github/workflows/docker-lint.yaml
+++ b/.github/workflows/docker-lint.yaml
@@ -1,0 +1,22 @@
+name: Dockerfile Linting
+
+# Run the test suite on pushes (incl. merges) to master and dev
+# Run the test suite when a PR is opened, pushed to, or reopened
+on:
+  push:
+    branches:
+      - docker-rework
+    paths:
+      - deploy/docker/seqr/Dockerfile
+      - .hadolint.yaml
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
+
+jobs:
+  hadolint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2 
+      - uses: hadolint/hadolint-action@v1.5.0
+        with:
+          dockerfile: deploy/docker/seqr/Dockerfile

--- a/.github/workflows/docker-lint.yaml
+++ b/.github/workflows/docker-lint.yaml
@@ -5,13 +5,21 @@ name: Dockerfile Linting
 on:
   push:
     branches:
-      - docker-cleanup-part-1
+      - dev
+      - master
     paths:
       - deploy/docker/seqr/Dockerfile
       - .hadolint.yaml
       - .github/workflows/docker-lint.yaml
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - dev
+      - master
+    paths:
+      - deploy/docker/seqr/Dockerfile
+      - .hadolint.yaml
+      - .github/workflows/docker-lint.yaml
 
 jobs:
   hadolint:

--- a/.github/workflows/docker-lint.yaml
+++ b/.github/workflows/docker-lint.yaml
@@ -5,7 +5,7 @@ name: Dockerfile Linting
 on:
   push:
     branches:
-      - docker-rework
+      - docker-cleanup-part-1
     paths:
       - deploy/docker/seqr/Dockerfile
       - .hadolint.yaml

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+ignored:
+  - DL3008 # pinning apt versions. Deeming it reasonable to install the latest packages on builds
+  - DL3013 # pinning pip versions. Deeming it reasonable to install the latest versions of packages that we don't put in requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## dev
 
+## 11/23/21
+* Update the seqr Dockerfile base image from debian:stretch to python:3.7-slim-bullseye
+* Consolidation and cleanup of various RUN tasks in the seqr Dockerfile
+
 ## 11/17/21
 * Update pathogenicity search to override frequency filters
 * Add ACMG classifier to variants (REQUIRES DB MIGRATION)

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -31,11 +31,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # install gcloud tools
-RUN CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
-    && CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
-    && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
+RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-bullseye main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
         google-cloud-sdk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -61,6 +61,4 @@ COPY bashrc /root/.bashrc
 
 COPY entrypoint.sh /
 
-WORKDIR /seqr
-
 CMD [ "/entrypoint.sh" ]

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -22,14 +22,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# install dev dependencies for react, javascript development. These are not needed at runtime.
-RUN apt-get update \
-    && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get install -y --no-install-recommends \
-        nodejs \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 # install gcloud tools
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-bullseye main" > /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -25,13 +25,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# install database clients for debugging (https://www.postgresql.org/download/linux/debian/)
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
-    && curl -L0 -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get update && apt-get install -y \
-        postgresql-12 \
-        postgresql-client-12 \
-        libpq-dev \
+# install database clients for debugging
+RUN apt-get update && apt-get install -y \
+    postgresql \
+    postgresql-client \
+    libpq-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim-bullseye
 
 LABEL maintainer="Broad TGG"
 
-# install commmon utilities
+# install commmon utilities, database clients for debugging
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     bzip2 \
@@ -12,9 +12,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     htop \
     less \
+    libpq-dev \
     nano \
     xterm \
+    postgresql \
+    postgresql-client \
     procps \
+    redis-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -23,19 +27,6 @@ RUN apt-get update \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get install -y --no-install-recommends \
         nodejs \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# install database clients for debugging
-RUN apt-get update && apt-get install -y \
-    postgresql \
-    postgresql-client \
-    libpq-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y \
-    redis-tools \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     nano \
     xterm \
-    postgresql \
     postgresql-client \
     procps \
     redis-tools \

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM python:3.7-slim-bullseye
 
 LABEL maintainer="Broad TGG"
 
@@ -16,33 +16,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-#  install the packages necessary to build Python source:
-RUN apt update && apt install -y --no-install-recommends build-essential zlib1g-dev libncurses5-dev libgdbm-dev \
-    libnss3-dev libssl-dev libreadline-dev libffi-dev libbz2-dev \
-    libncursesw5-dev libsqlite3-dev tk-dev libc6-dev ca-certificates \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-ARG PYTHON_MAIN_VER="3.7"
-ARG PYTHON_MINOR_VER="8"
-ARG PYTHON_VERSION=$PYTHON_MAIN_VER.$PYTHON_MINOR_VER
-
-# downland and install Python from soruce code
-WORKDIR /
-RUN curl -O https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tar.xz \
-    && tar -xf Python-$PYTHON_VERSION.tar.xz \
-    && rm -f Python-$PYTHON_VERSION.tar.xz
-
-WORKDIR /Python-$PYTHON_VERSION
-RUN ./configure --enable-optimizations \
-    && make -j "$(nproc)" \
-    && make install
-
-WORKDIR /
-RUN rm -rf ./Python-$PYTHON_VERSION \
-    && ln -s /usr/local/bin/pip$PYTHON_MAIN_VER /usr/local/bin/pip \
-    && ln -s /usr/local/bin/python$PYTHON_MAIN_VER /usr/local/bin/python
 
 # install dev dependencies for react, javascript development. These are not needed at runtime.
 RUN apt-get update \

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bzip2 \
     curl \
     emacs \
+    gcc \
     git \
     htop \
     less \
@@ -39,15 +40,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install gcloud tools
-RUN CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
-    && curl https://sdk.cloud.google.com | bash \
-    && apt-get update && apt-get install -y \
-        gcc \
-        libpq-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install gsutil
-
 RUN CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
     && CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
     && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list \

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -45,10 +45,7 @@ WORKDIR /seqr
 # install seqr dependencies
 RUN pip install --no-cache-dir wheel && pip install --no-cache-dir -r requirements.txt
 
-ARG SEQR_SERVICE_PORT
-ENV SEQR_SERVICE_PORT=$SEQR_SERVICE_PORT
-
-EXPOSE $SEQR_SERVICE_PORT
+EXPOSE 8000
 
 ENV TERM=xterm
 

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -11,8 +11,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     emacs \
     gcc \
     git \
+    gnupg \
     htop \
     less \
+    libc6-dev \
     libpq-dev \
     nano \
     xterm \

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.7-slim-bullseye
 LABEL maintainer="Broad TGG"
 
 # install commmon utilities, database clients for debugging
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     bzip2 \
@@ -30,11 +31,6 @@ RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-bullseye main" > /e
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
-    && chmod +x ./kubectl \
-    && mv ./kubectl /usr/local/bin/kubectl
-
-
 # DISABLE_CACHE work-around to force git pull on every docker build, based on https://github.com/docker/docker/issues/1996
 ARG DISABLE_CACHE=1
 ARG SEQR_REPO=https://github.com/broadinstitute/seqr
@@ -46,7 +42,7 @@ RUN git clone -q --branch $SEQR_GIT_BRANCH $SEQR_REPO
 WORKDIR /seqr
 
 # install seqr dependencies
-RUN pip install wheel && pip install -r requirements.txt
+RUN pip install --no-cache-dir wheel && pip install --no-cache-dir -r requirements.txt
 
 ARG SEQR_SERVICE_PORT
 ENV SEQR_SERVICE_PORT=$SEQR_SERVICE_PORT

--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -54,7 +54,7 @@ spec:
       containers:
       - name: seqr-pod
         ports:
-        - containerPort: {{ SEQR_SERVICE_PORT }}
+        - containerPort: 8000
           protocol: TCP
         imagePullPolicy: {{ IMAGE_PULL_POLICY }}
         image: {{ DOCKER_IMAGE_PREFIX }}/seqr{{ DOCKER_IMAGE_TAG }}
@@ -151,8 +151,6 @@ spec:
           value: "{{ KIBANA_SERVICE_HOSTNAME }}"
         - name: REDIS_SERVICE_HOSTNAME
           value: "{{ REDIS_SERVICE_HOSTNAME }}"
-        - name: SEQR_SERVICE_PORT
-          value: "{{ SEQR_SERVICE_PORT }}"
         - name: POSTGRES_SERVICE_PORT
           value: "{{ POSTGRES_SERVICE_PORT }}"
         - name: ELASTICSEARCH_SERVICE_PORT


### PR DESCRIPTION
I think this is ready for an initial review. More changes to come eventually, but I think this is the smallest unit of work that improves our docker build to the point where we can start automating it. The resulting image here should be a little bit smaller in size than our current one, and should maintain equivalent functionality so that the `docker_build()` method could still be used for generating release images.

Major changes include:
- Rebasing our image on `python:3.7-slim-bullseye`. This is the official debian-based python image that provides python 3.7.12 presently. We also get upgraded from debian buster (which was EOL), but I don't think there's much we depend on there.
- Removing all the steps that download and compile python, since that is functionally provided by the python base image
- Moving all of the apt package installations into a single `RUN` instruction
- Removes duplicate gcloud/gsutil SDK installations, kubectl, and the full postgres database package installation (since I think we only need the psql client).
- Configures a [hadolint](https://github.com/hadolint/hadolint) github action to lint the seqr Dockerfile. I've also applied fixes to the issues raised by the linter
- A cloudbuild configuration that can be used to trigger automatic builds of the seqr image (currently in a testing repository) when the seqr `dev` branch gets new commits.

Closes https://github.com/broadinstitute/seqr-private/issues/1061, https://github.com/broadinstitute/seqr-private/issues/1063

Touches https://github.com/broadinstitute/seqr-private/issues/1062, https://github.com/broadinstitute/seqr-private/issues/1065