### PR TITLE
Search util cleanup

### DIFF
--- a/seqr/utils/elasticsearch/es_gene_agg_search.py
+++ b/seqr/utils/elasticsearch/es_gene_agg_search.py
@@ -8,9 +8,9 @@ class EsGeneAggSearch(EsSearch):
     AGGREGATION_NAME = 'gene aggregation'
     CACHED_COUNTS_KEY = None
 
-    def search(self, **kwargs):
+    def search(self, *args, **kwargs):
         self._aggregate_by_gene()
-        return super(EsGeneAggSearch, self).search(**kwargs)
+        return super(EsGeneAggSearch, self).search(*args, **kwargs)
 
     def _aggregate_by_gene(self):
         searches = [self._search]

--- a/seqr/utils/elasticsearch/es_gene_agg_search.py
+++ b/seqr/utils/elasticsearch/es_gene_agg_search.py
@@ -8,7 +8,11 @@ class EsGeneAggSearch(EsSearch):
     AGGREGATION_NAME = 'gene aggregation'
     CACHED_COUNTS_KEY = None
 
-    def aggregate_by_gene(self):
+    def search(self, **kwargs):
+        self._aggregate_by_gene()
+        return super(EsGeneAggSearch, self).search(**kwargs)
+
+    def _aggregate_by_gene(self):
         searches = [self._search]
         for index_searches in self._index_searches.values():
             searches += [index_search for index_search in index_searches]

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -76,7 +76,7 @@ class EsSearch(object):
 
         self._sort = deepcopy(SORT_FIELDS.get(sort, [])) if sort else None
         if self._sort:
-            self._sort_variants(sort)
+            self._sort_variants()
 
     @staticmethod
     def _parse_xstop(result):
@@ -176,7 +176,7 @@ class EsSearch(object):
         self._set_index_name()
         return self
 
-    def _sort_variants(self, sort):
+    def _sort_variants(self):
         main_sort_dict = self._sort[0] if len(self._sort) and isinstance(self._sort[0], dict) else None
 
         # Add parameters to scripts

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -76,7 +76,7 @@ class EsSearch(object):
 
         self._sort = deepcopy(SORT_FIELDS.get(sort, [])) if sort else None
         if self._sort:
-            self._sort_search(sort)
+            self._sort_variants(sort)
 
     @staticmethod
     def _parse_xstop(result):
@@ -176,7 +176,7 @@ class EsSearch(object):
         self._set_index_name()
         return self
 
-    def _sort_search(self, sort):
+    def _sort_variants(self, sort):
         main_sort_dict = self._sort[0] if len(self._sort) and isinstance(self._sort[0], dict) else None
 
         # Add parameters to scripts

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -210,6 +210,33 @@ class EsSearch(object):
         self._search = self._search.filter(new_filter)
         return self
 
+    def filter_variants(self, inheritance=None, genes=None, intervals=None, rs_ids=None, variant_ids=None, locus=None,
+                        frequencies=None, pathogenicity=None, in_silico=None, annotations=None, annotations_secondary=None,
+                        quality_filter=None, custom_query=None, skip_genotype_filter=False):
+        has_location_filter = genes or intervals or rs_ids or variant_ids
+
+        if custom_query:
+            if not isinstance(custom_query, list):
+                custom_query = [custom_query]
+            for q_dict in custom_query:
+                self._filter(Q(q_dict))
+
+        if has_location_filter:
+            self.filter_by_location(
+                genes=genes, intervals=intervals, rs_ids=rs_ids, variant_ids=variant_ids, locus=locus)
+
+        if frequencies:
+            self.filter_by_frequency(frequencies, pathogenicity=pathogenicity)
+
+        if in_silico:
+            self.filter_by_in_silico(in_silico)
+
+        self.filter_by_annotation_and_genotype(
+            inheritance, quality_filter=quality_filter,
+            annotations=annotations, annotations_secondary=annotations_secondary,
+            pathogenicity=pathogenicity, skip_genotype_filter=skip_genotype_filter,
+            has_location_filter=has_location_filter)
+
     def filter_by_in_silico(self, in_silico_filters):
         in_silico_filters = {k: v for k, v in in_silico_filters.items() if v is not None and len(v) != 0}
         if in_silico_filters:

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -259,14 +259,7 @@ class EsSearch(object):
                     self.update_dataset_type(comp_het_dataset_type)
                 return
 
