### PR TITLE
PanelApp Mode of Inheritance

### DIFF
--- a/panelapp/models.py
+++ b/panelapp/models.py
@@ -24,7 +24,7 @@ class PaLocusList(models.Model):
     class Meta:
         """Fields included in JSON in API calls."""
 
-        json_fields = ['panel_app_id']
+        json_fields = ['url', 'panel_app_id']
 
 
 class PaLocusListGene(models.Model):

--- a/panelapp/pa_locus_list_api_tests.py
+++ b/panelapp/pa_locus_list_api_tests.py
@@ -208,7 +208,7 @@ class PaLocusListAPITest(AuthenticationTestCase):
             'locusListGuid': NEW_AU_PA_LOCUS_LIST_GUID,
             'name': 'Hereditary Neuropathy_CMT - isolated',
             'description': 'PanelApp_3069_0.199_Neurology and neurodevelopmental disorders',
-            'items': [{'geneId': 'ENSG00000090861'}], 'paLocusList': {'panelAppId': 3069},
+            'items': [{'geneId': 'ENSG00000090861'}], 'paLocusList': {'url': 'https://test-panelapp.url.au/api/panels/3069/genes', 'panelAppId': 3069},
             'numEntries': 1, 'numProjects': 0, 'isPublic': True, 'createdBy': None,
             'canEdit': False, 'createdDate': mock.ANY, 'lastModifiedDate': mock.ANY, 'intervalGenomeVersion': None,
         })
@@ -216,7 +216,7 @@ class PaLocusListAPITest(AuthenticationTestCase):
             'locusListGuid': NEW_UK_PA_LOCUS_LIST_GUID,
             'name': 'Auditory Neuropathy Spectrum Disorde',
             'description': 'PanelApp_UK_260_1.8_Hearing and ear disorders;Non-syndromic hearing loss',
