### PR TITLE
select main transcript that has filtered annotation

### DIFF
--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -776,11 +776,19 @@ class EsSearch(object):
 
         main_transcript_id = sorted_transcripts[0]['transcriptId'] \
             if len(sorted_transcripts) and 'transcriptRank' in sorted_transcripts[0] else None
+        selected_main_transcript_id = None
+        if self._allowed_consequences and sorted_transcripts[0].get('majorConsequence') not in self._allowed_consequences:
+            selected_main_transcript_id = next((
+                t.get('transcriptId') for t in sorted_transcripts if t.get('majorConsequence') in self._allowed_consequences), None)
+            if not selected_main_transcript_id and self._allowed_consequences_secondary:
+                selected_main_transcript_id = next((
+                    t for t in sorted_transcripts if t.get('majorConsequence') in self._allowed_consequences_secondary), None)
 
         result.update({
             'familyGuids': sorted(family_guids),
             'genotypes': genotypes,
             'mainTranscriptId': main_transcript_id,
+            'selectedMainTranscriptId': selected_main_transcript_id,
             'populations': populations,
             'predictions': _get_field_values(
                 hit, PREDICTION_FIELDS_CONFIG, format_response_key=get_prediction_response_key

--- a/seqr/utils/elasticsearch/es_search.py
+++ b/seqr/utils/elasticsearch/es_search.py
@@ -777,7 +777,7 @@ class EsSearch(object):
         main_transcript_id = sorted_transcripts[0]['transcriptId'] \
             if len(sorted_transcripts) and 'transcriptRank' in sorted_transcripts[0] else None
         selected_main_transcript_id = None
-        if self._allowed_consequences and sorted_transcripts[0].get('majorConsequence') not in self._allowed_consequences:
+        if main_transcript_id and self._allowed_consequences and sorted_transcripts[0].get('majorConsequence') not in self._allowed_consequences:
             selected_main_transcript_id = next((
                 t.get('transcriptId') for t in sorted_transcripts if t.get('majorConsequence') in self._allowed_consequences), None)
             if not selected_main_transcript_id and self._allowed_consequences_secondary:

--- a/seqr/utils/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/elasticsearch/es_utils_tests.py
@@ -551,6 +551,7 @@ for variant in PARSED_COMPOUND_HET_VARIANTS_PROJECT_2:
         'liftedOverGenomeVersion': '37',
         'liftedOverPos': variant['pos'] - 10,
         'liftedOverChrom': variant['chrom'],
+        'selectedMainTranscriptId': None,
     })
 
 PARSED_COMPOUND_HET_VARIANTS_MULTI_GENOME_VERSION = deepcopy(PARSED_COMPOUND_HET_VARIANTS_MULTI_PROJECT)
@@ -560,13 +561,17 @@ for variant in PARSED_COMPOUND_HET_VARIANTS_MULTI_GENOME_VERSION:
         'liftedOverGenomeVersion': '37',
         'liftedOverPos': variant['pos'] - 10,
         'liftedOverChrom': variant['chrom'],
+        'selectedMainTranscriptId': None,
     })
 
-PARSED_NO_SORT_VARIANTS = deepcopy(PARSED_VARIANTS)
+PARSED_NO_CONSEQUENCE_FILTER_VARIANTS = deepcopy(PARSED_VARIANTS)
+PARSED_NO_CONSEQUENCE_FILTER_VARIANTS[1]['selectedMainTranscriptId'] = None
+
+PARSED_NO_SORT_VARIANTS = deepcopy(PARSED_NO_CONSEQUENCE_FILTER_VARIANTS)
 for var in PARSED_NO_SORT_VARIANTS:
     del var['_sort']
 
-PARSED_CADD_VARIANTS = deepcopy(PARSED_VARIANTS)
+PARSED_CADD_VARIANTS = deepcopy(PARSED_NO_CONSEQUENCE_FILTER_VARIANTS)
 PARSED_CADD_VARIANTS[0]['_sort'][0] = -25.9
 PARSED_CADD_VARIANTS[1]['_sort'][0] = maxsize
 
@@ -1743,7 +1748,7 @@ class EsUtilsTest(TestCase):
         results_model.families.set(self.families)
 
         variants, _ = get_es_variants(results_model, num_results=5)
-        self.assertListEqual(variants, [PARSED_SV_VARIANT] + PARSED_VARIANTS)
+        self.assertListEqual(variants, [PARSED_SV_VARIANT] + PARSED_NO_CONSEQUENCE_FILTER_VARIANTS)
         path_filter = {'terms': {
             'clinvar_clinical_significance': [
                 'Pathogenic', 'Pathogenic/Likely_pathogenic'

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -758,6 +758,7 @@ PARSED_VARIANTS = [
         'liftedOverGenomeVersion': None,
         'liftedOverPos': None,
         'mainTranscriptId': TRANSCRIPT_3['transcriptId'],
+        'selectedMainTranscriptId': None,
         'originalAltAlleles': ['T'],
         'populations': {
             'callset': {'an': 32, 'ac': 2, 'hom': None, 'af': 0.063, 'hemi': None, 'filter_af': None, 'het': None, 'id': None},
@@ -822,6 +823,7 @@ PARSED_VARIANTS = [
         'liftedOverChrom': None,
         'liftedOverPos': None,
         'mainTranscriptId': TRANSCRIPT_1['transcriptId'],
+        'selectedMainTranscriptId': TRANSCRIPT_2['transcriptId'],
         'originalAltAlleles': ['G'],
         'populations': {
             'callset': {'an': 32, 'ac': 1, 'hom': None, 'af': 0.031, 'hemi': None, 'filter_af': None, 'het': None, 'id': None},
@@ -888,6 +890,7 @@ PARSED_SV_VARIANT = {
     'liftedOverGenomeVersion': None,
     'liftedOverPos': None,
     'mainTranscriptId': None,
+    'selectedMainTranscriptId': None,
     'originalAltAlleles': [],
     'populations': {
         'callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None, 'het': None, 'id': None},
@@ -952,6 +955,7 @@ PARSED_SV_WGS_VARIANT = {
     'liftedOverGenomeVersion': None,
     'liftedOverPos': None,
     'mainTranscriptId': None,
+    'selectedMainTranscriptId': None,
     'originalAltAlleles': [],
     'populations': {
         'callset': {'an': None, 'ac': None, 'hom': None, 'af': None, 'hemi': None, 'filter_af': None, 'het': None, 'id': None},


### PR DESCRIPTION
Implements the final outstanding feature from https://github.com/broadinstitute/seqr/issues/229 to prevent the confusion as caused in https://github.com/broadinstitute/seqr/issues/2710

Sets a selected main transcript for variants where the worst transcript was not actually one of the filtered transcripts from search. The UI for this already exists for saved variants, so no UI code change is needed to properly display the selection