### PR TITLE
Add kubectl rollout/restart support to servctl

### DIFF
--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -42,17 +42,18 @@ cat ~/.pgpass
 
 # init seqrdb unless it already exists
 if ! psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -l | grep seqrdb; then
-
   psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE reference_data_db';
   psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE seqrdb';
-  python -u manage.py makemigrations
-  python -u manage.py migrate
-  python -u manage.py migrate --database=reference_data
-  python -u manage.py check
-  python -u manage.py loaddata variant_tag_types
-  python -u manage.py loaddata variant_searches
-  python -u manage.py update_all_reference_data --use-cached-omim
 fi
+
+# perform database migrations on container startup
+python -u manage.py makemigrations
+python -u manage.py migrate
+python -u manage.py migrate --database=reference_data
+python -u manage.py check
+python -u manage.py loaddata variant_tag_types
+python -u manage.py loaddata variant_searches
+python -u manage.py update_all_reference_data --use-cached-omim
 
 # launch django server in background
 /usr/local/bin/start_server.sh

--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -40,20 +40,22 @@ echo "*:*:*:*:$POSTGRES_PASSWORD" > ~/.pgpass
 chmod 600 ~/.pgpass
 cat ~/.pgpass
 
-# init seqrdb unless it already exists
+# init and populate seqrdb unless it already exists
 if ! psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -l | grep seqrdb; then
-  psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE reference_data_db';
-  psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE seqrdb';
+    psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE reference_data_db';
+    psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE seqrdb';
+    python -u manage.py migrate
+    python -u manage.py migrate --database=reference_data
+    python -u manage.py loaddata variant_tag_types
+    python -u manage.py loaddata variant_searches
+    python -u manage.py update_all_reference_data --use-cached-omim
+else
+    # run any pending migrations if the database already exists
+    python -u manage.py migrate
+    python -u manage.py migrate --database=reference_data
 fi
 
-# perform database migrations on container startup
-python -u manage.py makemigrations
-python -u manage.py migrate
-python -u manage.py migrate --database=reference_data
 python -u manage.py check
-python -u manage.py loaddata variant_tag_types
-python -u manage.py loaddata variant_searches
-python -u manage.py update_all_reference_data --use-cached-omim
 
 # launch django server in background
 /usr/local/bin/start_server.sh

--- a/deploy/kubectl_helpers/redeploy_seqr.sh
+++ b/deploy/kubectl_helpers/redeploy_seqr.sh
@@ -4,11 +4,4 @@ DIR=$(dirname "$BASH_SOURCE")
 
 set -x -e
 
-DEPLOYMENT_TARGET=$1
-
-POD_NAME=$("${DIR}"/utils/get_pod_name.sh "${DEPLOYMENT_TARGET}" seqr)
-
-kubectl exec "${POD_NAME}" -- git pull
-kubectl exec "${POD_NAME}" -- pip install -r requirements.txt
-kubectl exec "${POD_NAME}" -- ./manage.py migrate
-kubectl exec "${POD_NAME}" -- restart_server.sh
+kubectl rollout restart deployment/seqr


### PR DESCRIPTION
Until we have a more automated release pipeline, servctl needs to know how to issue a restart to the seqr deployment for cases when we are only deploying a new image. Right now, seqr will correctly restart itself after a kubectl apply if anything about the kubernetes manifests change. However, if we're deploying an update that is only a new docker image that's using a moving tag (i.e. gcloud-dev, or gcloud-prod), then kubernetes won't notice that the deployment needs to be restarted.

To get the new image deployed, our options are:
- to run the servctl deploy with the `-d` option to force the pod to get deleted and then recreated, which will cause some short downtime
- After the docker image updates, manually running a `kubectl rollout restart deployment/seqr`, which shouldn't incur any downtime

The change here adds a `-r / --rollout` option to servctl to try and take the second option there, which the person deploying can optionally pass when they know there's nothing being deployed that will trigger the pod to restart automatically.