### PR TITLE
Variant rna seq performance

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1203,6 +1203,25 @@
     }
 },
 {
+    "model": "seqr.sample",
+    "pk": 151,
+    "fields": {
+        "guid": "S000151_na20889",
+        "created_date": "2017-02-05T06:42:55.397Z",
+        "created_by": null,
+        "last_modified_date": "2017-03-13T09:07:49.744Z",
+        "individual": 17,
+        "sample_type": "RNA",
+        "dataset_type": "VARIANTS",
+        "sample_id": "NA20889",
+        "is_active": true,
+        "elasticsearch_index":null,
+        "tissue_type": "M",
+        "data_source": "muscle_samples.tsv.gz",
+        "loaded_date": "2017-02-05T06:42:55.397Z"
+    }
+},
+{
     "model": "seqr.rnaseqoutlier",
     "pk": 1,
     "fields": {
@@ -1242,6 +1261,15 @@
         "sample": 150,
         "gene_id": "ENSG00000135953",
         "tpm": 8.38
+    }
+},
+{
+    "model": "seqr.rnaseqtpm",
+    "pk": 4,
+    "fields": {
+        "sample": 151,
+        "gene_id": "ENSG00000135953",
+        "tpm": 1.01
     }
 },
 {

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -26,6 +26,7 @@ from seqr.views.apis.family_api import \
     update_family_note, \
     delete_family_note, \
     family_page_data, \
+    get_family_rna_seq_data, \
     family_variant_tag_summary
 
 from seqr.views.apis.individual_api import \
@@ -116,7 +117,7 @@ from seqr.views.apis.report_api import \
     get_cmg_projects, \
     sample_metadata_export, \
     seqr_stats
-from seqr.views.apis.summary_data_api import success_story, saved_variants_page, mme_details, rna_seq_expression, \
+from seqr.views.apis.summary_data_api import success_story, saved_variants_page, mme_details, \
     bulk_update_family_analysed_by
 from seqr.views.apis.superuser_api import get_all_users
 
@@ -180,6 +181,7 @@ api_endpoints = {
     'family/(?P<family_guid>[\w.|-]+)/note/create': create_family_note,
     'family/(?P<family_guid>[\w.|-]+)/note/(?P<note_guid>[\w.|-]+)/update': update_family_note,
     'family/(?P<family_guid>[\w.|-]+)/note/(?P<note_guid>[\w.|-]+)/delete': delete_family_note,
+    'family/(?P<family_guid>[\w.|-]+)/rna_seq_data/(?P<gene_id>[\w.|-]+)': get_family_rna_seq_data,
 
     'dashboard': dashboard_page_data,
 
@@ -299,8 +301,6 @@ api_endpoints = {
     'summary_data/success_story/(?P<success_story_types>[^/]+)': success_story,
     'summary_data/matchmaker': mme_details,
     'summary_data/update_analysed_by': bulk_update_family_analysed_by,
-
-    'rna_seq_expression/gene/(?P<gene>[^/]+)/tissues/(?P<tissues>[^/]+)': rna_seq_expression,
 
     # EXTERNAL APIS: DO NOT CHANGE
     # matchmaker public facing MME URLs

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -44,6 +44,8 @@ def family_page_data(request, family_guid):
     for sample in outlier_samples:
         individual_guid = response['samplesByGuid'][sample.guid]['individualGuid']
         response['individualsByGuid'][individual_guid]['hasRnaOutlierData'] = True
+    if sample_models.filter(sample_type=Sample.SAMPLE_TYPE_RNA).exclude(rnaseqtpm=None):
+        response['familiesByGuid'][family_guid]['hasRnaTpmData'] = True
 
     submissions = get_json_for_matchmaker_submissions(MatchmakerSubmission.objects.filter(individual__family=family))
     individual_mme_submission_guids = {s['individualGuid']: s['submissionGuid'] for s in submissions}

--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -9,7 +9,7 @@ from matchmaker.models import MatchmakerSubmission
 from seqr.views.apis.family_api import update_family_pedigree_image, update_family_assigned_analyst, \
     update_family_fields_handler, update_family_analysed_by, edit_families_handler, delete_families_handler, \
     receive_families_table_handler, create_family_note, update_family_note, delete_family_note, family_page_data, \
-    family_variant_tag_summary, update_family_analysis_groups
+    family_variant_tag_summary, update_family_analysis_groups, get_family_rna_seq_data
 from seqr.views.utils.test_utils import AuthenticationTestCase, FAMILY_NOTE_FIELDS, FAMILY_FIELDS, IGV_SAMPLE_FIELDS, \
     SAMPLE_FIELDS, INDIVIDUAL_FIELDS, INTERNAL_INDIVIDUAL_FIELDS, INTERNAL_FAMILY_FIELDS, CASE_REVIEW_FAMILY_FIELDS, \
     MATCHMAKER_SUBMISSION_FIELDS, TAG_TYPE_FIELDS
@@ -473,3 +473,16 @@ class FamilyAPITest(AuthenticationTestCase):
         response = self.client.post(delete_note_url, content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'familyNotesByGuid': {new_note_guid: None}})
+
+    def test_get_family_rna_seq_data(self):
+        url = reverse(get_family_rna_seq_data, args=[FAMILY_GUID, 'ENSG00000135953'])
+        self.check_collaborator_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), {
+            'M': {
+                'individualData': {'NA19675_1': 8.38},
+                'rdgData': [8.38, 1.01],
+            }
+        })

