### PR TITLE
Use longer placeholder text, to make the Project Category dropdown wider

### DIFF
--- a/ui/pages/Dashboard/components/FilterSelector.jsx
+++ b/ui/pages/Dashboard/components/FilterSelector.jsx
@@ -9,7 +9,7 @@ import { getProjectFilter, getCategoryOptions } from '../selectors'
 
 const FilterContainer = styled.span`
   display: inline-block;
-  min-width: 8em;
+  min-width: 14em;
   font-size: 12px;
 `
 

--- a/ui/pages/Dashboard/selectors.js
+++ b/ui/pages/Dashboard/selectors.js
@@ -41,7 +41,7 @@ export const getVisibleProjects = createSelector(
 export const getCategoryOptions = createSelector(
   getProjectCategoriesByGuid,
   projectCategoriesByGuid => ([
-    { value: SHOW_ALL, text: 'All', key: SHOW_ALL },
+    { value: SHOW_ALL, text: 'All project categories', key: SHOW_ALL },
     { value: SHOW_DEMO, text: 'Demo', key: SHOW_DEMO },
     ...Object.values(projectCategoriesByGuid).map(
       projectCategory => ({ value: projectCategory.guid, text: projectCategory.name, key: projectCategory.guid }),


### PR DESCRIPTION
This PR is a simpler version which just uses longer placeholder text, no weird CSS.

Changing the placeholder text to "All project categories" is a natural way to make the select field wider, while also giving users more context on what the field is for.

The increase to 14em vs 8em should be enough to accomodate any long word used in a category title.

For issue #2615