### PR TITLE
add Created Date to LocusListTables and set it as the default sort column

### DIFF
--- a/ui/shared/components/table/LocusListTables.jsx
+++ b/ui/shared/components/table/LocusListTables.jsx
@@ -10,7 +10,7 @@ import { UpdateLocusListButton, DeleteLocusListButton } from '../buttons/LocusLi
 import { SelectableTableFormInput } from './DataTable'
 import { VerticalSpacer } from '../Spacers'
 import {
-  LOCUS_LIST_FIELDS, LOCUS_LIST_NAME_FIELD, LOCUS_LIST_NUM_ENTRIES_FIELD, LOCUS_LIST_LAST_MODIFIED_FIELD_NAME,
+  LOCUS_LIST_FIELDS, LOCUS_LIST_NAME_FIELD, LOCUS_LIST_NUM_ENTRIES_FIELD, LOCUS_LIST_CREATED_DATE_FIELD_NAME, LOCUS_LIST_LAST_MODIFIED_FIELD_NAME,
   LOCUS_LIST_DESCRIPTION_FIELD, LOCUS_LIST_IS_PUBLIC_FIELD_NAME, LOCUS_LIST_CURATOR_FIELD_NAME,
 } from '../../utils/constants'
 
@@ -33,7 +33,7 @@ const FIELD_LOOKUP = LOCUS_LIST_FIELDS.reduce(
   }), {},
 )
 
-const BASIC_FIELDS = [LOCUS_LIST_NAME_FIELD, LOCUS_LIST_DESCRIPTION_FIELD, LOCUS_LIST_NUM_ENTRIES_FIELD].map(
+const BASIC_FIELDS = [LOCUS_LIST_NAME_FIELD, LOCUS_LIST_DESCRIPTION_FIELD, LOCUS_LIST_CREATED_DATE_FIELD_NAME, LOCUS_LIST_NUM_ENTRIES_FIELD].map(
   field => FIELD_LOOKUP[field],
 )
 
@@ -44,7 +44,7 @@ const NAME_WITH_LINK_FIELD = {
 
 const CORE_FIELDS = [
   NAME_WITH_LINK_FIELD,
-  ...[LOCUS_LIST_NUM_ENTRIES_FIELD, LOCUS_LIST_DESCRIPTION_FIELD, LOCUS_LIST_LAST_MODIFIED_FIELD_NAME].map(
+  ...[LOCUS_LIST_NUM_ENTRIES_FIELD, LOCUS_LIST_DESCRIPTION_FIELD, LOCUS_LIST_CREATED_DATE_FIELD_NAME, LOCUS_LIST_LAST_MODIFIED_FIELD_NAME].map(
     field => FIELD_LOOKUP[field],
   ), { name: 'numProjects', content: 'Projects', width: 1, format: null },
 ]
@@ -83,7 +83,8 @@ const LocusListTables = React.memo(
         <Header size="large" dividing content={`${name} Gene Lists`} />
         <SelectableTableFormInput
           idField="locusListGuid"
-          defaultSortColumn="name"
+          defaultSortColumn="createdDate"
+          defaultSortDescending
           columns={basicFields ? BASIC_FIELDS : tableFields}
           data={tableData[name]}
           getRowFilterVal={getLocusListFilterVal}

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -407,6 +407,7 @@ export const LOCUS_LIST_NAME_FIELD = 'name'
 export const LOCUS_LIST_NUM_ENTRIES_FIELD = 'numEntries'
 export const LOCUS_LIST_DESCRIPTION_FIELD = 'description'
 export const LOCUS_LIST_IS_PUBLIC_FIELD_NAME = 'isPublic'
+export const LOCUS_LIST_CREATED_DATE_FIELD_NAME = 'createdDate'
 export const LOCUS_LIST_LAST_MODIFIED_FIELD_NAME = 'lastModifiedDate'
 export const LOCUS_LIST_CURATOR_FIELD_NAME = 'createdBy'
 
@@ -427,6 +428,12 @@ export const LOCUS_LIST_FIELDS = [
     validate: value => (value ? undefined : 'Description is required'),
     width: 9,
     isEditable: true,
+  },
+  {
+    name: LOCUS_LIST_CREATED_DATE_FIELD_NAME,
+    label: 'Created Date',
+    width: 3,
+    fieldDisplay: createdDate => new Date(createdDate).toLocaleString('en-US', { year: 'numeric', month: 'numeric', day: 'numeric', hour: 'numeric', minute: 'numeric' }),
   },
   {
     name: LOCUS_LIST_LAST_MODIFIED_FIELD_NAME,


### PR DESCRIPTION
I added the Created Date as a column to both the CORE_FIELDS and BASIC_FIELDS, so that it would show on both the summary page and the modal (when adding a gene list to a project).

I think it would also be useful to show the filter in the modal, since on the Broad instance there are over 600 public gene lists. That can be a sepearte issue & pull request or I can add it to this request, whichever you prefer.

This is for issue https://github.com/broadinstitute/seqr/issues/2603