--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -49,7 +49,7 @@ class FamilyAPITest(AuthenticationTestCase):
 
         self.assertEqual(len(response_json['familiesByGuid']), 1)
         family = response_json['familiesByGuid'][FAMILY_GUID]
-        family_fields = {'individualGuids', 'detailsLoaded'}
+        family_fields = {'individualGuids', 'hasRnaTpmData', 'detailsLoaded'}
         family_fields.update(FAMILY_FIELDS)
         self.assertSetEqual(set(family.keys()), family_fields)
         self.assertEqual(family['projectGuid'], PROJECT_GUID)

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -227,7 +227,7 @@ class ReportAPITest(AuthenticationTestCase):
         self.assertEqual(response_json['familiesCount'], {'internal': 13, 'external': 1})
         self.assertDictEqual(
             response_json['sampleCountsByType'],
-            {'WES__VARIANTS': {'internal': 8}, 'WES__SV': {'internal': 3}, 'WGS__SV': {'external': 1}, 'RNA__VARIANTS': {'internal': 1}},
+            {'WES__VARIANTS': {'internal': 8}, 'WES__SV': {'internal': 3}, 'WGS__SV': {'external': 1}, 'RNA__VARIANTS': {'internal': 2}},
         )
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -168,10 +168,10 @@ class SavedVariantAPITest(object):
                     'geneId': 'ENSG00000135953', 'zScore': 7.31, 'pValue': 0.00000000000948, 'pAdjust': 0.00000000781,
                     'isSignificant': True,
             }},
-            'tpms': {
-                'ENSG00000135953': {
-                    'geneId': 'ENSG00000135953', 'tpm': 8.38, 'sampleTissueType': 'M',
-            }},
+            # 'tpms': { TODO
+            #     'ENSG00000135953': {
+            #         'geneId': 'ENSG00000135953', 'tpm': 8.38, 'sampleTissueType': 'M',
+            # }},
         }})
 
         # include project tag types
@@ -207,7 +207,7 @@ class SavedVariantAPITest(object):
         self.assertSetEqual(set(response_json.keys()), response_keys)
         self.assertEqual(len(response_json['savedVariantsByGuid']), 2)
         self.assertEqual(set(response_json['familiesByGuid'].keys()), {'F000001_1', 'F000002_2'})
-        family_fields = {'individualGuids'}
+        family_fields = {'individualGuids', 'hasRnaTpmData'}
         family_fields.update(FAMILY_FIELDS)
         self.assertSetEqual(set(response_json['familiesByGuid']['F000001_1'].keys()), family_fields)
         individual_fields = {'igvSampleGuids'}

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -168,10 +168,6 @@ class SavedVariantAPITest(object):
                     'geneId': 'ENSG00000135953', 'zScore': 7.31, 'pValue': 0.00000000000948, 'pAdjust': 0.00000000781,
                     'isSignificant': True,
             }},
-            # 'tpms': { TODO
-            #     'ENSG00000135953': {
-            #         'geneId': 'ENSG00000135953', 'tpm': 8.38, 'sampleTissueType': 'M',
-            # }},
         }})
 
         # include project tag types

