### PR TITLE
update preprint link label

### DIFF
--- a/ui/pages/Public/components/LandingPage.jsx
+++ b/ui/pages/Public/components/LandingPage.jsx
@@ -61,7 +61,7 @@ const LandingPage = ({ googleLoginEnabled }) => (
       Broad Institute.
       <Header size="small">
         {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
-        View the <SeqrPaperLink content={<span><i>seqr</i> preprint</span>} />
+        View the <SeqrPaperLink content={<span><i>seqr</i> paper</span>} />
       </Header>
     </PageSegment>
     <PageSegment size="large">


### PR DESCRIPTION
The actual link was updated from the preprint to the main paper in a previous PR, but we accidentally left the word preprint here