-        pathogenicity_filter = _pathogenicity_filter(pathogenicity or {})
-        splice_ai_filter = _in_silico_filter({SPLICE_AI_FIELD: splice_ai}, allow_missing=False) if splice_ai else None
-        if pathogenicity_filter and splice_ai_filter:
-            annotation_override_filter = _or_filters([pathogenicity_filter, splice_ai_filter])
-        else:
-            annotation_override_filter = pathogenicity_filter or splice_ai_filter
-
-        dataset_type = self._filter_by_annotations(annotations, annotation_override_filter, new_svs)
+        dataset_type = self._filter_by_annotations(annotations, pathogenicity, splice_ai, new_svs)
 
         if skip_genotype_filter and not inheritance_mode:
             return
@@ -322,8 +315,16 @@ class EsSearch(object):
 
         self._filter(q)
 
-    def _filter_by_annotations(self, annotations, annotation_override_filter, new_svs):
+    def _filter_by_annotations(self, annotations, pathogenicity, splice_ai, new_svs):
         dataset_type = None
+
+        pathogenicity_filter = _pathogenicity_filter(pathogenicity or {})
+        splice_ai_filter = _in_silico_filter({SPLICE_AI_FIELD: splice_ai}, allow_missing=False) if splice_ai else None
+        if pathogenicity_filter and splice_ai_filter:
+            annotation_override_filter = _or_filters([pathogenicity_filter, splice_ai_filter])
+        else:
+            annotation_override_filter = pathogenicity_filter or splice_ai_filter
+
         if self._allowed_consequences:
             consequences_filter = _annotations_filter(self._allowed_consequences)
 

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -226,23 +226,23 @@ class EsSearch(object):
                 genes=genes, intervals=intervals, rs_ids=rs_ids, variant_ids=variant_ids, locus=locus)
 
         if frequencies:
-            self.filter_by_frequency(frequencies, pathogenicity=pathogenicity)
+            self._filter_by_frequency(frequencies, pathogenicity=pathogenicity)
 
         if in_silico:
-            self.filter_by_in_silico(in_silico)
+            self._filter_by_in_silico(in_silico)
 
-        self.filter_by_annotation_and_genotype(
+        self._filter_by_annotation_and_genotype(
             inheritance, quality_filter=quality_filter,
             annotations=annotations, annotations_secondary=annotations_secondary,
             pathogenicity=pathogenicity, skip_genotype_filter=skip_genotype_filter,
             has_location_filter=has_location_filter)
 
-    def filter_by_in_silico(self, in_silico_filters):
+    def _filter_by_in_silico(self, in_silico_filters):
         in_silico_filters = {k: v for k, v in in_silico_filters.items() if v is not None and len(v) != 0}
         if in_silico_filters:
             self._filter(_in_silico_filter(in_silico_filters))
 
-    def filter_by_frequency(self, frequencies, pathogenicity=None):
+    def _filter_by_frequency(self, frequencies, pathogenicity=None):
         clinvar_path_filters = [
             f for f in (pathogenicity or {}).get('clinvar', [])
             if f in {CLINVAR_PATH_FILTER, CLINVAR_LIKELY_PATH_FILTER}
@@ -319,7 +319,7 @@ class EsSearch(object):
             self._filtered_variant_ids = variant_id_genome_versions
         return self
 
-    def filter_by_annotation_and_genotype(self, inheritance, quality_filter=None, annotations=None, annotations_secondary=None, pathogenicity=None, skip_genotype_filter=False, has_location_filter=False):
+    def _filter_by_annotation_and_genotype(self, inheritance, quality_filter=None, annotations=None, annotations_secondary=None, pathogenicity=None, skip_genotype_filter=False, has_location_filter=False):
         has_previous_compound_hets = self.previous_search_results.get('grouped_results')
 
         inheritance_mode = (inheritance or {}).get('mode')

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -547,12 +547,12 @@ class EsSearch(object):
             }
         return INHERITANCE_FILTERS[COMPOUND_HET]
 
-    def search(self,  **kwargs):
+    def search(self, page=1, num_results=100):
         indices = self._indices
 
         logger.info('Searching in elasticsearch indices: {}'.format(', '.join(indices)), self._user)
 
-        is_single_search, search_kwargs = self._should_execute_single_search(**kwargs)
+        is_single_search, search_kwargs = self._should_execute_single_search(page=page, num_results=num_results)
 
         if is_single_search:
             return self._execute_single_search(**search_kwargs)

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -1806,9 +1806,7 @@ class EsUtilsTest(TestCase):
             'total_results': 1,
         })
 
