### PR TITLE
do not return information on 403 response

### DIFF
--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -184,7 +184,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
         invalid_url = reverse(get_individual_mme_matches, args=[INVALID_PROJECT_SUBMISSION_GUID])
         response = self.client.get(invalid_url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Matchmaker is not enabled')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
         response = self.client.get(url)
 

--- a/seqr/utils/middleware.py
+++ b/seqr/utils/middleware.py
@@ -97,6 +97,10 @@ class JsonErrorMiddleware(MiddlewareMixin):
         if isinstance(detail, dict):
             exception_json['detail'] = detail
 
+        if isinstance(exception, PermissionDenied):
+            logger.warning('PermissionDenied: {}'.format(exception_json['error']), request.user)
+            exception_json['error'] = 'Permission Denied'
+
         if request.path.startswith('/api'):
             return create_json_response(exception_json, status=status)
 

--- a/seqr/views/apis/auth_api_tests.py
+++ b/seqr/views/apis/auth_api_tests.py
@@ -93,7 +93,7 @@ class AuthAPITest(TestCase):
         url = reverse(login_view)
         response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Username/ password authentication is disabled')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     def test_logout_view(self):
         url = reverse(login_view)

--- a/seqr/views/apis/case_review_api_tests.py
+++ b/seqr/views/apis/case_review_api_tests.py
@@ -40,7 +40,7 @@ class CaseReviewAPITest(AuthenticationTestCase):
         url = reverse(save_internal_case_review_notes, args=[NO_CASE_REVIEW_FAMILY_GUID])
         response = self.client.post(url, content_type='application/json', data=json.dumps(req_values))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'User cannot edit case review for this project')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     def test_save_internal_case_review_summary(self):
         url = reverse(save_internal_case_review_summary, args=[FAMILY_GUID])
@@ -62,7 +62,7 @@ class CaseReviewAPITest(AuthenticationTestCase):
         url = reverse(save_internal_case_review_summary, args=[NO_CASE_REVIEW_FAMILY_GUID])
         response = self.client.post(url, content_type='application/json', data=json.dumps(req_values))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'User cannot edit case review for this project')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     @mock.patch('seqr.views.utils.json_to_orm_utils.timezone.now', lambda: datetime.strptime('2020-01-01', '%Y-%m-%d'))
     def test_update_case_review_status(self):
@@ -82,7 +82,7 @@ class CaseReviewAPITest(AuthenticationTestCase):
         url = reverse(update_case_review_status, args=[NO_CASE_REVIEW_INDIVIDUAL_GUID])
         response = self.client.post(url, content_type='application/json', data=json.dumps({'caseReviewStatus': 'A'}))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'User cannot edit case review for this project')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     def test_update_case_review_discussion(self):
         url = reverse(update_case_review_discussion, args=[INDIVIDUAL_GUID])
@@ -99,4 +99,4 @@ class CaseReviewAPITest(AuthenticationTestCase):
         url = reverse(update_case_review_discussion, args=[NO_CASE_REVIEW_INDIVIDUAL_GUID])
         response = self.client.post(url, content_type='application/json', data=json.dumps({'caseReviewDiscussion': 'A Note'}))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'User cannot edit case review for this project')
+        self.assertEqual(response.json()['error'], 'Permission Denied')

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -112,7 +112,7 @@ def delete_index(request):
         projects = {
             sample.individual.family.project.name for sample in active_index_samples.select_related('individual__family__project')
         }
-        return create_json_response({'error': 'Index "{}" is still used by: {}'.format(index, ', '.join(projects))}, status=403)
+        return create_json_response({'error': 'Index "{}" is still used by: {}'.format(index, ', '.join(projects))}, status=400)
 
     client = get_es_client()
     client.indices.delete(index)

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -302,7 +302,7 @@ class DataManagerAPITest(AuthenticationTestCase):
         self.check_data_manager_login(url)
 
         response = self.client.post(url, content_type='application/json', data=json.dumps({'index': 'test_index'}))
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 400)
         self.assertDictEqual(
             response.json(), ({'error': 'Index "test_index" is still used by: 1kg project n\xe5me with uni\xe7\xf8de'}))
         self.assertEqual(len(urllib3_responses.calls), 0)

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -305,20 +305,18 @@ class ReportAPITest(AuthenticationTestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'User has insufficient permission')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 
         unauthorized_project_url = reverse(anvil_export, args=[NO_ANALYST_PROJECT_GUID])
         response = self.client.get(unauthorized_project_url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.json()['error'], 'test_user does not have sufficient permissions for Non-Analyst Project')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.json()['error'], 'Error: To access airtable user must login with Google authentication.')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
         mock_google_authenticated.return_value = True
 
         responses.add(responses.GET, '{}/Samples'.format(AIRTABLE_URL), json=AIRTABLE_SAMPLE_RECORDS, status=200)
