### PR TITLE
Upgrade ECK to 1.9.1 and ES to 7.16.3

### DIFF
--- a/deploy/kubernetes/shared-settings.yaml
+++ b/deploy/kubernetes/shared-settings.yaml
@@ -1,6 +1,6 @@
 #####################################################
 ####### SETTINGS THAT MAY NEED TO BE MODIFIED #######
-ELASTICSEARCH_VERSION: 7.15.2
+ELASTICSEARCH_VERSION: 7.16.3
 LINKERD_VERSION: 'stable-2.10.0'
 
 ES_DATA_DISK_TYPE: pd-ssd

--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -107,8 +107,6 @@ def deploy_secrets(settings, components=None):
 def deploy_elasticsearch(settings):
     print_separator("elasticsearch")
 
-    docker_build("elasticsearch", settings, ["--build-arg ELASTICSEARCH_SERVICE_PORT=%s" % settings["ELASTICSEARCH_SERVICE_PORT"]])
-
     if settings["ONLY_PUSH_TO_REGISTRY"]:
         return
 

--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -147,8 +147,8 @@ def deploy_elasticsearch(settings):
 def _set_elasticsearch_kubernetes_resources():
     has_kube_resource = run('kubectl explain elasticsearch', errors_to_ignore=["server doesn't have a resource type", "couldn't find resource for"])
     if not has_kube_resource:
-        run('kubectl create -f https://download.elastic.co/downloads/eck/1.8.0/crds.yaml')
-        run('kubectl apply -f https://download.elastic.co/downloads/eck/1.8.0/operator.yaml')
+        run('kubectl create -f https://download.elastic.co/downloads/eck/1.9.1/crds.yaml')
+        run('kubectl apply -f https://download.elastic.co/downloads/eck/1.9.1/operator.yaml')
 
 
 def deploy_elasticsearch_snapshot_config(settings):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
     volumes:
       - ./data/elasticsearch:/usr/share/elasticsearch/data
     container_name: elasticsearch
@@ -44,7 +44,7 @@ services:
 
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.15.2
+    image: docker.elastic.co/kibana/kibana:7.16.3
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
     depends_on:


### PR DESCRIPTION
This bumps elasticsearch to the latest ECK operator and 7.x elasticsearch release. I PR'd this against master, since I think this will likely get deployed without anything else; let me know if that's not the case.

There was also still a `docker_build()` call in the `deploy_elasticsearch()` method, which I removed since I believe we're no longer using our custom elasticsearch image.

I think the deploy steps here are just to run the servctl deploy command for elasticsearch. But, I haven't done this particular upgrade before, so if you can confirm that, please do 👍 

Closes https://github.com/broadinstitute/seqr-private/issues/1087