### PR TITLE
add cron to seqr docker image

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -7,6 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-utils \
     bzip2 \
+    cron \
     curl \
     emacs \
     gcc \


### PR DESCRIPTION
It turns out cron has not been running since we updated out image in November

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Static assets have been built and committed if needed
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes:
  - [x] No changes to the required seqr infrastructure are included in this change 
  
  OR 
  
  - [x] Any changes to seqr's infrastructure are already been deployed to a new docker image, and these changes will be released via that image. All these changes have been tested before release on the docker image
  - [x] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [x] All these changes have bee vetted for potential vulnerabilities