### PR TITLE
properly clear search form loading on success

### DIFF
--- a/ui/shared/components/form/FormWrapper.jsx
+++ b/ui/shared/components/form/FormWrapper.jsx
@@ -237,7 +237,7 @@ class FormWrapper extends React.PureComponent {
           <StyledForm
             onSubmit={confirmDialog ? this.showConfirmDialog : handleSubmit}
             size={size}
-            loading={submitting || loading}
+            loading={loading === undefined ? submitting : loading}
             hasSubmitButton={!submitOnChange}
             inline={inline}
           >

--- a/ui/shared/components/panel/search/VariantSearchFormContainer.jsx
+++ b/ui/shared/components/panel/search/VariantSearchFormContainer.jsx
@@ -2,12 +2,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
 import { navigateSavedHashedSearch } from 'redux/rootReducer'
-import { getSearchedVariantsErrorMessage } from 'redux/selectors'
+import { getSearchedVariantsErrorMessage, getSearchedVariantsIsLoading } from 'redux/selectors'
 import FormWrapper from 'shared/components/form/FormWrapper'
 import { toUniqueCsvString } from 'shared/utils/stringUtils'
 
-const VariantSearchFormContainer = React.memo(({ history, onSubmit, resultsPath, children, ...formProps }) => (
-  <FormWrapper onSubmit={onSubmit} submitButtonText="Search" noModal {...formProps}>
+const VariantSearchFormContainer = React.memo((
+  { history, onSubmit, resultsPath, loading, variantsLoading, children, ...formProps },
+) => (
+  <FormWrapper onSubmit={onSubmit} loading={loading || variantsLoading} submitButtonText="Search" noModal {...formProps}>
     {children}
   </FormWrapper>
 ))
@@ -17,9 +19,12 @@ VariantSearchFormContainer.propTypes = {
   history: PropTypes.object.isRequired,
   onSubmit: PropTypes.func,
   resultsPath: PropTypes.string,
+  loading: PropTypes.bool,
+  variantsLoading: PropTypes.bool,
 }
 
 const mapStateToProps = state => ({
+  variantsLoading: getSearchedVariantsIsLoading(state),
   submissionError: getSearchedVariantsErrorMessage(state),
 })
 


### PR DESCRIPTION
small bug introduced in the FormWrapper change, for the search form we want the loading spinner to be explicitly tied to the variants loading and not the internal submitting promise. The only place we explicitly pass a loading prop to the form is for the search form, so this gets the desired behavior