### PR TITLE
Fix for reference data MGI parsing

### DIFF
--- a/reference_data/management/commands/update_dbnsfp_gene.py
+++ b/reference_data/management/commands/update_dbnsfp_gene.py
@@ -26,6 +26,7 @@ EXCLUDE_FIELDS = (
     'SORVA_LOF', 'Essential_gene', 'chr', 'MIM', 'OMIM', 'RVIS_percentile_EVS', 'RVIS_EVS', 'HIPred',
 )
 
+REFSEQ_OVERRIDE = {'NM_021006': 'ENSG00000256515'}
 
 class DbNSFPReferenceDataHandler(ReferenceDataHandler):
 
@@ -38,6 +39,8 @@ class DbNSFPReferenceDataHandler(ReferenceDataHandler):
                          for k, v in record.items() if not k.startswith(EXCLUDE_FIELDS)}
         parsed_record["function_desc"] = parsed_record["function_desc"].replace("FUNCTION: ", "")
         parsed_record['gene_id'] = parsed_record['gene_id'].split(';')[0]
+        if record['Refseq_id'] and REFSEQ_OVERRIDE.get(record['Refseq_id']):
+            parsed_record['gene_id'] = REFSEQ_OVERRIDE.get(record['Refseq_id'])
 
         gene_names = [record['Gene_name']]
         for gene_name_key in ['Gene_old_names', 'Gene_other_names']:

--- a/reference_data/management/commands/update_dbnsfp_gene.py
+++ b/reference_data/management/commands/update_dbnsfp_gene.py
@@ -26,8 +26,6 @@ EXCLUDE_FIELDS = (
     'SORVA_LOF', 'Essential_gene', 'chr', 'MIM', 'OMIM', 'RVIS_percentile_EVS', 'RVIS_EVS', 'HIPred',
 )
 
-REFSEQ_OVERRIDE = {'NM_021006': 'ENSG00000256515'}
-
 class DbNSFPReferenceDataHandler(ReferenceDataHandler):
 
     model_cls = dbNSFPGene
@@ -39,8 +37,6 @@ class DbNSFPReferenceDataHandler(ReferenceDataHandler):
                          for k, v in record.items() if not k.startswith(EXCLUDE_FIELDS)}
         parsed_record["function_desc"] = parsed_record["function_desc"].replace("FUNCTION: ", "")
         parsed_record['gene_id'] = parsed_record['gene_id'].split(';')[0]
-        if record['Refseq_id'] and REFSEQ_OVERRIDE.get(record['Refseq_id']):
-            parsed_record['gene_id'] = REFSEQ_OVERRIDE.get(record['Refseq_id'])
 
         gene_names = [record['Gene_name']]
         for gene_name_key in ['Gene_old_names', 'Gene_other_names']:

--- a/reference_data/management/commands/update_mgi.py
+++ b/reference_data/management/commands/update_mgi.py
@@ -22,7 +22,7 @@ class MGIReferenceDataHandler(ReferenceDataHandler):
 
     @staticmethod
     def get_file_header(f):
-        return ['gene_symbol', 'entrez_gene_id', 'homologene_id', '?', 'mouse_gene_symbol', 'marker_id', 'phenotype_ids']
+        return ['gene_symbol', 'entrez_gene_id', 'homologene_id', 'marker_id', 'phenotype_ids']
 
     @staticmethod
     def parse_record(record):

--- a/reference_data/management/tests/update_mgi_tests.py
+++ b/reference_data/management/tests/update_mgi_tests.py
@@ -8,10 +8,10 @@ from django.core.management.base import CommandError
 class UpdateMgiTest(ReferenceDataCommandTestCase):
     URL = 'http://www.informatics.jax.org/downloads/reports/HMD_HumanPhenotype.rpt'
     DATA = [
-        'A1BG	  1	11167	yes	A1bg	  MGI:2152878		\n',
-        'A1CF	  29974	16363	yes	A1cf	  MGI:1917115	  MP:0005367 MP:0005370 MP:0005385 MP:0010768 MP:0005369 MP:0005376 MP:0005384 MP:0005378\n',
-        'A2M	  2	37248	yes	A2m	  MGI:2449119\n',
-        'A3GALT2	  127550	16326	yes	A3galt2	  MGI:2685279\n',
+        'A1BG	  1	11167	  MGI:2152878		\n',
+        'A1CF	  29974	16363	  MGI:1917115	  MP:0005367 MP:0005370 MP:0005385 MP:0010768 MP:0005369 MP:0005376 MP:0005384 MP:0005378\n',
+        'A2M	  2	37248	  MGI:2449119\n',
+        'A3GALT2	  127550	16326	  MGI:2685279\n',
     ]
 
     def test_update_mgi_command(self):


### PR DESCRIPTION
Running `python -u manage.py update_all_reference_data --use-cached-omim` in our local instance resulted in errors.  One was a data issue in DBNSFP and the second was a change in format in the MGI report.  Raising this PR for reference.

I suspect this is not regularly run at Broad?  What's the process used at Broad to maintain these gene associated reference datasets?