### PR TITLE
fix pipeline runner perl installation

### DIFF
--- a/deploy/docker/pipeline-runner/Dockerfile
+++ b/deploy/docker/pipeline-runner/Dockerfile
@@ -96,7 +96,8 @@ RUN /usr/bin/cpanm --notest DBD::SQLite
 RUN /usr/bin/cpanm --notest  List::MoreUtils
 
 # install VEP
-WORKDIR /ensembl-vep-release-${VEP_VERSION} && perl INSTALL.pl -a ap -n -l -g all
+WORKDIR /ensembl-vep-release-${VEP_VERSION}
+RUN perl INSTALL.pl -a ap -n -l -g all
 RUN ln -s /ensembl-vep-release-${VEP_VERSION}/vep /vep
 
 # clone and hail-elasticsearch-pipelines repo


### PR DESCRIPTION
bug leftover from switching all `cd` calls to `WORKDIR`. The updated image has already been built and pushed

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [ ] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [x] Any chages to non-seqr docker images have been built and pushed to the container registry
    -  pipeline-runner image is build/ pushed
  - [x] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [x] All these changes have been vetted for potential vulnerabilities