### PR TITLE
Fix locus search dropdown, set dropdown to blank when an empty object is passed in as the locus list

### DIFF
--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -52,13 +52,14 @@ class BaseLocusListDropdown extends React.Component {
 
   render() {
     const { locusList, projectLocusListOptions } = this.props
+    const locusListGuid = locusList.locusListGuid || ""
     return (
       <div>
         <Dropdown
           inline
           selection
           label="Gene List"
-          value={locusList.locusListGuid}
+          value={locusListGuid}
           onChange={this.onChange}
           options={projectLocusListOptions}
         />


### PR DESCRIPTION
Passing in an undefined value to Dropdown does not select the blank option.
A string that matches one of the options must be passed up to BaseSemanticInput (and then semantic-ui-react). In this case a blank string works because there is a blank option in projectLocusListOptions.

This is for issue https://github.com/broadinstitute/seqr/issues/2601