--- a/seqr/views/apis/summary_data_api.py
+++ b/seqr/views/apis/summary_data_api.py
@@ -93,14 +93,6 @@ def saved_variants_page(request, tag):
 
     return create_json_response(response_json)
 
-@login_and_policies_required
-def rna_seq_expression(request, gene, tissues):
-    response = {}
-    for tissue in tissues.split(','):
-        response[tissue] = list(RnaSeqTpm.objects.filter(sample__tissue_type=tissue, gene_id=gene).values_list('tpm', flat=True))
-
-    return create_json_response(response)
-
 
 @analyst_required
 def bulk_update_family_analysed_by(request):

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -63,7 +63,7 @@ EXPECTED_SEARCH_RESPONSE = {
         'VFD0000025_1248367227_r0390_10': mock.ANY, 'VFD0000026_1248367227_r0390_10': mock.ANY,
     },
     'locusListsByGuid': {LOCUS_LIST_GUID: mock.ANY},
-    'rnaSeqData': {'I000001_na19675': {'outliers': {'ENSG00000268903': mock.ANY}, 'tpms': {}}},
+    'rnaSeqData': {'I000001_na19675': {'outliers': {'ENSG00000268903': mock.ANY}}},
 }
 
 EXPECTED_SEARCH_CONTEXT_RESPONSE = {
@@ -127,6 +127,10 @@ class VariantSearchAPITest(object):
 
         family_fields = {'individualGuids'}
         family_fields.update(FAMILY_FIELDS)
+        if len(response_json['familiesByGuid']) > 1:
+            self.assertSetEqual(set(response_json['familiesByGuid']['F000002_2'].keys()), family_fields)
+
+        family_fields.add('hasRnaTpmData')
         self.assertSetEqual(set(response_json['familiesByGuid']['F000001_1'].keys()), family_fields)
 
         self.assertEqual(len(response_json['individualsByGuid']), len(response_json['familiesByGuid'])*3)

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from django.db.models import prefetch_related_objects, Prefetch
 import logging
 import redis
 

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -131,7 +131,7 @@ def _get_rna_seq_outliers(gene_ids, families):
     return data_by_individual_gene
 
 
-def _add_family_rna_tpm(families_by_guid):
+def _add_family_has_rna_tpm(families_by_guid):
     tpm_families = RnaSeqTpm.objects.filter(
         sample__individual__family__guid__in=families_by_guid.keys()
     ).values_list('sample__individual__family__guid', flat=True).distinct()
@@ -192,6 +192,6 @@ def get_variants_response(request, saved_variants, response_variants=None, add_a
         response['rnaSeqData'] = _get_rna_seq_outliers(genes.keys(), families)
         families_by_guid = response.get('familiesByGuid')
         if families_by_guid:
-            _add_family_rna_tpm(families_by_guid)
+            _add_family_has_rna_tpm(families_by_guid)
 
     return response

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -129,17 +129,6 @@ def _get_rna_seq_outliers(gene_ids, families):
     for data in outlier_data:
         data_by_individual_gene[data.pop('individualGuid')]['outliers'][data['geneId']] = data
 
-    # TODO add endpoint
-    # tpm_data = _get_json_for_models(
-    #     RnaSeqTpm.objects.filter(gene_id__in=gene_ids, sample__individual__family__in=families),
-    #     nested_fields=[
-    #         {'fields': ('sample', 'individual', 'guid'), 'key': 'individualGuid'},
-    #         {'fields': ('sample', 'tissue_type')},
-    #     ]
-    # )
-    # for data in tpm_data:
-    #     data_by_individual_gene[data.pop('individualGuid')]['tpms'][data['geneId']] = data
-
     return data_by_individual_gene
 
 

--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -171,28 +171,6 @@ export const getIGVSamplesByFamilySampleIndividual = createSelector(
   }, {}),
 )
 
