### PR TITLE
saved variant model fields supercede cached json

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1375,6 +1375,7 @@
             "predictions": {"eigen": null, "revel": null, "sift": null, "cadd": "14.33", "metasvm": "", "mpc": null, "splice_ai": null, "phastcons_100_vert": null, "mut_taster": null, "fathmm": null, "polyphen": null, "dann": null, "primate_ai": null, "gerp_rs": null},
             "hgmd": {"accession": null, "class": null},
             "rsid": null,
+            "selectedMainTranscriptId": null,
             "liftedOverChrom": "",
             "originalAltAlleles": ["G"],
             "transcripts": {"ENSG00000135953": [

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -8,6 +8,7 @@ from seqr.models import SavedVariant, VariantNote, VariantTag, VariantFunctional
 from seqr.views.apis.saved_variant_api import saved_variant_data, create_variant_note_handler, create_saved_variant_handler, \
     update_variant_note_handler, delete_variant_note_handler, update_variant_tags_handler, update_saved_variant_json, \
     update_variant_main_transcript, update_variant_functional_data_handler, update_variant_acmg_classification_handler
+from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variant
 from seqr.views.utils.test_utils import AuthenticationTestCase, SAVED_VARIANT_FIELDS, TAG_FIELDS, GENE_VARIANT_FIELDS, \
     TAG_TYPE_FIELDS, LOCUS_LIST_FIELDS, PA_LOCUS_LIST_FIELDS, FAMILY_FIELDS, INDIVIDUAL_FIELDS, IGV_SAMPLE_FIELDS, \
     FAMILY_NOTE_FIELDS, AnvilAuthenticationTestCase, MixAuthenticationTestCase
@@ -877,6 +878,7 @@ class SavedVariantAPITest(object):
 
         saved_variant = SavedVariant.objects.get(guid=VARIANT_GUID)
         self.assertEqual(saved_variant.selected_main_transcript_id, transcript_id)
+        self.assertEqual(get_json_for_saved_variant(saved_variant, add_details=True)['selectedMainTranscriptId'], transcript_id)
 
     def test_update_variant_acmg_classification(self):
         update_variant_acmg_classification_url = reverse(update_variant_acmg_classification_handler, args=[VARIANT_GUID])

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -445,7 +445,7 @@ def get_json_for_saved_variants(saved_variants, add_details=False):
     """
     def _process_result(variant_json, saved_variant):
         if add_details:
-            variant_json.update(saved_variant.saved_variant_json)
+            variant_json.update({k: v for k, v in saved_variant.saved_variant_json.items() if k not in variant_json})
         variant_json['familyGuids'] = [saved_variant.family.guid]
         return variant_json
 


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/seqr/issues/2749 and sets desired behavior that the fields explicitly set on the model always override anything cached in the json