### PR TITLE
all project search context for data managers

### DIFF
--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -86,7 +86,10 @@ def _get_or_create_results_model(search_hash, search_context, user):
             families = Family.objects.filter(guid__in=all_families)
         elif _is_all_project_family_search(search_context):
             omit_projects = [p.guid for p in Project.objects.filter(is_demo=True).only('guid')]
-            project_guids = [project_guid for project_guid in get_project_guids_user_can_view(user) if project_guid not in omit_projects]
+            project_guids = [
+                project_guid for project_guid in get_project_guids_user_can_view(user, limit_data_manager=True)
+                if project_guid not in omit_projects
+            ]
             families = Family.objects.filter(project__guid__in=project_guids)
         elif search_context.get('projectGuids'):
             families = Family.objects.filter(project__guid__in=search_context['projectGuids'])

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -439,16 +439,25 @@ class VariantSearchAPITest(object):
         }))
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
-        self.assertDictEqual(response_json, {
+        empty_search_response = {
             'searchedVariants': [], 'search': {
                 'search': SEARCH,
                 'projectFamilies': [],
                 'totalResults': 0,
-        }})
+        }}
+        self.assertDictEqual(response_json, empty_search_response)
         results_model = VariantSearchResults.objects.get(search_hash=SEARCH_HASH)
         mock_get_variants.assert_called_with(results_model, sort='xpos', page=1, num_results=100, skip_genotype_filter=True, user=self.no_access_user)
 
-        results_model.delete()
+        VariantSearchResults.objects.filter(search_hash=SEARCH_HASH).delete()
+        self.login_data_manager_user()
+        response = self.client.post(url, content_type='application/json', data=json.dumps({
+            'allProjectFamilies': True, 'search': SEARCH
+        }))
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), empty_search_response)
+
+        VariantSearchResults.objects.filter(search_hash=SEARCH_HASH).delete()
         self.login_collaborator()
         expected_searched_families = {
             'F000001_1', 'F000002_2', 'F000003_3', 'F000004_4', 'F000005_5', 'F000006_6', 'F000007_7', 'F000008_8',

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -189,14 +189,14 @@ def _get_analyst_projects():
     return ProjectCategory.objects.get(name=ANALYST_PROJECT_CATEGORY).projects.all()
 
 
-def get_project_guids_user_can_view(user):
+def get_project_guids_user_can_view(user, limit_data_manager=False):
     cache_key = 'projects__{}'.format(user)
     project_guids = safe_redis_get_json(cache_key)
     if project_guids is not None:
         return project_guids
 
     is_data_manager = user_is_data_manager(user)
-    if is_data_manager:
+    if is_data_manager and not limit_data_manager:
         projects = Project.objects.all()
     else:
         projects = get_local_access_projects(user)


### PR DESCRIPTION
For the "all project" search we actually don't want to include variants from AnVIL-only projects for the data managers. We only have access to those projects for the purposes of loading and debugging so we shouldn't be getting variants back from those projects in any standard search. If a data manager really needs to debug a search issue on an AnVIL project, they can still do searches directly in that project