### PR TITLE
match ui to server permissions for project deletion

### DIFF
--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -61,6 +61,7 @@ class ProjectAPITest(object):
 
         project_guid = new_project.guid
         self.assertSetEqual(set(response.json()['projectsByGuid'].keys()), {project_guid})
+        self.assertTrue(response.json()['projectsByGuid'][project_guid]['userIsCreator'])
 
         # update the project. genome version and workspace should not update
         update_project_url = reverse(update_project_handler, args=[project_guid])

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -163,8 +163,10 @@ def get_json_for_projects(projects, user=None, is_analyst=None, add_project_cate
             ] if add_project_category_guids_field else [],
             'isMmeEnabled': result['isMmeEnabled'] and not result['isDemo'],
             'canEdit': has_project_permissions(project, user, can_edit=True),
+            'userIsCreator': project.created_by == user,
         })
 
+    prefetch_related_objects(projects, 'created_by')
     if add_project_category_guids_field:
         prefetch_related_objects(projects, 'projectcategory_set')
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -427,6 +427,7 @@ PROJECT_FIELDS = {
     'projectGuid', 'projectCategoryGuids', 'canEdit', 'name', 'description', 'createdDate', 'lastModifiedDate',
     'lastAccessedDate',  'mmeContactUrl', 'genomeVersion', 'mmePrimaryDataOwner', 'mmeContactInstitution',
     'isMmeEnabled', 'workspaceName', 'workspaceNamespace', 'hasCaseReview', 'enableHgmd', 'isDemo', 'allUserDemo',
+    'userIsCreator',
 }
 
 ANALYSIS_GROUP_FIELDS = {'analysisGroupGuid', 'description', 'name', 'projectGuid', 'familyGuids'}

--- a/ui/pages/Dashboard/components/ProjectEllipsisMenu.jsx
+++ b/ui/pages/Dashboard/components/ProjectEllipsisMenu.jsx
@@ -54,7 +54,7 @@ const ProjectEllipsisMenu = React.memo((props) => {
       <Dropdown.Divider key="divider1" />,
     )
   }
-  if (props.user.isDataManager) {
+  if (props.project.userIsCreator) {
     menuItems.push(
       <Dropdown.Divider key="divider2" />,
       <DeleteButton
@@ -81,13 +81,10 @@ const ProjectEllipsisMenu = React.memo((props) => {
 export { ProjectEllipsisMenu as ProjectEllipsisMenuComponent }
 
 ProjectEllipsisMenu.propTypes = {
-  user: PropTypes.object.isRequired,
   project: PropTypes.object.isRequired,
   updateProject: PropTypes.func.isRequired,
 }
 
-const mapStateToProps = state => ({ user: state.user })
-
 const mapDispatchToProps = { updateProject }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectEllipsisMenu)
+export default connect(null, mapDispatchToProps)(ProjectEllipsisMenu)


### PR DESCRIPTION
On the server side, projects can only be deleted by the person who created them, which is the desired behavior. This updates the front end code to show the "delete project" button to the correct users