-        annotation_query = {'bool': {'should': [
-            {'terms': {'transcriptConsequenceTerms': ['frameshift_variant']}},
-            {'terms': {'transcriptConsequenceTerms': ['frameshift_variant', 'intron']}}]}}
+        annotation_query = {'terms': {'transcriptConsequenceTerms': ['frameshift_variant', 'intron']}}
 
         self.assertExecutedSearch(
             filters=[annotation_query, COMPOUND_HET_INHERITANCE_QUERY],
@@ -1836,9 +1834,7 @@ class EsUtilsTest(TestCase):
         self.assertIsNone(variants)
         self.assertEqual(total_results, 0)
 
-        annotation_query = {'bool': {'should': [
-            {'terms': {'transcriptConsequenceTerms': ['frameshift_variant']}},
-            {'terms': {'transcriptConsequenceTerms': ['intron']}}]}}
+        annotation_query = {'terms': {'transcriptConsequenceTerms': ['frameshift_variant', 'intron']}}
 
         self.assertExecutedSearch(
             filters=[annotation_query, COMPOUND_HET_INHERITANCE_QUERY],
@@ -2087,10 +2083,7 @@ class EsUtilsTest(TestCase):
 
         get_es_variants(results_model, num_results=10)
 
-        annotation_secondary_query = {'bool': {'should': [
-            {'terms': {'transcriptConsequenceTerms': ['gCNV_DEL']}},
-            {'terms': {'transcriptConsequenceTerms': ['frameshift_variant']}},
-        ]}}
+        annotation_secondary_query = {'terms': {'transcriptConsequenceTerms': ['frameshift_variant', 'gCNV_DEL']}}
 
         self.assertExecutedSearches([
             dict(

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -110,7 +110,6 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, sk
     es_search = es_search_cls(
         search_model.families.all(),
         previous_search_results=previous_search_results,
-        inheritance_search=search.get('inheritance'),
         user=user,
         sort=sort,
     )

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 import elasticsearch
-from elasticsearch_dsl import Q
 
 from settings import ELASTICSEARCH_SERVICE_HOSTNAME, ELASTICSEARCH_SERVICE_PORT, ELASTICSEARCH_CREDENTIALS, ELASTICSEARCH_PROTOCOL, ES_SSL_CONTEXT
 from seqr.models import Sample

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -119,7 +119,7 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, sk
         if not isinstance(custom_q, list):
             custom_q = [custom_q]
         for q_dict in custom_q:
-            es_search.filter(Q(q_dict))
+            es_search._filter(Q(q_dict))
 
     if has_location_filter:
         es_search.filter_by_location(

--- a/seqr/utils/elasticsearch/utils.py
+++ b/seqr/utils/elasticsearch/utils.py
@@ -112,6 +112,7 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, sk
         previous_search_results=previous_search_results,
         inheritance_search=search.get('inheritance'),
         user=user,
+        sort=sort,
     )
 
     if search.get('customQuery'):
@@ -120,9 +121,6 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, sk
             custom_q = [custom_q]
         for q_dict in custom_q:
             es_search.filter(Q(q_dict))
-
-    if sort:
-        es_search.sort(sort)
 
     if has_location_filter:
         es_search.filter_by_location(
@@ -141,9 +139,6 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, sk
         annotations=search.get('annotations'), annotations_secondary=search.get('annotations_secondary'),
         pathogenicity=search.get('pathogenicity'), skip_genotype_filter=skip_genotype_filter,
         has_location_filter=has_location_filter)
-
-    if hasattr(es_search, 'aggregate_by_gene'):
-        es_search.aggregate_by_gene()
 
     variant_results = es_search.search(**search_kwargs)
 


### PR DESCRIPTION
This cleans up the utility functions/ classes for search. This will help with eventually swapping out the backend, and in the mean time cleans up the code to make behavior/ data flow cleaner. The biggest change is moving the logic for filtering variants to a single `filter_variants` helper in the search class itself, rather than keeping that logic in the utility function. As the logic complicated over time, that logic became more complex/ interconnected and it makes more sense to abstract it out