### PR TITLE
ensure that we also push the latest docker tag on auto builds

### DIFF
--- a/.cloudbuild/seqr-docker.cloudbuild.yaml
+++ b/.cloudbuild/seqr-docker.cloudbuild.yaml
@@ -3,6 +3,7 @@ steps:
   args:
   - --destination=gcr.io/seqr-project/seqr:${COMMIT_SHA}
   - --destination=gcr.io/seqr-project/seqr:${_CUSTOM_BRANCH_TAG}
+  - --destination=gcr.io/seqr-project/seqr:latest
   - --dockerfile=deploy/docker/seqr/Dockerfile
   - --cache=true
   - --cache-ttl=168h


### PR DESCRIPTION
The cloudbuild file was only pushing the commit SHA tag and the `gcloud-{env}` tag (I had incorrectly assumed that cloudbuild would bump the `latest` tag on its own).

Let me know if there's other tags that we'd like to push. It looks like previously we were pushing a timestamp tag, but I'm unsure of what the utility of that was. Happy to add it if we'd like to keep it.