### PR TITLE
Various nodejs fixes for the docker image

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -9,16 +9,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bzip2 \
     curl \
     gcc \
+    # git needed for the nodejs install
+    git \
     libc6-dev \
     libpq-dev \
-    nodejs \
-    npm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install nodejs14 repo since debian is still on node 12.x
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+# installs the nodejs and npm packages
+RUN apt-get install -y --no-install-recommends \
+    nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
 
@@ -29,13 +37,19 @@ RUN pip install --no-cache-dir wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     ln -s python3 /opt/venv/bin/python3.7
 
-WORKDIR /build
+WORKDIR /build/
+COPY ./ui/package.json ./ui/package.json
+COPY ./ui/package-lock.json ./ui/package-lock.json
+WORKDIR /build/ui
+RUN git config --global url."https://github.com/".insteadOf git@github.com: \
+    && git config --global url."https://".insteadOf ssh:// \
+    && npm ci
 
+WORKDIR /build/
 COPY ./ui ./ui
 
 WORKDIR /build/ui
-RUN npm ci && \
-    npm run build
+RUN npm run build
 
 FROM python:3.7-slim-bullseye as runtime
 

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get install -y --no-install-recommends \
     nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+# upgrade npm to v7 to fix lockfile resolution
+RUN npm install -g npm@7.24.2
 
 WORKDIR /opt
 
@@ -37,15 +39,14 @@ RUN pip install --no-cache-dir wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     ln -s python3 /opt/venv/bin/python3.7
 
-WORKDIR /build/
+# update nodejs modules on package lock updates
+WORKDIR /build
 COPY ./ui/package.json ./ui/package.json
 COPY ./ui/package-lock.json ./ui/package-lock.json
 WORKDIR /build/ui
-RUN git config --global url."https://github.com/".insteadOf git@github.com: \
-    && git config --global url."https://".insteadOf ssh:// \
-    && npm ci
+RUN npm ci
 
-WORKDIR /build/
+WORKDIR /build
 COPY ./ui ./ui
 
 WORKDIR /build/ui

--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -34,22 +34,20 @@ WORKDIR /opt
 
 COPY ./requirements.txt .
 
-# install seqr dependencies
+# install seqr python dependencies
 RUN pip install --no-cache-dir wheel && \
     pip install --no-cache-dir -r requirements.txt && \
     ln -s python3 /opt/venv/bin/python3.7
 
-# update nodejs modules on package lock updates
-WORKDIR /build
-COPY ./ui/package.json ./ui/package.json
-COPY ./ui/package-lock.json ./ui/package-lock.json
+# install seqr nodejs dependencies
 WORKDIR /build/ui
+# Copy the package configs from the build context -> the temporary build container, for generating node_modules
+COPY ./ui/package.json .
+COPY ./ui/package-lock.json .
 RUN npm ci
 
-WORKDIR /build
-COPY ./ui ./ui
+COPY ./ui/ .
 
-WORKDIR /build/ui
 RUN npm run build
 
 FROM python:3.7-slim-bullseye as runtime


### PR DESCRIPTION
Two goals on this one:

1. I wanted to separate the `npm ci` (install) step from the `npm build` step. This should make it so that the docker build won't have to reinstall all node_modules every time something in `ui/` changes. It should only have to do that when either the docker cache has expired, or if the package/package-lock change.
2. Upgrades node to 14.x, and npm to v7 to match our developer laptop env. This appears to fix the issues i mentioned at standup with regards to the lockfile that is being generated with npm v7.

    What's odd, is that the version of NPM we were getting from Debian was already v7, so it was able to handle the new lockfile, even with the older nodejs. The nodejs 14.x that comes from nodesource installs npm v6, which apparently couldn't handle the new lockfile, and is where the bug with trying to clone things over ssh cropped up. The previous workaround for that problem was to configure git to rewrite github URLs to https, but upgrading NPM seems to make that not required anymore (and it's probably the right move if we're using npm 7 on our developer laptops).

    So, long story short, if we want to continue using npm 7 and nodejs 14.x, this should do it.