### PR TITLE
seqr stat breakup

### DIFF
--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -206,6 +206,7 @@ EXPECTED_SAMPLE_METADATA_ROW = {
 class ReportAPITest(AuthenticationTestCase):
     fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
 
+    @mock.patch('seqr.views.apis.report_api.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     def test_seqr_stats(self, mock_analyst_group):
@@ -220,10 +221,14 @@ class ReportAPITest(AuthenticationTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
-        self.assertSetEqual(set(response_json.keys()), {'individualCount', 'familyCount', 'sampleCountByType'})
-        self.assertEqual(response_json['individualCount'], 18)
-        self.assertEqual(response_json['familyCount'], 14)
-        self.assertDictEqual(response_json['sampleCountByType'], {'WES': 8, 'WGS': 1, 'RNA': 1})
+        self.assertSetEqual(set(response_json.keys()), {'projectsCount', 'individualsCount', 'familiesCount', 'sampleCountsByType'})
+        self.assertEqual(response_json['projectsCount'], {'internal': 3, 'external': 1})
+        self.assertEqual(response_json['individualsCount'], {'internal': 17, 'external': 1})
+        self.assertEqual(response_json['familiesCount'], {'internal': 13, 'external': 1})
+        self.assertDictEqual(
+            response_json['sampleCountsByType'],
+            {'WES__VARIANTS': {'internal': 8}, 'WES__SV': {'internal': 3}, 'WGS__SV': {'external': 1}, 'RNA__VARIANTS': {'internal': 1}},
+        )
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -18,7 +18,7 @@ import { ButtonLink, HelpIcon } from 'shared/components/StyledComponents'
 import {
   SAMPLE_TYPE_LOOKUP,
   GENOME_VERSION_LOOKUP,
-  DATASET_TYPE_SV_CALLS,
+  DATASET_TITLE_LOOKUP,
   ANVIL_URL,
 } from 'shared/utils/constants'
 import { updateProjectMmeContact, loadMmeSubmissions } from '../reducers'
@@ -37,8 +37,6 @@ import EditDatasetsButton from './EditDatasetsButton'
 const DetailContent = styled.div`
  padding: 5px 0px 0px 20px;
 `
-
-const DATASET_TITLE_LOOKUP = { [DATASET_TYPE_SV_CALLS]: ' SV' }
 
 const FAMILY_SIZE_LABELS = {
   0: plural => ` ${plural ? 'families' : 'family'} with no individuals`,

--- a/ui/pages/Report/components/SeqrStats.jsx
+++ b/ui/pages/Report/components/SeqrStats.jsx
@@ -4,26 +4,37 @@ import PropTypes from 'prop-types'
 import { Header, Table } from 'semantic-ui-react'
 
 import DataLoader from 'shared/components/DataLoader'
+import { DATASET_TITLE_LOOKUP } from 'shared/utils/constants'
 import { getSeqrStatsLoading, getSeqrStatsLoadingError, getSeqrStats } from '../selectors'
 import { loadSeqrStats } from '../reducers'
 
 const SeqrStats = React.memo(({ stats, error, loading, load }) => (
   <div>
-    <Header size="medium" content="Seqr Stats:" subheader="NOTE: counts are based on the total number of unique family/individual/sample ids" />
+    <Header size="large" content="Seqr Stats:" />
     <DataLoader load={load} content={Object.keys(stats).length} loading={loading} errorMessage={error}>
       <Table collapsing basic="very">
-        <Table.Row>
-          <Table.Cell textAlign="right"><b>Families</b></Table.Cell>
-          <Table.Cell>{stats.familyCount}</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <Table.Cell textAlign="right"><b>Individuals</b></Table.Cell>
-          <Table.Cell>{stats.individualCount}</Table.Cell>
-        </Table.Row>
-        {Object.entries(stats.sampleCountByType || {}).map(([sampleType, count]) => (
-          <Table.Row key={sampleType}>
-            <Table.Cell textAlign="right"><b>{`${sampleType} samples`}</b></Table.Cell>
-            <Table.Cell>{count}</Table.Cell>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell />
+            <Table.HeaderCell content="Internal Projects" />
+            <Table.HeaderCell content="External AnVIL Projects" />
+          </Table.Row>
+        </Table.Header>
+        {['Projects', 'Families', 'Individuals'].map(field => (
+          <Table.Row key={field}>
+            <Table.HeaderCell textAlign="right" content={field} />
+            <Table.Cell content={stats[`${field.toLowerCase()}Count`]?.internal} />
+            <Table.Cell content={stats[`${field.toLowerCase()}Count`]?.external} />
+          </Table.Row>
+        ))}
+        {Object.keys(stats.sampleCountsByType || {}).sort().map(sampleTypes => (
+          <Table.Row key={sampleTypes}>
+            <Table.HeaderCell
+              textAlign="right"
+              content={`${sampleTypes.split('__')[0]}${DATASET_TITLE_LOOKUP[sampleTypes.split('__')[1]] || ''} samples`}
+            />
+            <Table.Cell content={stats.sampleCountsByType[sampleTypes].internal} />
+            <Table.Cell content={stats.sampleCountsByType[sampleTypes].external} />
           </Table.Row>
         ))}
       </Table>

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -82,6 +82,8 @@ export const MATCHMAKER_CONTACT_URL_FIELD = {
 export const DATASET_TYPE_VARIANT_CALLS = 'VARIANTS'
 export const DATASET_TYPE_SV_CALLS = 'SV'
 
+export const DATASET_TITLE_LOOKUP = { [DATASET_TYPE_SV_CALLS]: ' SV' }
+
 export const SAMPLE_TYPE_EXOME = 'WES'
 export const SAMPLE_TYPE_GENOME = 'WGS'
 export const SAMPLE_TYPE_RNA = 'RNA'


### PR DESCRIPTION
Breaks up seqr stats based on internal projects vs external projects, and breaks apart sample counts by dataset type. No specific ticket, I just got frustrated by not being able to easily find these stats