### PR TITLE
Wait for postgres connectivity

### DIFF
--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -25,7 +25,7 @@ if [ -e "/.config/service-account-key.json" ]; then
     until [ "$retries" -ge 5 ]
     do
         gcloud auth activate-service-account --key-file /.config/service-account-key.json && break
-        retries=$((retries+1)) 
+        retries=$((retries+1))
         echo "gcloud auth failed. Retrying, attempt ${retries}/5"
         sleep 10
     done
@@ -39,6 +39,21 @@ cd /seqr
 echo "*:*:*:*:$POSTGRES_PASSWORD" > ~/.pgpass
 chmod 600 ~/.pgpass
 cat ~/.pgpass
+
+# wait for database connectivity, exit if we don't get it within ~2 minutes
+pg_retries=0
+until [ "$pg_retries" -ge 10 ]
+do
+    pg_isready -d postgres -h "$POSTGRES_SERVICE_HOSTNAME" -U postgres && break
+    pg_retries=$((pg_retries+1))
+    if [ "$pg_retries" -eq 10 ]; then
+        echo "Postgres database wasn't available after 10 connection attempts"
+        exit 1
+    else
+        echo "Unable to connect to postgres, retrying. Attempt ${pg_retries}/10"
+        sleep 12
+    fi
+done
 
 # init and populate seqrdb unless it already exists
 if ! psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -l | grep seqrdb; then


### PR DESCRIPTION
This adds an until/retry loop that uses the `pg_isready` command from postgresql-client to determine if the postgres database is accepting connections before proceeding with the entrypoint (which includes the db migration scripts). If it's unable to connect to the database within 2 minutes, it exits the entrypoint. If that happens, the container goes into an Error state, and kubernetes will keep trying to restart the container on the same host until the entrypoint succeeds (and going into a BackoffLoop to retry at greater intervals after that).

Closes #2549 