@@ -399,8 +397,7 @@ class ReportAPITest(AuthenticationTestCase):
         self.login_pm_user()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.json()['error'], 'Error: To access airtable user must login with Google authentication.')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
@@ -413,20 +410,18 @@ class ReportAPITest(AuthenticationTestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'User has insufficient permission')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
         mock_analyst_group.__bool__.return_value = True
         mock_analyst_group.resolve_expression.return_value = 'analysts'
 
         unauthorized_project_url = reverse(sample_metadata_export, args=[NO_ANALYST_PROJECT_GUID])
         response = self.client.get(unauthorized_project_url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.json()['error'], 'test_user does not have sufficient permissions for Non-Analyst Project')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.json()['error'], 'Error: To access airtable user must login with Google authentication.')
+        self.assertEqual( response.json()['error'], 'Permission Denied')
         mock_google_authenticated.return_value = True
 
         # Test invalid airtable responses
@@ -470,5 +465,4 @@ class ReportAPITest(AuthenticationTestCase):
         self.login_pm_user()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(
-            response.json()['error'], 'Error: To access airtable user must login with Google authentication.')
+        self.assertEqual(response.json()['error'], 'Permission Denied')

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -77,7 +77,7 @@ class UsersAPITest(object):
 
         response = self.client.post(create_url, content_type='application/json', data=json.dumps({}))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Adding collaborators directly in seqr is disabled. Users can be managed from the associated AnVIL workspace')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     @mock.patch('seqr.views.apis.users_api.logger')
     @mock.patch('django.contrib.auth.models.send_mail')
@@ -213,7 +213,7 @@ class UsersAPITest(object):
     def _test_password_auth_disabled(self, url):
         response = self.client.post(url, content_type='application/json', data=json.dumps({}))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Username/ password authentication is disabled')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
     @mock.patch('seqr.views.apis.users_api.SEQR_TOS_VERSION')
     @mock.patch('seqr.views.apis.users_api.SEQR_PRIVACY_VERSION')
@@ -316,12 +316,12 @@ class LocalUsersAPITest(AuthenticationTestCase, UsersAPITest):
     def _test_set_password(self, set_password_url, password): # pylint: disable=arguments-differ
         response = self.client.post(set_password_url, content_type='application/json', data=json.dumps({}))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Not authorized to update password')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
         response = self.client.post(set_password_url, content_type='application/json', data=json.dumps(
             {'userToken': 'invalid'}))
         self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Not authorized to update password')
+        self.assertEqual(response.json()['error'], 'Permission Denied')
 
         response = self.client.post(set_password_url, content_type='application/json', data=json.dumps(
             {'userToken': quote_plus(password)}))

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -20,7 +20,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_saved_search,\
     get_json_for_saved_searches, get_json_for_discovery_tags
 from seqr.views.utils.permissions_utils import check_project_permissions, get_project_guids_user_can_view, \
-    user_is_analyst, login_and_policies_required
+    user_is_analyst, login_and_policies_required, check_user_created_object_permissions
 from seqr.views.utils.project_context_utils import get_projects_child_entities
 from seqr.views.utils.variant_utils import get_variant_key, saved_variant_genes
 from settings import DEMO_PROJECT_CATEGORY
@@ -392,8 +392,7 @@ def create_saved_search_handler(request):
 @login_and_policies_required
 def update_saved_search_handler(request, saved_search_guid):
     search = VariantSearch.objects.get(guid=saved_search_guid)
-    if search.created_by != request.user:
-        return create_json_response({}, status=403, reason='User does not have permission to edit this search')
+    check_user_created_object_permissions(search, request.user)
 
     request_json = json.loads(request.body)
     name = request_json.pop('name', None)


### PR DESCRIPTION
Resolves security audit risk of disclosing too much information on a 403 response