### PR TITLE
Panel app gene search cleanup

### DIFF
--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -27,11 +27,10 @@ class BaseLocusListDropdown extends React.Component {
 
     if (prevProps.locusList.rawItems !== locusList.rawItems) {
       const { locusListGuid } = locusList
-      let panelAppItems
 
       if (locusList.paLocusList) {
         const CONFIDENCE_COLORS = { 0: 'none', 1: 'red', 2: 'amber', 3: 'green', 4: 'green' } // TODO constant
-        panelAppItems = locusList.items?.reduce((acc, item) => {
+        const panelAppItems = locusList.items?.reduce((acc, item) => {
           const color = CONFIDENCE_COLORS[item.pagene?.confidenceLevel || 0]
           if (color in acc) {
             acc[color] = [acc[color], item.display].filter(val => val).join(', ')

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -27,11 +27,11 @@ class BaseLocusListDropdown extends React.Component {
 
     if (prevProps.locusList.rawItems !== locusList.rawItems) {
       const { locusListGuid } = locusList
-      let { rawItems } = locusList
+      let panelAppItems
 
       if (locusList.paLocusList) {
-        const CONFIDENCE_COLORS = { 0: 'none', 1: 'red', 2: 'amber', 3: 'green', 4: 'green' }
-        rawItems = locusList.items?.reduce((acc, item) => {
+        const CONFIDENCE_COLORS = { 0: 'none', 1: 'red', 2: 'amber', 3: 'green', 4: 'green' } // TODO constant
+        panelAppItems = locusList.items?.reduce((acc, item) => {
           const color = CONFIDENCE_COLORS[item.pagene?.confidenceLevel || 0]
           if (color in acc) {
             acc[color] = [acc[color], item.display].filter(val => val).join(', ')
@@ -39,9 +39,11 @@ class BaseLocusListDropdown extends React.Component {
 
           return acc
         }, { green: '', amber: '', red: '', none: '' })
+        onChange({ locusListGuid, panelAppItems })
+      } else {
+        const { rawItems } = locusList
+        onChange({ locusListGuid, rawItems })
       }
-
-      onChange({ locusListGuid, rawItems })
     }
   }
 

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { FormSpy } from 'react-final-form'
 import { Dropdown } from 'shared/components/form/Inputs'
 import { LocusListItemsLoader } from 'shared/components/LocusListLoader'
+import { PANEL_APP_CONFIDENCE_LEVELS } from 'shared/utils/constants'
 import { getSearchedProjectsLocusListOptions } from '../../selectors'
 
 class BaseLocusListDropdown extends React.Component {
@@ -29,15 +30,10 @@ class BaseLocusListDropdown extends React.Component {
       const { locusListGuid } = locusList
 
       if (locusList.paLocusList) {
-        const CONFIDENCE_COLORS = { 0: 'none', 1: 'red', 2: 'amber', 3: 'green', 4: 'green' } // TODO constant
         const panelAppItems = locusList.items?.reduce((acc, item) => {
-          const color = CONFIDENCE_COLORS[item.pagene?.confidenceLevel || 0]
-          if (color in acc) {
-            acc[color] = [acc[color], item.display].filter(val => val).join(', ')
-          }
-
-          return acc
-        }, { green: '', amber: '', red: '', none: '' })
+          const color = PANEL_APP_CONFIDENCE_LEVELS[item.pagene?.confidenceLevel] || PANEL_APP_CONFIDENCE_LEVELS[0]
+          return { ...acc, [color]: [acc[color], item.display].filter(val => val).join(', ') }
+        }, {})
         onChange({ locusListGuid, panelAppItems })
       } else {
         const { rawItems } = locusList

--- a/ui/shared/components/panel/search/LocusListItemsFilter.jsx
+++ b/ui/shared/components/panel/search/LocusListItemsFilter.jsx
@@ -1,20 +1,12 @@
 import PropTypes from 'prop-types'
-import React, { useCallback } from 'react'
-import { Icon, Popup } from 'semantic-ui-react'
+import React from 'react'
+import { FormSpy } from 'react-final-form'
+
 import { BaseSemanticInput } from 'shared/components/form/Inputs'
 import { ColoredIcon } from 'shared/components/StyledComponents'
 import { PANEL_APP_CONFIDENCE_DESCRIPTION, PANEL_APP_CONFIDENCE_LEVEL_COLORS } from 'shared/utils/constants'
-import { camelcaseToTitlecase } from 'shared/utils/stringUtils'
 
-const PA_POPUP_HELP = (
-  <Popup
-    trigger={<Icon name="question circle outline" />}
-    content="A list of genes, can be separated by commas or whitespace."
-    size="small"
-    position="top center"
-  />
-)
-const PA_ICON_PROPS = Object.entries({ 1: 'red', 2: 'amber', 3: 'green' }).reduce((acc, [confidence, color]) => ({
+const PA_ICON_PROPS = Object.entries({ 1: 'red', 2: 'amber', 3: 'green' }).reduce((acc, [confidence, color]) => ({ // TODO constant
   ...acc,
   [color]: {
     name: 'circle',
@@ -23,65 +15,30 @@ const PA_ICON_PROPS = Object.entries({ 1: 'red', 2: 'amber', 3: 'green' }).reduc
   },
 }), {})
 
-const PanelAppItemsFilter = ({ color, value, onChange, ...props }) => {
-  const onChangeInner = useCallback((colorVal) => {
-    onChange({ ...value, [color]: colorVal })
-  })
+const SUBSCRIPTION = { values: true }
 
-  const label = `${camelcaseToTitlecase(color)} Genes`
-  const iconLabel = color === 'none' ?
-    (
-      <label>
-        Genes
-        &nbsp;
-        {PA_POPUP_HELP}
-      </label>
-    ) :
-    (
-      <label>
-        <ColoredIcon {...PA_ICON_PROPS[color]} />
-        {label}
-        &nbsp;
-        {PA_POPUP_HELP}
-      </label>
-    )
-
-  return (
-    <BaseSemanticInput
-      {...props}
-      inputType="TextArea"
-      width={3}
-      label={iconLabel}
-      value={value[color]}
-      onChange={onChangeInner}
-    />
-  )
-}
-
-PanelAppItemsFilter.propTypes = {
-  color: PropTypes.string,
-  value: PropTypes.object,
-  onChange: PropTypes.func,
-}
-
-export const LocusListItemsFilter = ({ ...props }) => {
-  const { value } = props
-
-  return value && typeof value === 'object' ?
-    [
-      <PanelAppItemsFilter {...props} key="green" color="green" name="rawItems.green" />,
-      <PanelAppItemsFilter {...props} key="amber" color="amber" name="rawItems.amber" />,
-      <PanelAppItemsFilter {...props} key="red" color="red" name="rawItems.red" />,
-      <PanelAppItemsFilter {...props} key="none" color="none" name="rawItems.none" />,
-    ] :
-    (
-      <BaseSemanticInput {...props} inputType="TextArea" />
-    )
-}
+const LocusListItemsFilter = ({ shouldShow, iconColor, label, ...props }) => (
+  <FormSpy subscription={SUBSCRIPTION}>
+    {({ values }) => shouldShow(values?.search?.locus || {}) && (
+      <BaseSemanticInput
+        inputType="TextArea"
+        rows={8}
+        label={PA_ICON_PROPS[iconColor] ? (
+          <label>
+            <ColoredIcon {...PA_ICON_PROPS[iconColor]} />
+            {label}
+          </label>
+        ) : label}
+        {...props}
+      />
+    )}
+  </FormSpy>
+)
 
 LocusListItemsFilter.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  onChange: PropTypes.func,
+  label: PropTypes.string,
+  iconColor: PropTypes.string,
+  shouldShow: PropTypes.func,
 }
 
-export default (LocusListItemsFilter)
+export default LocusListItemsFilter

--- a/ui/shared/components/panel/search/LocusListItemsFilter.jsx
+++ b/ui/shared/components/panel/search/LocusListItemsFilter.jsx
@@ -4,16 +4,13 @@ import { FormSpy } from 'react-final-form'
 
 import { BaseSemanticInput } from 'shared/components/form/Inputs'
 import { ColoredIcon } from 'shared/components/StyledComponents'
-import { PANEL_APP_CONFIDENCE_DESCRIPTION, PANEL_APP_CONFIDENCE_LEVEL_COLORS } from 'shared/utils/constants'
+import { PANEL_APP_CONFIDENCE_LEVELS, PANEL_APP_CONFIDENCE_DESCRIPTION, PANEL_APP_CONFIDENCE_LEVEL_COLORS } from 'shared/utils/constants'
 
-const PA_ICON_PROPS = Object.entries({ 1: 'red', 2: 'amber', 3: 'green' }).reduce((acc, [confidence, color]) => ({ // TODO constant
-  ...acc,
-  [color]: {
-    name: 'circle',
-    title: PANEL_APP_CONFIDENCE_DESCRIPTION[confidence],
-    color: PANEL_APP_CONFIDENCE_LEVEL_COLORS[confidence],
-  },
-}), {})
+const PA_ICON_PROPS = Object.entries(PANEL_APP_CONFIDENCE_LEVELS).reduce((acc, [confidence, colorKey]) => {
+  const color = PANEL_APP_CONFIDENCE_LEVEL_COLORS[confidence]
+  return color ?
+    { ...acc, [colorKey]: { name: 'circle', color, title: PANEL_APP_CONFIDENCE_DESCRIPTION[confidence] } } : acc
+}, {})
 
 const SUBSCRIPTION = { values: true }
 

--- a/ui/shared/components/panel/search/VariantSearchFormContainer.jsx
+++ b/ui/shared/components/panel/search/VariantSearchFormContainer.jsx
@@ -10,14 +10,13 @@ import { LOCUS_LIST_ITEMS_FIELD } from 'shared/utils/constants'
 
 import { LOCUS_FIELD_NAME, PANEL_APP_FIELD_NAME } from './constants'
 
-const SEARCH_LOCUS_FIELD_NAME = `search.${LOCUS_FIELD_NAME}`
-const GENE_ITEMS_LOCUS_FIELD_NAME = `${SEARCH_LOCUS_FIELD_NAME}.${LOCUS_LIST_ITEMS_FIELD.name}`
-const PANEL_APP_LOCUS_FIELD_NAME = `${SEARCH_LOCUS_FIELD_NAME}.${PANEL_APP_FIELD_NAME}`
 const DECORATORS = [
   createDecorator({
-    field: PANEL_APP_LOCUS_FIELD_NAME,
+    field: `search.${LOCUS_FIELD_NAME}.${PANEL_APP_FIELD_NAME}`,
     updates: {
-      [GENE_ITEMS_LOCUS_FIELD_NAME]: locusValue => locusValue && toUniqueCsvString(Object.values(locusValue)),
+      [`search.${LOCUS_FIELD_NAME}.${LOCUS_LIST_ITEMS_FIELD.name}`]: locusValue => (
+        locusValue && toUniqueCsvString(Object.values(locusValue))
+      ),
     },
   }),
 ]

--- a/ui/shared/components/panel/search/VariantSearchFormContainer.jsx
+++ b/ui/shared/components/panel/search/VariantSearchFormContainer.jsx
@@ -1,15 +1,38 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
+import createDecorator from 'final-form-calculate'
 import { navigateSavedHashedSearch } from 'redux/rootReducer'
 import { getSearchedVariantsErrorMessage, getSearchedVariantsIsLoading } from 'redux/selectors'
 import FormWrapper from 'shared/components/form/FormWrapper'
 import { toUniqueCsvString } from 'shared/utils/stringUtils'
+import { LOCUS_LIST_ITEMS_FIELD } from 'shared/utils/constants'
+
+import { LOCUS_FIELD_NAME, PANEL_APP_FIELD_NAME } from './constants'
+
+const SEARCH_LOCUS_FIELD_NAME = `search.${LOCUS_FIELD_NAME}`
+const GENE_ITEMS_LOCUS_FIELD_NAME = `${SEARCH_LOCUS_FIELD_NAME}.${LOCUS_LIST_ITEMS_FIELD.name}`
+const PANEL_APP_LOCUS_FIELD_NAME = `${SEARCH_LOCUS_FIELD_NAME}.${PANEL_APP_FIELD_NAME}`
+const DECORATORS = [
+  createDecorator({
+    field: PANEL_APP_LOCUS_FIELD_NAME,
+    updates: {
+      [GENE_ITEMS_LOCUS_FIELD_NAME]: locusValue => locusValue && toUniqueCsvString(Object.values(locusValue)),
+    },
+  }),
+]
 
 const VariantSearchFormContainer = React.memo((
   { history, onSubmit, resultsPath, loading, variantsLoading, children, ...formProps },
 ) => (
-  <FormWrapper onSubmit={onSubmit} loading={loading || variantsLoading} submitButtonText="Search" noModal {...formProps}>
+  <FormWrapper
+    onSubmit={onSubmit}
+    loading={loading || variantsLoading}
+    submitButtonText="Search"
+    noModal
+    decorators={DECORATORS}
+    {...formProps}
+  >
     {children}
   </FormWrapper>
 ))
@@ -29,17 +52,9 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  onSubmit: ({ search, ...searchParams }) => {
-    let restructuredSearch = search
-    if (search?.locus) {
-      const { rawItems } = search?.locus || ''
-      const formattedRawItems = (rawItems && typeof rawItems === 'object') ? toUniqueCsvString(Object.values(rawItems)) : rawItems
-      restructuredSearch = { ...search, locus: { ...search.locus, rawItems: formattedRawItems } }
-    }
-    dispatch(navigateSavedHashedSearch(
-      { ...searchParams, search: restructuredSearch }, ownProps.history.push, ownProps.resultsPath,
-    ))
-  },
+  onSubmit: values => dispatch(navigateSavedHashedSearch(
+    values, ownProps.history.push, ownProps.resultsPath,
+  )),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(VariantSearchFormContainer)

--- a/ui/shared/components/panel/search/VariantSearchFormPanels.jsx
+++ b/ui/shared/components/panel/search/VariantSearchFormPanels.jsx
@@ -27,6 +27,7 @@ import {
   HIGH_IMPACT_GROUPS_SPLICE,
   MODERATE_IMPACT_GROUPS,
   SV_GROUPS,
+  LOCUS_FIELD_NAME,
 } from './constants'
 
 const LabeledSlider = React.lazy(() => import('./LabeledSlider'))
@@ -201,7 +202,7 @@ export const FREQUENCY_PANEL = {
 }
 
 export const LOCATION_PANEL = {
-  name: 'locus',
+  name: LOCUS_FIELD_NAME,
   headerProps: { title: 'Location' },
   fields: LOCATION_FIELDS,
   helpText: 'Filter by variant location. Entries can be either gene symbols (e.g. CFTR) or intervals in the form <chrom>:<start>-<end> (e.g. 4:6935002-87141054) or separated by tab. Variant entries can be either rsIDs (e.g. rs61753695) or variants in the form <chrom>-<pos>-<ref>-<alt> (e.g. 4-88047328-C-T). Entries can be separated by commas or whitespace.',

--- a/ui/shared/components/panel/search/constants.js
+++ b/ui/shared/components/panel/search/constants.js
@@ -357,7 +357,7 @@ export const LOCATION_FIELDS = [
     label: LOCUS_LIST_ITEMS_FIELD.label,
     labelHelp: LOCUS_LIST_ITEMS_FIELD.labelHelp,
     component: LocusListItemsFilter,
-    width: 16,
+    width: 7,
     shouldShow: locus => !locus[PANEL_APP_FIELD_NAME],
   },
   ...['green', 'amber', 'red', 'none'].map(color => ({ // TODO constant
@@ -367,8 +367,7 @@ export const LOCATION_FIELDS = [
     label: color === 'none' ? 'Genes' : `${camelcaseToTitlecase(color)} Genes`,
     labelHelp: 'A list of genes, can be separated by commas or whitespace',
     component: LocusListItemsFilter,
-    inline: true,
-    width: 4,
+    width: 2,
     shouldShow: locus => !!locus[PANEL_APP_FIELD_NAME],
   })),
   {
@@ -378,14 +377,14 @@ export const LOCATION_FIELDS = [
     component: BaseSemanticInput,
     inputType: 'TextArea',
     rows: 8,
-    width: 16,
+    width: 4,
   },
   {
     name: 'excludeLocations',
     component: BooleanCheckbox,
     label: 'Exclude locations',
     labelHelp: 'Search for variants not in the specified genes/ intervals',
-    width: 5,
+    width: 3,
   },
 ]
 

--- a/ui/shared/components/panel/search/constants.js
+++ b/ui/shared/components/panel/search/constants.js
@@ -21,6 +21,7 @@ import {
   PREDICTOR_FIELDS,
   SPLICE_AI_FIELD,
   VEP_GROUP_SV_NEW,
+  PANEL_APP_CONFIDENCE_LEVELS,
 } from 'shared/utils/constants'
 
 import LocusListItemsFilter from './LocusListItemsFilter'
@@ -351,6 +352,9 @@ export const FREQUENCIES = [...SNP_FREQUENCIES, ...SV_FREQUENCIES]
 
 export const LOCUS_FIELD_NAME = 'locus'
 export const PANEL_APP_FIELD_NAME = 'panelAppItems'
+const PANEL_APP_COLORS = [...new Set(
+  Object.entries(PANEL_APP_CONFIDENCE_LEVELS).sort((a, b) => b[0] - a[0]).map(config => config[1]),
+)]
 export const LOCATION_FIELDS = [
   {
     name: LOCUS_LIST_ITEMS_FIELD.name,
@@ -360,7 +364,7 @@ export const LOCATION_FIELDS = [
     width: 7,
     shouldShow: locus => !locus[PANEL_APP_FIELD_NAME],
   },
-  ...['green', 'amber', 'red', 'none'].map(color => ({ // TODO constant
+  ...PANEL_APP_COLORS.map(color => ({ // TODO constant
     key: color,
     name: `${PANEL_APP_FIELD_NAME}.${color}`,
     iconColor: color,

--- a/ui/shared/components/panel/search/constants.js
+++ b/ui/shared/components/panel/search/constants.js
@@ -364,7 +364,7 @@ export const LOCATION_FIELDS = [
     width: 7,
     shouldShow: locus => !locus[PANEL_APP_FIELD_NAME],
   },
-  ...PANEL_APP_COLORS.map(color => ({ // TODO constant
+  ...PANEL_APP_COLORS.map(color => ({
     key: color,
     name: `${PANEL_APP_FIELD_NAME}.${color}`,
     iconColor: color,

--- a/ui/shared/components/panel/search/constants.js
+++ b/ui/shared/components/panel/search/constants.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Form } from 'semantic-ui-react'
 import styled from 'styled-components'
 import { RadioGroup, BooleanCheckbox, BaseSemanticInput, Select } from 'shared/components/form/Inputs'
-import { snakecaseToTitlecase } from 'shared/utils/stringUtils'
+import { snakecaseToTitlecase, camelcaseToTitlecase } from 'shared/utils/stringUtils'
 import {
   VEP_GROUP_NONSENSE,
   VEP_GROUP_ESSENTIAL_SPLICE_SITE,
@@ -23,7 +23,7 @@ import {
   VEP_GROUP_SV_NEW,
 } from 'shared/utils/constants'
 
-import { LocusListItemsFilter } from './LocusListItemsFilter'
+import LocusListItemsFilter from './LocusListItemsFilter'
 
 export const getSelectedAnalysisGroups = (
   analysisGroupsByGuid, familyGuids,
@@ -349,15 +349,28 @@ const SV_FREQUENCIES = [
 
 export const FREQUENCIES = [...SNP_FREQUENCIES, ...SV_FREQUENCIES]
 
+export const LOCUS_FIELD_NAME = 'locus'
+export const PANEL_APP_FIELD_NAME = 'panelAppItems'
 export const LOCATION_FIELDS = [
   {
     name: LOCUS_LIST_ITEMS_FIELD.name,
     label: LOCUS_LIST_ITEMS_FIELD.label,
     labelHelp: LOCUS_LIST_ITEMS_FIELD.labelHelp,
     component: LocusListItemsFilter,
-    rows: 8,
-    width: 7,
+    width: 16,
+    shouldShow: locus => !locus[PANEL_APP_FIELD_NAME],
   },
+  ...['green', 'amber', 'red', 'none'].map(color => ({ // TODO constant
+    key: color,
+    name: `${PANEL_APP_FIELD_NAME}.${color}`,
+    iconColor: color,
+    label: color === 'none' ? 'Genes' : `${camelcaseToTitlecase(color)} Genes`,
+    labelHelp: 'A list of genes, can be separated by commas or whitespace',
+    component: LocusListItemsFilter,
+    inline: true,
+    width: 4,
+    shouldShow: locus => !!locus[PANEL_APP_FIELD_NAME],
+  })),
   {
     name: 'rawVariantItems',
     label: 'Variants',
@@ -365,14 +378,14 @@ export const LOCATION_FIELDS = [
     component: BaseSemanticInput,
     inputType: 'TextArea',
     rows: 8,
-    width: 4,
+    width: 16,
   },
   {
     name: 'excludeLocations',
     component: BooleanCheckbox,
     label: 'Exclude locations',
     labelHelp: 'Search for variants not in the specified genes/ intervals',
-    width: 3,
+    width: 5,
   },
 ]
 

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -1265,13 +1265,17 @@ export const PANEL_APP_CONFIDENCE_DESCRIPTION = {
   4: 'Green, highest level of confidence; a gene from 3 or 4 sources.',
 }
 
-export const PANEL_APP_CONFIDENCE_LEVEL_COLORS = {
+export const PANEL_APP_CONFIDENCE_LEVELS = {
   0: 'none',
-  1: VARIANT_ICON_COLORS.red,
-  2: VARIANT_ICON_COLORS.amber,
-  3: VARIANT_ICON_COLORS.green,
-  4: VARIANT_ICON_COLORS.green,
+  1: 'red',
+  2: 'amber',
+  3: 'green',
+  4: 'green',
 }
+
+export const PANEL_APP_CONFIDENCE_LEVEL_COLORS = Object.entries(PANEL_APP_CONFIDENCE_LEVELS).reduce(
+  (acc, [confidence, color]) => ({ ...acc, [confidence]: VARIANT_ICON_COLORS[color] }), {},
+)
 
 // Users
 


### PR DESCRIPTION
This is a precursor Pr for https://github.com/broadinstitute/seqr/issues/2656 . It cleans up the way the panel app gene lists are handled in the location panel in preparation for other changes to that panel. It has no changes to display/ behavior/ performance, it just makes the code easier to work with going forward

Change summary:
Currently, panel app gene lists are added to the same form field as regular lists, but they are formatted a a dictionary instead of a string, and the `LocusListItemsFilter` has conditional logic to render it based on type, and then before the form is submitted it post processes the object into a string. This changes the form to use a separate field for panel app list data, uses a decorator to keep the string and object values in sync to remove the need for post processing before submission, and can therefore make the panel app fields themselves top-level fields which cleans up the logic for `LocusListItemsFilter` so it is a simple field type. `LocusListItemsFilter` also now has a `FormSpy` so the filters can be shown or hidden based on other form field values