### PR TITLE
Fix static assets for local dvelopment

### DIFF
--- a/seqr/views/react_app.py
+++ b/seqr/views/react_app.py
@@ -33,7 +33,14 @@ def no_login_main_app(request, *args, **kwargs):
 
 def render_app_html(request, additional_json=None, include_user=True, status=200):
     html = loader.render_to_string('app.html')
-    ui_version = re.search('static/app-(.*)\.js', html).group(1)
+
+    app_js_script = re.search('static/app-(.*)\.js', html)
+    if app_js_script:
+        ui_version = app_js_script.group(1)
+    else:
+        ui_version = 'local'
+        html = html.replace('</head>', '<script defer="defer" src="/app.js"></script></head>')
+
     initial_json = {'meta':  {
         'version': '{}-{}'.format(SEQR_VERSION, ui_version),
         'hijakEnabled': DEBUG or False,
@@ -65,9 +72,5 @@ def render_app_html(request, additional_json=None, include_user=True, status=200
             'window.gaTrackingId=null',
             'window.gaTrackingId="{}"'.format(GA_TOKEN_ID),
         )
-
-    if request.get_host() == 'localhost:3000':
-        html = re.sub(r'static/app(-[^\.]*).js', 'app.js', html)
-        html = re.sub(r'<link\s+href="/static/app.*css"[^>]*>', '', html)
 
     return HttpResponse(html, content_type="text/html", status=status)

--- a/seqr/views/react_app_tests.py
+++ b/seqr/views/react_app_tests.py
@@ -30,8 +30,6 @@ class DashboardPageTest(AuthenticationTestCase):
 
         # test static assets are correctly loaded
         content = response.content.decode('utf-8')
-        self.assertRegex(content, r'src="/static/app(-.*)js"')
-        self.assertRegex(content, r'<link\s+href="/static/app.*css"[^>]*>')
         self.assertEqual(content.count('<script type="text/javascript" nonce="{}">'.format(nonce)), 5)
 
     @mock.patch('seqr.views.react_app.GA_TOKEN_ID', MOCK_GA_TOKEN)

--- a/settings.py
+++ b/settings.py
@@ -130,25 +130,6 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-        'DIRS': [
-            os.path.join(BASE_DIR, 'ui/dist'),
-        ],
-        'OPTIONS': {
-            'context_processors': [
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',  # required for admin template
-                'django.template.context_processors.request',   # must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin navigation sidebar
-                'social_django.context_processors.backends',  # required for social_auth, same for below
-                'social_django.context_processors.login_redirect',
-            ],
-        },
-    },
-]
-
 # If specified, store data in the named GCS bucket and use the gcloud storage backend.
 # Else, fall back to a path on the local filesystem.
 GCS_MEDIA_ROOT_BUCKET = os.environ.get('GCS_MEDIA_ROOT_BUCKET')
@@ -255,6 +236,10 @@ ANYMAIL = {
     "POSTMARK_SERVER_TOKEN": os.environ.get('POSTMARK_SERVER_TOKEN', 'postmark-server-token-placeholder'),
 }
 
+TEMPLATE_DIRS = [
+    os.path.join(BASE_DIR, 'ui/dist'),
+]
+
 DEPLOYMENT_TYPE = os.environ.get('DEPLOYMENT_TYPE')
 if DEPLOYMENT_TYPE in {'prod', 'dev'}:
     SESSION_COOKIE_SECURE = True
@@ -277,6 +262,24 @@ else:
     HIJACK_DISPLAY_WARNING = True
     HIJACK_ALLOW_GET_REQUESTS = True
     HIJACK_LOGIN_REDIRECT_URL = '/'
+    TEMPLATE_DIRS.append('ui')
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': TEMPLATE_DIRS,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',  # required for admin template
+                'django.template.context_processors.request',   # must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin navigation sidebar
+                'social_django.context_processors.backends',  # required for social_auth, same for below
+                'social_django.context_processors.login_redirect',
+            ],
+        },
+    },
+]
 
 #########################################################
 #  seqr specific settings


### PR DESCRIPTION
We can no longer uses the compiled `app.html` for local development since it doesn't exist so this instead updates seqr to use use the non-compiled `app.html` template for local development and updates tests accordingly