-export const getRnaSeqDataByFamilyGene = createSelector(
-  getIndividualsByGuid,
-  getRnaSeqDataByIndividual,
-  (individualsByGuid, rnaSeqDataByIndividual) => Object.entries(rnaSeqDataByIndividual).reduce(
-    (acc, [individualGuid, rnaSeqData]) => {
-      const { familyGuid, displayName } = individualsByGuid[individualGuid]
-      acc[familyGuid] = {
-        significantOutliers: Object.entries(rnaSeqData.outliers || {}).reduce(
-          (acc2, [geneId, data]) => (data.isSignificant ?
-            { ...acc2, [geneId]: { ...(acc2[geneId] || {}), [displayName]: data } } : acc2
-          ), acc[familyGuid]?.significantOutliers || {},
-        ),
-        tpms: Object.entries(rnaSeqData.tpms || {}).reduce(
-          (acc2, [geneId, data]) => ({ ...acc2, [geneId]: { ...(acc2[geneId] || {}), [displayName]: data } }),
-          acc[familyGuid]?.tpms || {},
-        ),
-      }
-      return acc
-    }, {},
-  ),
-)
-
 export const getProjectDatasetTypes = createSelector(
   getProjectsByGuid,
   getSamplesGroupedByProjectGuid,

--- a/ui/redux/selectors.test.js
+++ b/ui/redux/selectors.test.js
@@ -6,7 +6,6 @@ import {
   getSearchGeneBreakdownValues,
   getTagTypesByProject,
   getUserOptions,
-  getRnaSeqDataByFamilyGene,
 } from './selectors'
 import {FAMILY_GUID, GENE_ID, SEARCH, SEARCH_HASH, STATE} from "../pages/Search/fixtures";
 
@@ -47,51 +46,4 @@ test('getUserOptions', () => {
   const options = getUserOptions(STATE_WITH_2_FAMILIES)
   expect(Object.keys(options).length).toEqual(7)
   expect(options[1]).toEqual({ key: '4MW8vPtmHG', value: '4MW8vPtmHG', text: 'Mekdes (mgetaneh@broadinstitute.org)'})
-})
-
-const RNA_SEQ_STATE = {
-  rnaSeqDataByIndividual: {
-    I021476_na19678_1: {
-      outliers: {
-        ENSG00000228198: { isSignificant: true, pValue: 0.0004 },
-        ENSG00000164458: { isSignificant: true, pValue: 0.0073 },
-      },
-      tpms: { ENSG00000228198: { tpm: 1.03 } },
-    },
-    I021474_na19679_1: {
-      outliers: {
-        ENSG00000228198: { isSignificant: true, pValue: 0.01 },
-        ENSG00000164458: { isSignificant: false, pValue: 0.73 },
-      },
-      tpms: { ENSG00000164458: { tpm: 17.8 } },
-    },
-    I021476_na19678_2: { outliers: { ENSG00000228198: { isSignificant: true, pValue: 0.0214 } } },
-  },
-  ...STATE_WITH_2_FAMILIES,
-}
-
-test('getRnaSeqDataByFamilyGene', () => {
-  expect(getRnaSeqDataByFamilyGene(RNA_SEQ_STATE)).toEqual({
-    F011652_1: {
-      significantOutliers: {
-        ENSG00000228198: {
-          NA19678: { isSignificant: true, pValue: 0.0004 },
-          NA19679_1: { isSignificant: true, pValue: 0.01 },
-        },
-        ENSG00000164458: {
-          NA19678: { isSignificant: true, pValue: 0.0073 },
-        },
-      },
-      tpms: {
-        ENSG00000228198: { NA19678: { tpm: 1.03 } },
-        ENSG00000164458: { NA19679_1: { tpm: 17.8 } },
-      },
-    },
-    F011652_2: {
-      significantOutliers: {
-        ENSG00000228198: { NA19678_2: { isSignificant: true, pValue: 0.0214 } },
-      },
-      tpms: {},
-    },
-  })
 })

--- a/ui/shared/components/panel/variants/RnaSeqTpm.test.js
+++ b/ui/shared/components/panel/variants/RnaSeqTpm.test.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import { shallow, configure } from 'enzyme'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import configureStore from 'redux-mock-store'
@@ -10,14 +9,8 @@ import { STATE1 } from '../fixtures'
 
 configure({ adapter: new Adapter() })
 
-const mapStateToProps = (state, ownProps) => ({
-  tpms: getRnaSeqDataByFamilyGene(state)[ownProps.familyGuid].tpms[ownProps.geneId],
-})
-
-const ConnectedRnaSeqTpm = connect(mapStateToProps)(RnaSeqTpm)
-
 test('shallow-render without crashing', () => {
   const store = configureStore()(STATE1)
 
-  shallow(<ConnectedRnaSeqTpm store={store} familyGuid="F011652_1" geneId="ENSG00000228198" />)
+  shallow(<RnaSeqTpm store={store} familyGuid="F011652_1" geneId="ENSG00000228198" />)
 })

--- a/ui/shared/components/panel/variants/selectors.js
+++ b/ui/shared/components/panel/variants/selectors.js
@@ -14,8 +14,24 @@ import {
 } from 'shared/utils/constants'
 import {
   getVariantTagsByGuid, getVariantNotesByGuid, getSavedVariantsByGuid, getAnalysisGroupsByGuid, getGenesById, getUser,
-  getFamiliesByGuid, getProjectsByGuid,
+  getFamiliesByGuid, getProjectsByGuid, getIndividualsByGuid, getRnaSeqDataByIndividual,
 } from 'redux/selectors'
+
+export const getRnaSeqOutilerDataByFamilyGene = createSelector(
+  getIndividualsByGuid,
+  getRnaSeqDataByIndividual,
+  (individualsByGuid, rnaSeqDataByIndividual) => Object.entries(rnaSeqDataByIndividual).reduce(
+    (acc, [individualGuid, rnaSeqData]) => {
+      const { familyGuid, displayName } = individualsByGuid[individualGuid]
+      acc[familyGuid] = Object.entries(rnaSeqData.outliers || {}).reduce(
+        (acc2, [geneId, data]) => (data.isSignificant ?
+          { ...acc2, [geneId]: { ...(acc2[geneId] || {}), [displayName]: data } } : acc2
+        ), acc[familyGuid] || {},
+      )
+      return acc
+    }, {},
+  ),
+)
 
 // Saved variant selectors
 export const getSavedVariantTableState = state => (

--- a/ui/shared/components/panel/variants/selectors.test.js
+++ b/ui/shared/components/panel/variants/selectors.test.js
@@ -5,6 +5,7 @@ import {
   getPairedSelectedSavedVariants,
   getVisibleSortedSavedVariants,
   getPairedFilteredSavedVariants,
+  getRnaSeqOutilerDataByFamilyGene,
 } from './selectors'
 
 test('getPairedSelectedSavedVariants', () => {
@@ -71,3 +72,40 @@ test('getVisibleSortedSavedVariants', () => {
   expect(savedVariants.length).toEqual(1)
   expect(savedVariants[0].variantGuid).toEqual('SV0000002_1248367227_r0390_100')
 })
+
+const RNA_SEQ_STATE = {
+  rnaSeqDataByIndividual: {
+    I021476_na19678_1: {
+      outliers: {
+        ENSG00000228198: { isSignificant: true, pValue: 0.0004 },
+        ENSG00000164458: { isSignificant: true, pValue: 0.0073 },
+      },
+    },
+    I021474_na19679_1: {
+      outliers: {
+        ENSG00000228198: { isSignificant: true, pValue: 0.01 },
+        ENSG00000164458: { isSignificant: false, pValue: 0.73 },
+      },
+    },
+    I021476_na19678_2: { outliers: { ENSG00000228198: { isSignificant: true, pValue: 0.0214 } } },
+  },
+  ...STATE_WITH_2_FAMILIES,
+}
+
+test('getRnaSeqOutilerDataByFamilyGene', () => {
+  expect(getRnaSeqOutilerDataByFamilyGene(RNA_SEQ_STATE)).toEqual({
+    F011652_1: {
+      ENSG00000228198: {
+        NA19678: { isSignificant: true, pValue: 0.0004 },
+        NA19679_1: { isSignificant: true, pValue: 0.01 },
+      },
+      ENSG00000164458: {
+        NA19678: { isSignificant: true, pValue: 0.0073 },
+      },
+    },
+    F011652_2: {
+      ENSG00000228198: { NA19678_2: { isSignificant: true, pValue: 0.0214 } },
+    },
+  })
+})
+


### PR DESCRIPTION
Fetching the RNA TPM data for all the saved variants for large projects takes about a full minute. Rather than fetching the data with the variants, we should instead just indicate if a family has data or not, and then fetch it dynamically when the user actually wants to view the data