### PR TITLE
Fix sorting in management console

### DIFF
--- a/ui/pages/DataManagement/components/ElasticsearchStatus.jsx
+++ b/ui/pages/DataManagement/components/ElasticsearchStatus.jsx
@@ -9,29 +9,7 @@ import DataTable from 'shared/components/table/DataTable'
 import DataLoader from 'shared/components/DataLoader'
 import { getElasticsearchStatusLoading, getElasticsearchStatusData } from '../selectors'
 import { loadElasticsearchStatus, deleteEsIndex } from '../reducers'
-
-const sizeToBytes = (string) => {
-  if (!string || string.length < 2) return null
-
-  const units = {
-    kb: 1024,
-    mb: 1024 * 1024,
-    gb: 1024 * 1024 * 1024,
-  }
-  const size = parseFloat(string.slice(0, -2))
-  const stringUnit = string.slice(-2).toLowerCase()
-
-  return size * units[stringUnit]
-}
-const formatBytes = (bytes) => {
-  if (bytes === 0) return '0 Bytes'
-  if (!bytes) return null
-  const k = 1024
-  const dm = 2
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
-  return `${parseFloat((bytes / (k ** i)).toFixed(dm))}\xa0${sizes[i]}`
-}
+import { sizeToBytes, formatBytes } from '../../../shared/utils/stringUtils'
 
 const DISK_STAT_COLUMNS = [
   { name: 'node', content: 'Node name' },
@@ -50,7 +28,7 @@ const NODE_STAT_COLUMNS = [
 const INDEX_COLUMNS = [
   { name: 'index', content: 'Index' },
   {
-    name: 'projects',
+    name: 'projectSort',
     content: 'Project(s)',
     format: row => ((row.projects && row.projects.length) ? row.projects.map(project => (
       <div key={project.projectGuid}>
@@ -103,6 +81,7 @@ const ElasticsearchStatus = React.memo(({ data, loading, load }) => {
     ...index,
     docsCount: parseInt(index.docsCount, 10),
     storeSize: sizeToBytes(index.storeSize),
+    projectSort: index.projects?.map(project => `000${index.projects.length}`.slice(-3) + project.projectName)[0],
   })) || []
 
   return (

--- a/ui/shared/utils/stringUtils.js
+++ b/ui/shared/utils/stringUtils.js
@@ -19,3 +19,30 @@ export const toUniqueCsvString = (...csvStrs) => {
 
   return [...new Set(splitted)].join(',')
 }
+
+export const sizeToBytes = (string) => {
+  if (!string || string.length < 2) return null
+
+  const units = {
+    kb: 1024,
+    mb: 1024 * 1024,
+    gb: 1024 * 1024 * 1024,
+    tb: 1024 * 1024 * 1024 * 1024,
+    pb: 1024 * 1024 * 1024 * 1024 * 1024,
+    eb: 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+  }
+  const size = parseFloat(string.slice(0, -2))
+  const stringUnit = string.slice(-2).toLowerCase()
+
+  return size * units[stringUnit]
+}
+
+export const formatBytes = (bytes) => {
+  if (bytes === 0) return '0 Bytes'
+  if (!bytes) return null
+  const k = 1024
+  const dm = 2
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / (k ** i)).toFixed(dm))}\xa0${sizes[i]}`
+}


### PR DESCRIPTION
Low Priority

The tables in the Elastic Search Managment Console are not being sorted properly.
https://seqr.broadinstitute.org/data_management/elasticsearch_status

I dressed them up a bit and made them more usable.

* Simple numbers (shards) are parsed so they sort properly
* Disk sizes are stored as bytes to be sortable, and then formatted to be human readble
* The more complex Projects array of objects is sorted on number of projects, then project name.

I used this low priority task to understand the tables used in seqr, since other tables in seqr use the same DataTable component and similar patterns would be used for modifying them.