### PR TITLE
fix: Show gene lists filter input field due to bad margin

### DIFF
--- a/ui/shared/components/table/LocusListTables.jsx
+++ b/ui/shared/components/table/LocusListTables.jsx
@@ -17,8 +17,6 @@ import {
 
 const FilterContainer = styled.div`
   position: relative;
-  top: -60px;
-  margin-bottom: -60px;
   text-align: right;
 `
 


### PR DESCRIPTION
* Suspect this was caused by the new maxHeight prop in DataTable introduced in https://github.com/broadinstitute/seqr/pull/2532
