### PR TITLE
fix sv type mapping

### DIFF
--- a/seqr/utils/elasticsearch/constants.py
+++ b/seqr/utils/elasticsearch/constants.py
@@ -224,7 +224,7 @@ SORT_FIELDS = {
         '_script': {
             'type': 'number',
             'script': {
-               'source': "(doc.containsKey('svType') && doc['svType'].value == 'BND') ? -50 : doc['start'].value - doc['end'].value"
+               'source': "(doc.containsKey('svType') && (doc['svType'].value == 'BND' || doc['svType'].value == 'CTX')) ? -50 : doc['start'].value - doc['end'].value"
             }
         }
     }],

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -526,9 +526,9 @@ const VEP_SV_TYPES = [
     value: 'DUP',
   },
   {
-    description: 'A translocation variant',
+    description: 'A chromosomal translocation',
     text: 'Translocation',
-    value: 'BND',
+    value: 'CTX',
   },
   {
     description: 'A copy number polymorphism variant',
@@ -541,11 +541,6 @@ const VEP_SV_TYPES = [
     value: 'CPX',
   },
   {
-    description: 'A reciprocal chromosomal translocation',
-    text: 'Reciprocal Translocation',
-    value: 'CTX',
-  },
-  {
     description: 'A large insertion',
     text: 'Insertion',
     value: 'INS',
@@ -554,6 +549,11 @@ const VEP_SV_TYPES = [
     description: 'A large inversion',
     text: 'Inversion',
     value: 'INV',
+  },
+  {
+    description: 'An unresolved structural event',
+    text: 'Breakend',
+    value: 'BND',
   },
 ]
 


### PR DESCRIPTION
It turns out wires got crossed at some point and we got the mapping of SV types in seqr wrong. See this slack conversation withe Harrison in which he explains that BNDs are not, in fact, transloactions: https://the-tgg.slack.com/archives/CT1J8AGES/p1649436053460989