-            'items': [{'geneId': 'ENSG00000139734'}], 'paLocusList': {'panelAppId': 260},
+            'items': [{'geneId': 'ENSG00000139734'}], 'paLocusList': {'url': 'https://test-panelapp.url.uk/api/panels/260/genes', 'panelAppId': 260},
             'numEntries': 1, 'numProjects': 0, 'isPublic': True, 'createdBy': None,
             'canEdit': False, 'createdDate': mock.ANY, 'lastModifiedDate': mock.ANY, 'intervalGenomeVersion': None,
         })

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1946,6 +1946,20 @@
   }
 },
 {
+  "model": "panelapp.palocuslist",
+  "pk": 1,
+  "fields": {
+    "seqr_locus_list": 1,
+    "panel_app_id": 1,
+    "disease_group": null,
+    "disease_sub_group": "2018-04-28T00:03:25.347Z",
+    "status": "public",
+    "version": "1.0",
+    "version_created": "2018-04-28T00:03:25.347Z",
+    "url": "https://panelapp.agha.umccr.org/api/v1/panels/254/genes"
+  }
+},
+{
   "model": "seqr.locuslistgene",
   "pk": 13,
   "fields": {

--- a/seqr/views/apis/locus_list_api_tests.py
+++ b/seqr/views/apis/locus_list_api_tests.py
@@ -2,16 +2,19 @@ import json
 import mock
 
 from django.urls.base import reverse
-
+from copy import deepcopy
 from seqr.models import LocusList
 from seqr.views.apis.locus_list_api import locus_lists, locus_list_info, create_locus_list_handler, \
     update_locus_list_handler, delete_locus_list_handler, add_project_locus_lists, delete_project_locus_lists
-from seqr.views.utils.test_utils import AuthenticationTestCase, LOCUS_LIST_DETAIL_FIELDS
+from seqr.views.utils.test_utils import AuthenticationTestCase, LOCUS_LIST_DETAIL_FIELDS, PA_LOCUS_LIST_FIELDS
 
 
 LOCUS_LIST_GUID = 'LL00049_pid_genes_autosomal_do'
 PRIVATE_LOCUS_LIST_GUID = 'LL00005_retina_proteome'
 PROJECT_GUID = 'R0001_1kg'
+
+PUBLIC_LOCUS_LIST_FIELDS = deepcopy(LOCUS_LIST_DETAIL_FIELDS)
+PUBLIC_LOCUS_LIST_FIELDS.update(PA_LOCUS_LIST_FIELDS)
 
 
 class LocusListAPITest(AuthenticationTestCase):
@@ -29,7 +32,7 @@ class LocusListAPITest(AuthenticationTestCase):
 
         locus_list = locus_lists_dict[LOCUS_LIST_GUID]
         fields = {'numProjects'}
-        fields.update(LOCUS_LIST_DETAIL_FIELDS)
+        fields.update(PUBLIC_LOCUS_LIST_FIELDS)
         self.assertSetEqual(set(locus_list.keys()), fields)
 
         self.login_analyst_user()
@@ -50,7 +53,7 @@ class LocusListAPITest(AuthenticationTestCase):
         self.assertListEqual(list(locus_lists_dict.keys()), [LOCUS_LIST_GUID])
 
         locus_list = locus_lists_dict[LOCUS_LIST_GUID]
-        self.assertSetEqual(set(locus_list.keys()), LOCUS_LIST_DETAIL_FIELDS)
+        self.assertSetEqual(set(locus_list.keys()), PUBLIC_LOCUS_LIST_FIELDS)
         self.assertSetEqual(
             {item['geneId'] for item in locus_list['items'] if item.get('geneId')},
             set(response_json['genesById'].keys())

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -9,8 +9,8 @@ from seqr.views.apis.saved_variant_api import saved_variant_data, create_variant
     update_variant_note_handler, delete_variant_note_handler, update_variant_tags_handler, update_saved_variant_json, \
     update_variant_main_transcript, update_variant_functional_data_handler, update_variant_acmg_classification_handler
 from seqr.views.utils.test_utils import AuthenticationTestCase, SAVED_VARIANT_FIELDS, TAG_FIELDS, GENE_VARIANT_FIELDS, \
-    TAG_TYPE_FIELDS, LOCUS_LIST_FIELDS, FAMILY_FIELDS, INDIVIDUAL_FIELDS, IGV_SAMPLE_FIELDS, FAMILY_NOTE_FIELDS, \
-    AnvilAuthenticationTestCase, MixAuthenticationTestCase
+    TAG_TYPE_FIELDS, LOCUS_LIST_FIELDS, PA_LOCUS_LIST_FIELDS, FAMILY_FIELDS, INDIVIDUAL_FIELDS, IGV_SAMPLE_FIELDS, \
+    FAMILY_NOTE_FIELDS, AnvilAuthenticationTestCase, MixAuthenticationTestCase
 
 
 PROJECT_GUID = 'R0001_1kg'
@@ -189,6 +189,7 @@ class SavedVariantAPITest(object):
         self.assertSetEqual(set(response_json.keys()), SAVED_VARIANT_RESPONSE_KEYS)
         self.assertEqual(len(response_json['savedVariantsByGuid']), 2)
         locus_list_fields.update(LOCUS_LIST_FIELDS)
+        locus_list_fields.update(PA_LOCUS_LIST_FIELDS)
         self.assertEqual(len(response_json['locusListsByGuid']), 2)
         self.assertSetEqual(set(response_json['locusListsByGuid'][LOCUS_LIST_GUID].keys()), locus_list_fields)
 

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -13,7 +13,7 @@ from seqr.views.apis.variant_search_api import query_variants_handler, query_sin
     update_saved_search_handler, delete_saved_search_handler, get_variant_gene_breakdown
 from seqr.views.utils.test_utils import AuthenticationTestCase, VARIANTS, AnvilAuthenticationTestCase,\
     MixAuthenticationTestCase, GENE_VARIANT_FIELDS, GENE_VARIANT_DISPLAY_FIELDS, PROJECT_FIELDS, LOCUS_LIST_FIELDS, FAMILY_FIELDS, \
-    INDIVIDUAL_FIELDS, FUNCTIONAL_FIELDS, IGV_SAMPLE_FIELDS, FAMILY_NOTE_FIELDS, ANALYSIS_GROUP_FIELDS, \
+    PA_LOCUS_LIST_FIELDS, INDIVIDUAL_FIELDS, FUNCTIONAL_FIELDS, IGV_SAMPLE_FIELDS, FAMILY_NOTE_FIELDS, ANALYSIS_GROUP_FIELDS, \
     VARIANT_NOTE_FIELDS, TAG_FIELDS
 
 LOCUS_LIST_GUID = 'LL00049_pid_genes_autosomal_do'
@@ -112,6 +112,7 @@ class VariantSearchAPITest(object):
         self.assertSetEqual(set(response_json['projectsByGuid'][PROJECT_GUID]['datasetTypes']), {'VARIANTS', 'SV'})
 
         locus_list_fields = deepcopy(LOCUS_LIST_FIELDS)
+        locus_list_fields.update(PA_LOCUS_LIST_FIELDS)
         locus_list_fields.remove('numEntries')
         locus_list_fields.remove('canEdit')
         self.assertSetEqual(set(response_json['locusListsByGuid'][LOCUS_LIST_GUID].keys()), locus_list_fields)
@@ -144,12 +145,13 @@ class VariantSearchAPITest(object):
         self.assertEqual(len(response_json['familyNotesByGuid']), 3)
         self.assertSetEqual(set(response_json['familyNotesByGuid']['FAN000001_1'].keys()), FAMILY_NOTE_FIELDS)
 
-    def _assert_expected_results_context(self, response_json, has_confidence_gene=True, locus_list_detail=False):
+    def _assert_expected_results_context(self, response_json, has_pa_attrs=True, locus_list_detail=False):
         gene_fields = {'locusListGuids'}
         gene_fields.update(GENE_VARIANT_FIELDS)
         basic_gene_id = next(gene_id for gene_id in ['ENSG00000268903', 'ENSG00000233653'] if gene_id in response_json['genesById'])
         self.assertSetEqual(set(response_json['genesById'][basic_gene_id].keys()), gene_fields)
-        if has_confidence_gene:
+        if has_pa_attrs:
+            gene_fields.add('locusListPaAttrs')
             gene_fields.add('locusListConfidence')
             self.assertSetEqual(set(response_json['genesById']['ENSG00000227232'].keys()), gene_fields)
             self.assertListEqual(
@@ -158,10 +160,15 @@ class VariantSearchAPITest(object):
             self.assertDictEqual(
                 response_json['genesById']['ENSG00000227232']['locusListConfidence'], {LOCUS_LIST_GUID: '3'}
             )
+            self.assertDictEqual(
+                response_json['genesById']['ENSG00000227232']['locusListPaAttrs'], {LOCUS_LIST_GUID: {'confidence': '3', 'moi': 'BIALLELIC, autosomal or pseudoautosomal'}}
+            )
 
         locus_list_fields = {'intervals'}
         if locus_list_detail:
             locus_list_fields.update(LOCUS_LIST_FIELDS)
+            if has_pa_attrs:
+                locus_list_fields.update({'paLocusList'})
         self.assertSetEqual(set(response_json['locusListsByGuid'][LOCUS_LIST_GUID].keys()), locus_list_fields)
         intervals = response_json['locusListsByGuid'][LOCUS_LIST_GUID]['intervals']
         self.assertEqual(len(intervals), 2)
@@ -378,7 +385,7 @@ class VariantSearchAPITest(object):
         })
         expected_search_response['search']['totalResults'] = 1
         self.assertDictEqual(response_json, expected_search_response)
-        self._assert_expected_results_context(response_json, has_confidence_gene=False)
+        self._assert_expected_results_context(response_json, has_pa_attrs=False)
         mock_error_logger.assert_not_called()
 
         # Test cross-project discovery for analyst users

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -152,13 +152,9 @@ class VariantSearchAPITest(object):
         self.assertSetEqual(set(response_json['genesById'][basic_gene_id].keys()), gene_fields)
         if has_pa_attrs:
             gene_fields.add('locusListPaAttrs')
-            gene_fields.add('locusListConfidence')
             self.assertSetEqual(set(response_json['genesById']['ENSG00000227232'].keys()), gene_fields)
             self.assertListEqual(
                 response_json['genesById']['ENSG00000227232']['locusListGuids'], [LOCUS_LIST_GUID]
-            )
-            self.assertDictEqual(
-                response_json['genesById']['ENSG00000227232']['locusListConfidence'], {LOCUS_LIST_GUID: '3'}
             )
             self.assertDictEqual(
                 response_json['genesById']['ENSG00000227232']['locusListPaAttrs'], {LOCUS_LIST_GUID: {'confidence': '3', 'moi': 'BIALLELIC, autosomal or pseudoautosomal'}}

--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User
 from django.test import TestCase
 import mock
-
+from copy import deepcopy
 from seqr.models import Project, Family, Individual, Sample, IgvSample, SavedVariant, VariantTag, VariantFunctionalData, \
     VariantNote, LocusList, VariantSearch
 from seqr.views.utils.orm_to_json_utils import _get_json_for_user, _get_json_for_project, _get_json_for_family, \
@@ -10,8 +10,8 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_user, _get_json_for
  get_json_for_saved_search, get_json_for_saved_variants_with_tags
 from seqr.views.utils.test_utils import USER_FIELDS, PROJECT_FIELDS, FAMILY_FIELDS, INTERNAL_FAMILY_FIELDS, \
     INDIVIDUAL_FIELDS, INTERNAL_INDIVIDUAL_FIELDS, INDIVIDUAL_FIELDS_NO_FEATURES, SAMPLE_FIELDS, SAVED_VARIANT_FIELDS,  \
-    FUNCTIONAL_FIELDS, SAVED_SEARCH_FIELDS, LOCUS_LIST_DETAIL_FIELDS, IGV_SAMPLE_FIELDS, CASE_REVIEW_FAMILY_FIELDS, \
-    TAG_FIELDS, VARIANT_NOTE_FIELDS
+    FUNCTIONAL_FIELDS, SAVED_SEARCH_FIELDS, LOCUS_LIST_DETAIL_FIELDS, PA_LOCUS_LIST_FIELDS, IGV_SAMPLE_FIELDS, \
+    CASE_REVIEW_FAMILY_FIELDS, TAG_FIELDS, VARIANT_NOTE_FIELDS
 
 class JSONUtilsTest(TestCase):
     databases = '__all__'
@@ -184,4 +184,6 @@ class JSONUtilsTest(TestCase):
         locus_list = LocusList.objects.first()
         user = User.objects.filter().first()
         json = get_json_for_locus_list(locus_list, user)
-        self.assertSetEqual(set(json.keys()), LOCUS_LIST_DETAIL_FIELDS)
+        exp_detail_fields = deepcopy(LOCUS_LIST_DETAIL_FIELDS)
+        exp_detail_fields.update(PA_LOCUS_LIST_FIELDS)
+        self.assertSetEqual(set(json.keys()), exp_detail_fields)

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -493,6 +493,7 @@ LOCUS_LIST_FIELDS = {
     'locusListGuid', 'description', 'lastModifiedDate', 'numEntries', 'isPublic', 'createdBy', 'createdDate', 'canEdit',
     'name',
 }
+PA_LOCUS_LIST_FIELDS = {'paLocusList'}
 LOCUS_LIST_DETAIL_FIELDS = {'items', 'intervalGenomeVersion'}
 LOCUS_LIST_DETAIL_FIELDS.update(LOCUS_LIST_FIELDS)
 

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -147,11 +147,6 @@ def _add_discovery_tags(variants, discovery_tags):
 
 def _add_pa_attrs(locus_list_gene, locus_list_guid, gene_json):
     if hasattr(locus_list_gene, 'palocuslistgene'):
-        # Keeping locusListConfidence for backwards compatibility for now
-        if not gene_json.get('locusListConfidence'):
-            gene_json['locusListConfidence'] = {}
-        gene_json['locusListConfidence'][locus_list_guid] = locus_list_gene.palocuslistgene.confidence_level
-
         if not gene_json.get('locusListPaAttrs'):
             gene_json['locusListPaAttrs'] = {}
         gene_json['locusListPaAttrs'][locus_list_guid] = {

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -105,14 +105,11 @@ def _add_locus_lists(projects, genes, add_list_detail=False, user=None, is_analy
     for interval in _get_json_for_models(intervals, nested_fields=[{'fields': ('locus_list', 'guid')}]):
         locus_lists_by_guid[interval['locusListGuid']]['intervals'].append(interval)
 
-    for locus_list_gene in LocusListGene.objects.filter(locus_list__in=locus_lists, gene_id__in=genes.keys()).prefetch_related('locus_list', 'palocuslistgene'):
+    for locus_list_gene in LocusListGene.objects.filter(locus_list__in=locus_lists, gene_id__in=genes.keys()).prefetch_related('locus_list', 'locus_list__palocuslist', 'palocuslistgene'):
         gene_json = genes[locus_list_gene.gene_id]
         locus_list_guid = locus_list_gene.locus_list.guid
         gene_json['locusListGuids'].append(locus_list_guid)
-        if hasattr(locus_list_gene, 'palocuslistgene'):
-            if not gene_json.get('locusListConfidence'):
-                gene_json['locusListConfidence'] = {}
-            gene_json['locusListConfidence'][locus_list_guid] = locus_list_gene.palocuslistgene.confidence_level
+        _add_pa_attrs(locus_list_gene, locus_list_guid, gene_json)
 
     return locus_lists_by_guid
 
@@ -146,6 +143,21 @@ def _add_discovery_tags(variants, discovery_tags):
             if not variant.get('discoveryTags'):
                 variant['discoveryTags'] = []
             variant['discoveryTags'] += [tag for tag in tags if tag['savedVariant']['familyGuid'] not in variant['familyGuids']]
+
+
+def _add_pa_attrs(locus_list_gene, locus_list_guid, gene_json):
+    if hasattr(locus_list_gene, 'palocuslistgene'):
+        # Keeping locusListConfidence for backwards compatibility for now
+        if not gene_json.get('locusListConfidence'):
+            gene_json['locusListConfidence'] = {}
+        gene_json['locusListConfidence'][locus_list_guid] = locus_list_gene.palocuslistgene.confidence_level
+
+        if not gene_json.get('locusListPaAttrs'):
+            gene_json['locusListPaAttrs'] = {}
+        gene_json['locusListPaAttrs'][locus_list_guid] = {
+            'confidence': locus_list_gene.palocuslistgene.confidence_level,
+            'moi': locus_list_gene.palocuslistgene.mode_of_inheritance,
+        }
 
 
 LOAD_PROJECT_TAG_TYPES_CONTEXT_PARAM = 'loadProjectTagTypes'

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -1272,6 +1272,18 @@ const VARIANT_ICON_COLORS = {
   green: '#21a926',
 }
 
+export const PANEL_APP_MODE_OF_INHERITANCE_INITIALS = {
+  BIALLELIC: 'AR',
+  IMPRINTED_MATERNALY_EXPRESSED: null,
+  IMPRINTED_PATERNALY_EXPRESSED: null,
+  MITOCHONDRIAL: null,
+  MONOALLELIC: 'AD',
+  OTHER: null,
+  UNKNOWN: null,
+  X_LINKED_DOMINANT: 'XD',
+  X_LINKED_RECESSIVE: 'XR',
+}
+
 export const PANEL_APP_CONFIDENCE_DESCRIPTION = {
   0: 'No Panel App confidence level',
   1: 'Red, lowest level of confidence; 1 of the 4 sources or from other sources.',

--- a/ui/shared/utils/panelAppUtils.js
+++ b/ui/shared/utils/panelAppUtils.js
@@ -41,7 +41,7 @@ export const moiToMoiTypes = (rawMoi) => {
     return ['UNKNOWN']
   }
 
-  return ['OTHER']
+  return ['UNKNOWN']
 }
 
 export const panelAppUrl = (apiUrl, panelId, gene) => {

--- a/ui/shared/utils/panelAppUtils.js
+++ b/ui/shared/utils/panelAppUtils.js
@@ -1,0 +1,51 @@
+export const moiToMoiTypes = (rawMoi) => {
+  if (!rawMoi) {
+    return 'UNKNOWN'
+  }
+
+  const moi = rawMoi.toUpperCase()
+
+  if (moi.startsWith('MONOALLELIC')) {
+    if (moi.includes('PATERNALLY IMPRINTED')) {
+      return ['IMPRINTED_PATERNALY_EXPRESSED']
+    }
+    if (moi.includes('MATERNALLY IMPRINTED')) {
+      return ['IMPRINTED_MATERNALY_EXPRESSED']
+    }
+    return ['MONOALLELIC']
+  }
+  if (moi.startsWith('X-LINKED') || moi.startsWith('X LINKED')) {
+    if (moi.includes('BIALLELIC MUTATIONS')) {
+      return ['X_LINKED_RECESSIVE']
+    }
+    if (moi.includes('MONOALLELIC MUTATIONS')) {
+      return ['X_LINKED_RECESSIVE', 'X_LINKED_DOMINANT']
+    }
+  }
+  if (moi.startsWith('BIALLELIC')) {
+    return ['BIALLELIC']
+  }
+  if (moi.startsWith('BOTH')) {
+    return ['MONOALLELIC', 'BIALLELIC']
+  }
+  if (moi.startsWith('MITOCHONDRIAL')) {
+    return ['MITOCHONDRIAL']
+  }
+  if (moi.startsWith('OTHER')) {
+    if (moi.includes('EVALUATION COMMENTS')) {
+      return ['UNKNOWN']
+    }
+    return ['OTHER']
+  }
+  if (moi.startsWith('UNKNOWN')) {
+    return ['UNKNOWN']
+  }
+
+  return ['OTHER']
+}
+
+export const panelAppUrl = (apiUrl, panelId, gene) => {
+  const baseUrl = apiUrl.split('/api')[0]
+
+  return `${baseUrl}/panels/${panelId}/gene/${gene}`
+}

--- a/ui/shared/utils/panelAppUtils.test.js
+++ b/ui/shared/utils/panelAppUtils.test.js
@@ -1,0 +1,73 @@
+import { moiToMoiTypes, panelAppUrl } from './panelAppUtils'
+
+const moiArray = [['1', 'PanelApp_AU', 'BIALLELIC', 'BIALLELIC, autosomal or pseudoautosomal'],
+  ['2', 'PanelApp_AU', 'MONOALLELIC', 'MONOALLELIC, autosomal or pseudoautosomal, NOT imprinted'],
+  ['3', 'PanelApp_AU', 'UNKNOWN', 'Unknown'],
+  ['4', 'PanelApp_AU', 'MONOALLELIC,BIALLELIC', 'BOTH monoallelic and biallelic, autosomal or pseudoautosomal'],
+  ['5', 'PanelApp_AU', 'MONOALLELIC', 'MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown'],
+  ['6', 'PanelApp_AU', 'X_LINKED_RECESSIVE', 'X-LINKED: hemizygous mutation in males, biallelic mutations in females'],
+  ['7', 'PanelApp_AU', 'OTHER', 'Other'],
+  ['8', 'PanelApp_AU', 'X_LINKED_RECESSIVE,X_LINKED_DOMINANT', 'X-LINKED: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)'],
+  ['9', 'PanelApp_AU', 'UNKNOWN', 'NULL'],
+  ['10', 'PanelApp_AU', 'MONOALLELIC,BIALLELIC', 'BOTH monoallelic and biallelic (but BIALLELIC mutations cause a more SEVERE disease form), autosomal or pseudoautosomal'],
+  ['11', 'PanelApp_AU', 'MITOCHONDRIAL', 'MITOCHONDRIAL'],
+  ['12', 'PanelApp_AU', 'IMPRINTED_MATERNALY_EXPRESSED', 'MONOALLELIC, autosomal or pseudoautosomal, maternally imprinted (paternal allele expressed)'],
+  ['13', 'PanelApp_AU', 'IMPRINTED_PATERNALY_EXPRESSED', 'MONOALLELIC, autosomal or pseudoautosomal, paternally imprinted (maternal allele expressed)'],
+  ['14', 'PanelApp_UK', 'BIALLELIC', 'BIALLELIC, autosomal or pseudoautosomal'],
+  ['15', 'PanelApp_UK', 'UNKNOWN', 'NULL'],
+  ['16', 'PanelApp_UK', 'MONOALLELIC', 'MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown'],
+  ['17', 'PanelApp_UK', 'MONOALLELIC', 'MONOALLELIC, autosomal or pseudoautosomal, NOT imprinted'],
+  ['18', 'PanelApp_UK', 'MONOALLELIC,BIALLELIC', 'BOTH monoallelic and biallelic, autosomal or pseudoautosomal'],
+  ['19', 'PanelApp_UK', 'UNKNOWN', 'Unknown'],
+  ['20', 'PanelApp_UK', 'X_LINKED_RECESSIVE', 'X-LINKED: hemizygous mutation in males, biallelic mutations in females'],
+  ['21', 'PanelApp_UK', 'X_LINKED_RECESSIVE,X_LINKED_DOMINANT', 'X-LINKED: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)'],
+  ['22', 'PanelApp_UK', 'IMPRINTED_MATERNALY_EXPRESSED', 'MONOALLELIC, autosomal or pseudoautosomal, maternally imprinted (paternal allele expressed)'],
+  ['23', 'PanelApp_UK', 'MONOALLELIC,BIALLELIC', 'BOTH monoallelic and biallelic (but BIALLELIC mutations cause a more SEVERE disease form), autosomal or pseudoautosomal'],
+  ['24', 'PanelApp_UK', 'MITOCHONDRIAL', 'MITOCHONDRIAL'],
+  ['25', 'PanelApp_UK', 'IMPRINTED_PATERNALY_EXPRESSED', 'MONOALLELIC, autosomal or pseudoautosomal, paternally imprinted (maternal allele expressed)'],
+  ['26', 'PanelApp_UK', 'OTHER', 'Other'],
+  ['27', 'PanelApp_UK', 'UNKNOWN', 'Other - please specifiy in evaluation comments'],
+  ['28', 'PanelApp_UK', 'UNKNOWN', 'Other - please specify in evaluation comments'],
+  ['29', 'PanelApp_UK', 'MONOALLELIC', 'MONOALLELIC, autosomal or pseudoautosomal'],
+  ['30', 'PanelApp_UK', 'IMPRINTED_PATERNALY_EXPRESSED', 'MONOALLELIC, autosomal or pseudoautosomal, paternally imprinted (maternal allele expressed)'],
+  ['31', 'PanelApp_UK', 'X_LINKED_RECESSIVE,X_LINKED_DOMINANT', 'X linked: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)']]
+
+describe('Test moiToMoiTypes()', () => {
+  test.each(moiArray)('%s) %s: %s', (index, origin, moiType, moi) => {
+    expect(moiToMoiTypes(moi)).toEqual(moiType.split(','))
+  })
+})
+
+const panelAppData = [{
+  url: 'https://panelapp.agha.umccr.org/api/v1/panels/40/genes',
+  panel: 40,
+  gene: 'SLC2A1',
+  result: 'https://panelapp.agha.umccr.org/panels/40/gene/SLC2A1',
+}, {
+  url: 'https://panelapp.agha.umccr.org/api/v1/panels/40/genes',
+  panel: 40,
+  gene: 'SLC1A3',
+  result: 'https://panelapp.agha.umccr.org/panels/40/gene/SLC1A3',
+}, {
+  url: 'https://panelapp.genomicsengland.co.uk/api/v1',
+  panel: 486,
+  gene: 'GRIA2',
+  result: 'https://panelapp.genomicsengland.co.uk/panels/486/gene/GRIA2',
+}, {
+  url: 'https://panelapp.genomicsengland.co.uk/api/v1',
+  panel: 486,
+  gene: 'KIRREL3',
+  result: 'https://panelapp.genomicsengland.co.uk/panels/486/gene/KIRREL3',
+}, {
+  url: 'https://panelapp.genomicsengland.co.uk/api/v1',
+  panel: 486,
+  gene: 'ACOX1',
+  result: 'https://panelapp.genomicsengland.co.uk/panels/486/gene/ACOX1',
+}].map(account => Object.assign(account, { toString() { return this.gene } }))
+
+describe('Test panelAppUrl()', () => {
+  test.each(panelAppData)('panelAppUrl for gene: %s', (data) => {
+    const { url, panel, gene } = data
+    expect(panelAppUrl(url, panel, gene)).toEqual(data.result)
+  })
+})


### PR DESCRIPTION
For discussion #2700

Show PanelApp Mode of Inheritance in the Genelist Label on the variant_search page, with design as discussed in #2700:

![Screen Shot 2022-05-18 at 12 33 30 am](https://user-images.githubusercontent.com/3320713/168836929-1ef31f88-955d-47b5-9c2a-0bb4110f4c88.png)

* The freetext MOI from PanelApp is translated into an array of enums, which can be shown as initials on the label if they are of the 4 most common types: AD (Autosomal Dominant/Monoallelic), AR (Autosomal Recessive/Biallelic), XD (X-Linked Dominant), XR (X-Linked Recessive).
* The freetext MOI has been added to the pop-over. And if initials are used, the initials are shown next to the MOI.
* The max-width of the labels has been widened from 7em to 12em.
* The PanelApp link has been added to the pop-over.
* The URL API origin of the PanelApp genelist and the panelApp ID are provided with the locusList, so this link can be generated in the front end.
* PanelApp confidence has been moved to PaAttrs on the gene, along with the new moi attribute.
* Unit tests have been written for the new apis and utility functions, in python and jest.