### PR TITLE
fix trivy action to handle new docker build context expectations

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -13,7 +13,8 @@ jobs:
 
       - uses: broadinstitute/dsp-appsec-trivy-action@v1
         with:
-          context: deploy/docker/seqr
+          context: .
+          dockerfile: deploy/docker/seqr/Dockerfile
           sarif: trivy-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
We changed the docker build so that it expects the seqr code to be within the build context, which slightly changed how docker needs to be invoked. This updates the trivy config to align with those new build context expectations.