### PR TITLE
Use gcs media backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # _seqr_ Changes
 
+## 1/25/22
+* Add support for serving the django media root out of a google cloud storage bucket
+
 ## dev
 * Support setting explicit order for saved search display (REQUIRES DB MIGRATION)
 

--- a/deploy/kubernetes/gcloud-dev-settings.yaml
+++ b/deploy/kubernetes/gcloud-dev-settings.yaml
@@ -14,6 +14,7 @@ REDIS_POD_MEMORY_LIMIT: 8Gi
 TERRA_API_ROOT_URL: 'https://firecloud-orchestration.dsde-dev.broadinstitute.org'
 
 CLOUDSQL_AVAILABILITY_TYPE: 'zonal'
+GCS_MEDIA_ROOT_BUCKET: 'seqr-media-storage-public-dev'
 
 ####  Elasticsearch settings ####
 

--- a/deploy/kubernetes/gcloud-prod-settings.yaml
+++ b/deploy/kubernetes/gcloud-prod-settings.yaml
@@ -23,6 +23,8 @@ TERRA_API_ROOT_URL: 'https://api.firecloud.org'
 
 CLOUDSQL_AVAILABILITY_TYPE: 'regional'
 
+GCS_MEDIA_ROOT_BUCKET: 'seqr-media-storage-public-prod'
+
 ###########################################################
 ####### SETTINGS THAT SHOULDN'T NEED TO BE MODIFIED #######
 

--- a/deploy/kubernetes/seqr/seqr.gcloud.yaml
+++ b/deploy/kubernetes/seqr/seqr.gcloud.yaml
@@ -43,11 +43,6 @@ spec:
       - name: matchbox-secrets-volume
         secret:
           secretName: matchbox-secrets
-      - name: seqr-static-files
-        gcePersistentDisk:
-          # This disk must already exist.
-          pdName: {{ CLUSTER_NAME }}-seqr-static-files-disk
-          fsType: ext4
       # - name: elasticsearch-es-http-certs-public
       #   secret:
       #     secretName: elasticsearch-es-http-certs-public
@@ -64,8 +59,6 @@ spec:
           readOnly: true
         - name: matchbox-secrets-volume
           mountPath: {{ MME_CONFIG_DIR }}
-        - name: seqr-static-files
-          mountPath: {{ STATIC_MEDIA_DIR }}
         # - name: elasticsearch-es-http-certs-public
         #   mountPath: "/elasticsearch-certs"
         #   readOnly: true
@@ -167,8 +160,6 @@ spec:
           value: "{{ DATABASE_BACKUP_BUCKET }}"
         - name: RUN_CRON_JOBS
           value: "{{ RUN_CRON_JOBS }}"
-        - name: STATIC_MEDIA_DIR
-          value: "{{ STATIC_MEDIA_DIR }}"
         - name: MME_CONFIG_DIR
           value: "{{ MME_CONFIG_DIR }}"
         - name: TERRA_API_ROOT_URL
@@ -187,6 +178,8 @@ spec:
           value: "{{ ANALYST_USER_GROUP }}"
         - name: PM_USER_GROUP
           value: "{{ PM_USER_GROUP }}"
+        - name: GCS_MEDIA_ROOT_BUCKET
+          value: "{{ GCS_MEDIA_ROOT_BUCKET }}"
         readinessProbe:
           exec:
             command:

--- a/deploy/kubernetes/shared-settings.yaml
+++ b/deploy/kubernetes/shared-settings.yaml
@@ -39,7 +39,6 @@ DOCKER_IMAGE_PREFIX: 'gcr.io/seqr-project'
 IMAGE_PULL_POLICY: 'Always'
 
 DEPLOYMENT_TEMP_DIR: '/tmp'
-STATIC_MEDIA_DIR: '/seqr_static_files'
 MME_CONFIG_DIR: '/mme'
 
 POSTGRES_SERVICE_HOSTNAME: '127.0.0.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ django-csp==3.7                  # for setting CSP headers
 django-guardian==2.3.0           # object-level permissions for database records. Behind a major version due to missing Python 2 support
 django-hijack==2.1.10            # allows admins to login as other user
 django-cors-headers==3.5.0       # allows CORS requests for client-side development
