### PR TITLE
bump redis version

### DIFF
--- a/deploy/docker/redis/Dockerfile
+++ b/deploy/docker/redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:6.0.6
+FROM redis:6.2.6
 
 LABEL maintainer="Broad TGG"
 


### PR DESCRIPTION
The version of the redis docker image we are using is no longer supported. This bumps us to the latest version.
In the long run, we should really consider not maintaining our own copy of external docker images, and also should consider switching to a GCP managed redis instance, but both of those are out of scope for this fix

This has already been deployed and tested in dev. Because redis is not a required service for seqr, there is no downtime while it is redeploying, so it is safe to go directly to production once approved

**Release Checklist**
- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Static assets have been built and committed if needed
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes:
  - [ ] No changes to the required seqr infrastructure are included in this change 
  
  OR 
  
  - [x] Any changes to seqr's infrastructure are already been deployed to a new docker image, and these changes will be released via that image. All these changes have been tested before release on the docker image
    - Already built and released on dev. Once approved will build for prod and push to registry and then redeploy to pod
  - [x] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
    - N/A
  - [x] All these changes have bee vetted for potential vulnerabilities