### PR TITLE
fix error on paginating large project searches

### DIFF
--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -596,7 +596,7 @@ class EsSearch(object):
         compound_het_results = self.previous_search_results.get('compound_het_results', [])
         loaded_counts = defaultdict(lambda: defaultdict(int))
         for response_hits, response_total, is_compound_het, index_name in parsed_responses:
-            if not response_total:
+            if not response_hits:
                 continue
 
             if is_compound_het:


### PR DESCRIPTION
There is an edge case when searching across many families in the same index where all the results for a subset of families have been loaded so `response_total` is a positive number but `response_hits` are empty