+django-storages[google]==1.11.1  # alternative GCS storage backend for the django media_root
 social-auth-app-django==4.0.0    # the package for Django to authenticate users with social medieas
 social-auth-core==3.3.3          # the Python social authentication package. Required by social-auth-app-django
 

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -337,7 +337,9 @@ urlpatterns += [
     url(r'^admin/', admin.site.urls),
 ]
 
-# If serving /media from the local filesystem
+# The /media urlpattern is not needed if we are storing static media in a GCS bucket,
+# so this logic disables it in that case. If we want to serve media from a local filepath 
+# instead, set MEDIA_ROOT in settings.py to that local path, and then this urlpattern will be enabled.
 if MEDIA_ROOT:
     urlpatterns += [
         url(r'^media/(?P<path>.*)$', django.views.static.serve, {

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -338,7 +338,7 @@ urlpatterns += [
 ]
 
 # The /media urlpattern is not needed if we are storing static media in a GCS bucket,
-# so this logic disables it in that case. If we want to serve media from a local filepath 
+# so this logic disables it in that case. If we want to serve media from a local filepath
 # instead, set MEDIA_ROOT in settings.py to that local path, and then this urlpattern will be enabled.
 if MEDIA_ROOT:
     urlpatterns += [

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -335,10 +335,15 @@ urlpatterns += [
 urlpatterns += [
     url(r'^admin/login/$', RedirectView.as_view(url=LOGIN_URL, permanent=True, query_string=True)),
     url(r'^admin/', admin.site.urls),
-    url(r'^media/(?P<path>.*)$', django.views.static.serve, {
-        'document_root': MEDIA_ROOT,
-    }),
 ]
+
+# If serving /media from the local filesystem
+if MEDIA_ROOT:
+    urlpatterns += [
+        url(r'^media/(?P<path>.*)$', django.views.static.serve, {
+            'document_root': MEDIA_ROOT,
+        }),
+    ]
 
 urlpatterns += [
     url('', include('social_django.urls')),

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -205,7 +205,7 @@ def _get_json_for_families(families, user=None, add_individual_guids_field=False
                 pedigree_image = pedigree_image.url
             except Exception:
                 pedigree_image = None
-        return os.path.join("/media/", pedigree_image) if pedigree_image else None
+        return pedigree_image
 
     analyst_users = set(User.objects.filter(groups__name=ANALYST_USER_GROUP) if ANALYST_USER_GROUP else [])
     def _process_result(result, family):

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -3,7 +3,6 @@ Utility functions for converting Django ORM object to JSON
 """
 
 import json
-import os
 from collections import defaultdict
 from copy import deepcopy
 from django.db.models import prefetch_related_objects, Prefetch

--- a/settings.py
+++ b/settings.py
@@ -152,6 +152,7 @@ if GCS_MEDIA_ROOT_BUCKET:
     DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
     GS_BUCKET_NAME = GCS_MEDIA_ROOT_BUCKET
     GS_DEFAULT_ACL = 'publicRead'
+    MEDIA_ROOT = False
     MEDIA_URL = 'https://storage.googleapis.com/{bucket_name}/'.format(bucket_name=GS_BUCKET_NAME)
 else:
     GENERATED_FILES_DIR = os.path.join(os.environ.get('STATIC_MEDIA_DIR', BASE_DIR), 'generated_files')

--- a/settings.py
+++ b/settings.py
@@ -153,7 +153,9 @@ if GCS_MEDIA_ROOT_BUCKET:
     GS_BUCKET_NAME = GCS_MEDIA_ROOT_BUCKET
     GS_DEFAULT_ACL = 'publicRead'
     MEDIA_ROOT = False
-    MEDIA_URL = 'https://storage.googleapis.com/{bucket_name}/'.format(bucket_name=GS_BUCKET_NAME)
+    media_storage_url = 'https://{bucket_name}.storage.googleapis.com/'.format(bucket_name=GS_BUCKET_NAME)
+    MEDIA_URL = media_storage_url
+    CSP_IMG_SRC = CSP_IMG_SRC + (media_storage_url,)
 else:
     GENERATED_FILES_DIR = os.path.join(os.environ.get('STATIC_MEDIA_DIR', BASE_DIR), 'generated_files')
     MEDIA_ROOT = os.path.join(GENERATED_FILES_DIR, 'media/')

--- a/settings.py
+++ b/settings.py
@@ -145,9 +145,18 @@ TEMPLATES = [
     },
 ]
 
-GENERATED_FILES_DIR = os.path.join(os.environ.get('STATIC_MEDIA_DIR', BASE_DIR), 'generated_files')
-MEDIA_ROOT = os.path.join(GENERATED_FILES_DIR, 'media/')
-MEDIA_URL = '/media/'
+# If specified, store data in the named GCS bucket and use the gcloud storage backend.
+# Else, fall back to a path on the local filesystem.
+GCS_MEDIA_ROOT_BUCKET = os.environ.get('GCS_MEDIA_ROOT_BUCKET')
+if GCS_MEDIA_ROOT_BUCKET:
+    DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+    GS_BUCKET_NAME = GCS_MEDIA_ROOT_BUCKET
+    GS_DEFAULT_ACL = 'publicRead'
+    MEDIA_URL = 'https://storage.googleapis.com/{bucket_name}/'.format(bucket_name=GS_BUCKET_NAME)
+else:
+    GENERATED_FILES_DIR = os.path.join(os.environ.get('STATIC_MEDIA_DIR', BASE_DIR), 'generated_files')
+    MEDIA_ROOT = os.path.join(GENERATED_FILES_DIR, 'media/')
+    MEDIA_URL = '/media/'
 
 LOGGING = {
     'version': 1,

--- a/settings.py
+++ b/settings.py
@@ -74,7 +74,7 @@ CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src', 'style-src-elem']
 CSP_FONT_SRC = ('https://fonts.gstatic.com', 'data:', "'self'")
 CSP_CONNECT_SRC = ("'self'", 'https://gtexportal.org', 'https://www.google-analytics.com', 'https://storage.googleapis.com') # google storage used by IGV
 CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'", 'https://www.googletagmanager.com')
-CSP_IMG_SRC = ("'self'", 'https://www.google-analytics.com', 'data:')
+CSP_IMG_SRC = ("'self'", 'https://www.google-analytics.com', 'https://storage.googleapis.com', 'data:')
 # IGV js injects CSS into the page head so there is no way to set nonce. Therefore, support hashed value of the CSS
 IGV_CSS_HASHES = (
     "'sha256-dUpUK4yXR60CNDI/4ZeR/kpSqQ3HmniKj/Z7Hw9ZNTA='",
@@ -153,9 +153,7 @@ if GCS_MEDIA_ROOT_BUCKET:
     GS_BUCKET_NAME = GCS_MEDIA_ROOT_BUCKET
     GS_DEFAULT_ACL = 'publicRead'
     MEDIA_ROOT = False
-    media_storage_url = 'https://{bucket_name}.storage.googleapis.com/'.format(bucket_name=GS_BUCKET_NAME)
-    MEDIA_URL = media_storage_url
-    CSP_IMG_SRC = CSP_IMG_SRC + (media_storage_url,)
+    MEDIA_URL = 'https://storage.googleapis.com/{bucket_name}/'.format(bucket_name=GS_BUCKET_NAME)
 else:
     GENERATED_FILES_DIR = os.path.join(os.environ.get('STATIC_MEDIA_DIR', BASE_DIR), 'generated_files')
     MEDIA_ROOT = os.path.join(GENERATED_FILES_DIR, 'media/')


### PR DESCRIPTION
This PR adds a configuration option to use GCS to host the `MEDIA_ROOT` directory, with the goal of removing our dependence on a persistent GCP volume to store the data. This will enable us to redeploy seqr using more traditional kubernetes rollout semantics (which will be the way forward after #2344 )

If a `GCS_MEDIA_ROOT_BUCKET` isn't defined, the app will fall back to using a local directory for the `MEDIA_ROOT`, and will serve requests to `/media` with the builtin `django.views.static.serve` server. The intention here is for the behavior to remain unchanged for seqr local/docker-compose installs.