### PR TITLE
remove ped image from discovery sheet

### DIFF
--- a/ui/pages/Report/constants.js
+++ b/ui/pages/Report/constants.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 
-import PedigreeImagePanel from 'shared/components/panel/view-pedigree-image/PedigreeImagePanel'
-
 const PROJECT_ID_FIELD = 'project_id'
 const FAMILY_FIELD_ID = 'family_id'
 
@@ -69,10 +67,8 @@ export const VARIANT_ANVIL_COLUMNS = [
 ]
 
 const formatT0 = row => new Date(row.t0).toISOString().slice(0, 10)
-const pedigreeImageFamily = row => ({ pedigreeImage: row.extras_pedigree_url })
 const formatFamilySummary = row => (
   <div>
-    <PedigreeImagePanel family={pedigreeImageFamily(row)} disablePedigreeZoom compact />
     <Link to={`/project/${row.project_guid}/family_page/${row.family_guid}`} target="_blank">{row.family_id}</Link>
     {row.extras_variant_tag_list &&
       <div>{row.extras_variant_tag_list.map(tag => <div><small>{tag}</small></div>)}</div>}


### PR DESCRIPTION
Breaks with the new pedigree image computation, and showing this wasn't really necessary/ helpful anyways since the purpose of this sheet is to download data and we weren;t downloading the image at all