### PR TITLE
Fix es pv creation

### DIFF
--- a/deploy/servctl_utils/deploy_command_utils.py
+++ b/deploy/servctl_utils/deploy_command_utils.py
@@ -5,7 +5,6 @@ import os
 from pprint import pformat
 import time
 
-from deploy.servctl_utils.other_command_utils import get_disk_names
 from deploy.servctl_utils.kubectl_utils import is_pod_running, \
     wait_until_pod_is_running as sleep_until_pod_is_running, wait_until_pod_is_ready as sleep_until_pod_is_ready, \
     wait_for_resource, wait_for_not_resource
@@ -114,7 +113,11 @@ def deploy_elasticsearch(settings):
 
     # create persistent volumes
     pv_template_path = 'deploy/kubernetes/elasticsearch/persistent-volumes/es-data.yaml'
-    disk_names = get_disk_names('es-data', settings)
+    num_disks = settings['ES_DATA_NUM_PODS']
+    disk_names = [
+        '{cluster_name}-es-data-disk{suffix}'.format(
+            cluster_name=settings['CLUSTER_NAME'], suffix='-{}'.format(i + 1) if num_disks > 1 else '')
+        for i in range(num_disks)]
     for disk_name in disk_names:
         volume_settings = {'DISK_NAME': disk_name}
         volume_settings.update(settings)

--- a/deploy/servctl_utils/other_command_utils.py
+++ b/deploy/servctl_utils/other_command_utils.py
@@ -66,11 +66,3 @@ def delete_all(deployment_target):
         "deploy/kubernetes/shared-settings.yaml",
         "deploy/kubernetes/%(deployment_target)s-settings.yaml" % locals(),
     ], settings)
-
-def get_disk_names(disk, settings):
-    num_disks = settings.get('{}_NUM_DISKS'.format(disk.upper().replace('-', '_'))) or 1
-    return [
-        '{cluster_name}-{disk}-disk{suffix}'.format(
-            cluster_name=settings['CLUSTER_NAME'], disk=disk, suffix='-{}'.format(i + 1) if num_disks > 1 else '')
-    for i in range(num_disks)]
-

--- a/deploy/servctl_utils/shell_utils.py
+++ b/deploy/servctl_utils/shell_utils.py
@@ -74,8 +74,18 @@ def run(command,
     p.wait()
 
     output = log_buffer.getvalue()
+
     if p.returncode not in ok_return_codes:
-        if ignore_all_errors or (errors_to_ignore and any([error_to_ignore in str(output) for error_to_ignore in errors_to_ignore])):
+        should_ignore = False
+        if ignore_all_errors:
+            should_ignore = True
+        elif errors_to_ignore:
+            should_ignore = all(
+                any([error_to_ignore in error for error_to_ignore in errors_to_ignore])
+                for error in  str(output.strip()).split('\n')
+            )
+
+        if should_ignore:
             return None
         else:
             raise RuntimeError(output)


### PR DESCRIPTION
When we moved the configuration for disks from servctl to terraform, it ended up breaking the code for creating persistant volumes for the disks in kubernetes, which in turn breaks our elasticsearch deployment. This updates the pv code to instead create one pv for every data pod. It also fixes a bug in the command error handling that caused commands which raise multiple errors to be ignored if one of the errors is ignorable, instead of checking each error, which caused the deployment to proceed without a pv when that failed