### PR TITLE
Add mode of inheritance to location search

### DIFF
--- a/panelapp/models.py
+++ b/panelapp/models.py
@@ -53,4 +53,4 @@ class PaLocusListGene(models.Model):
     class Meta:
         """Fields included in JSON in API calls."""
 
-        json_fields = ['confidence_level']
+        json_fields = ['confidence_level', 'mode_of_inheritance']

--- a/panelapp/pa_locus_list_api_tests.py
+++ b/panelapp/pa_locus_list_api_tests.py
@@ -23,7 +23,7 @@ PA_LOCUS_LIST_FIELDS.update(LOCUS_LIST_DETAIL_FIELDS)
 
 PA_LOCUS_LIST_DETAIL_FIELDS = {'items', 'intervalGenomeVersion'}
 PA_LOCUS_LIST_DETAIL_FIELDS.update(PA_LOCUS_LIST_FIELDS)
-PA_GENE_FIELDS = {'confidenceLevel'}
+PA_GENE_FIELDS = {'confidenceLevel', 'modeOfInheritance'}
 
 PANEL_APP_API_URL_AU = 'https://test-panelapp.url.au/api'
 PANEL_APP_API_URL_UK = 'https://test-panelapp.url.uk/api'

--- a/ui/pages/Search/components/VariantSearchFormContent.jsx
+++ b/ui/pages/Search/components/VariantSearchFormContent.jsx
@@ -117,7 +117,7 @@ const LOCATION_PANEL_WITH_GENE_LIST = {
   headerProps: {
     title: 'Location',
     name: 'locus',
-    inputSize: 5,
+    inputSize: 10,
     inputProps: { component: LocusListSelector, format: val => val || {} },
   },
 }

--- a/ui/pages/Search/components/VariantSearchFormContent.jsx
+++ b/ui/pages/Search/components/VariantSearchFormContent.jsx
@@ -117,7 +117,7 @@ const LOCATION_PANEL_WITH_GENE_LIST = {
   headerProps: {
     title: 'Location',
     name: 'locus',
-    inputSize: 10,
+    inputSize: 12,
     inputProps: { component: LocusListSelector, format: val => val || {} },
   },
 }

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -52,7 +52,6 @@ class BaseLocusListDropdown extends React.Component {
     }
   }
 
-  // ignore all other properties on wrapperObject, except locusListGuid
   handleDropdown = (locusListGuid) => {
     const { onChange } = this.props
     onChange({ locusListGuid, selectedMOIs: [] })
@@ -79,10 +78,15 @@ class BaseLocusListDropdown extends React.Component {
       />
     )
 
+    const rightJustify = {
+      justifyContent: 'right',
+    }
+
     if (locusList.paLocusList) {
       return (
-        <div>
+        <div className="inline fields" style={rightJustify}>
           <Multiselect
+            className="wide eight"
             label="Modes of Inheritance"
             value={selectedMOIs}
             onChange={this.handleMOIselect}

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -79,7 +79,10 @@ class BaseLocusListDropdown extends React.Component {
       return acc
     }, {}) || {}
 
-    return PANEL_APP_MOI_OPTIONS.filter(moi => initials[moi.value])
+    return PANEL_APP_MOI_OPTIONS.map(moi => ({
+      ...moi,
+      disabled: !initials[moi.value],
+    }))
   }
 
   render() {

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -36,7 +36,8 @@ class BaseLocusListDropdown extends React.Component {
         const panelAppItems = locusList.items?.filter((item) => {
           let result = true
           if (selectedMOIs && selectedMOIs.length !== 0) {
-            const initials = moiToMoiInitials(item.pagene.modeOfInheritance)
+            const initials = moiToMoiInitials(item.pagene?.modeOfInheritance)
+            if (initials.length === 0) initials.push('other')
             result = selectedMOIs.filter(moi => initials.includes(moi)).length !== 0
           }
           return result
@@ -60,6 +61,36 @@ class BaseLocusListDropdown extends React.Component {
   handleMOIselect = (selectedMOIs) => {
     const { locusList, onChange } = this.props
     onChange({ locusListGuid: locusList.locusListGuid, selectedMOIs })
+  }
+
+  moiOptions = () => {
+    const { locusList } = this.props
+    if (!locusList.items) {
+      return []
+    }
+    const initials = locusList.items?.reduce((acc, gene) => {
+      moiToMoiInitials(gene.pagene?.modeOfInheritance).forEach((initial) => {
+        acc[initial] = true
+      })
+      if (moiToMoiInitials(gene.pagene?.modeOfInheritance).length === 0) {
+        acc.other = true
+      }
+      return acc
+    }, {}) || {}
+
+    const moiOptions = PANEL_APP_MOI_OPTIONS.map((moi) => {
+      if (initials[moi.value] !== true) {
+        return {
+          ...moi,
+          disabled: true,
+        }
+      }
+      return {
+        ...moi,
+      }
+    })
+
+    return moiOptions
   }
 
   render() {
@@ -91,7 +122,7 @@ class BaseLocusListDropdown extends React.Component {
             value={selectedMOIs}
             onChange={this.handleMOIselect}
             placeholder="Showing All MOIs"
-            options={PANEL_APP_MOI_OPTIONS}
+            options={this.moiOptions()}
             color="violet"
           />
           { GeneListDropdown }

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -68,6 +68,7 @@ class BaseLocusListDropdown extends React.Component {
     if (!locusList.items) {
       return []
     }
+
     const initials = locusList.items?.reduce((acc, gene) => {
       moiToMoiInitials(gene.pagene?.modeOfInheritance).forEach((initial) => {
         acc[initial] = true
@@ -78,19 +79,7 @@ class BaseLocusListDropdown extends React.Component {
       return acc
     }, {}) || {}
 
-    const moiOptions = PANEL_APP_MOI_OPTIONS.map((moi) => {
-      if (initials[moi.value] !== true) {
-        return {
-          ...moi,
-          disabled: true,
-        }
-      }
-      return {
-        ...moi,
-      }
-    })
-
-    return moiOptions
+    return PANEL_APP_MOI_OPTIONS.filter(moi => initials[moi.value])
   }
 
   render() {

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-perf/jsx-no-new-array-as-prop */
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
 import { FormSpy } from 'react-final-form'
-import { Form } from 'semantic-ui-react'
 import { Dropdown, Multiselect } from 'shared/components/form/Inputs'
 import { LocusListItemsLoader } from 'shared/components/LocusListLoader'
 import { PANEL_APP_CONFIDENCE_LEVELS } from 'shared/utils/constants'
@@ -19,8 +18,6 @@ class BaseLocusListDropdown extends React.Component {
     selectedMOIs: PropTypes.arrayOf(PropTypes.string),
   }
 
-  // selectedMOIs = []
-
   shouldComponentUpdate(nextProps) {
     const { locusList, selectedMOIs, projectLocusListOptions, onChange } = this.props
 
@@ -34,39 +31,21 @@ class BaseLocusListDropdown extends React.Component {
   componentDidUpdate(prevProps) {
     const { locusList, onChange, selectedMOIs } = this.props
 
-    console.log('running Component Did Update')
-    console.log(this.props)
-    console.log(prevProps)
-
     if (prevProps.locusList.rawItems !== locusList.rawItems || prevProps.selectedMOIs !== selectedMOIs) {
       const { locusListGuid } = locusList
 
       if (locusList.paLocusList) {
-        console.log('hey, I guess you picked a PanelApp list')
-        console.log('locusList', locusList)
-        console.log('the rest of the props', this.props)
-        console.log('selectedMOIs are:', selectedMOIs)
-        console.log('prevProps.selectedMOIs', prevProps.selectedMOIs)
-
         const panelAppItems = locusList.items?.filter((item) => {
           let result = true
           if (prevProps.selectedMOIs) {
             const initials = moiToMoiInitials(item.pagene.modeOfInheritance)
-            console.log(prevProps.selectedMOIs)
-            console.log('initials: ', initials)
             result = prevProps.selectedMOIs.filter(moi => initials.includes(moi)).length
           }
           return result
         }).reduce((acc, item) => {
-          console.log('item', item)
-
           const color = PANEL_APP_CONFIDENCE_LEVELS[item.pagene?.confidenceLevel] || PANEL_APP_CONFIDENCE_LEVELS[0]
           return { ...acc, [color]: [acc[color], item.display].filter(val => val).join(', ') }
         }, {})
-        console.log('about to run onChange', locusListGuid)
-        console.log('panelAppItems', panelAppItems)
-        console.log(this.props)
-
         onChange({ locusListGuid, panelAppItems })
       } else {
         const { rawItems } = locusList
@@ -77,21 +56,11 @@ class BaseLocusListDropdown extends React.Component {
 
   // ignore all other properties on wrapperObject, except locusListGuid
   handleDropdown = (locusListGuid) => {
-    console.log('this gets called first')
-    console.log('running onChange in LocusListSelector', this.props)
-    console.log('locusListGuid', locusListGuid)
     const { onChange } = this.props
-
-    console.log('search.locus stuff:', this.props)
     onChange({ locusListGuid })
   }
 
   handleMOIselect = (selectedMOIs) => {
-    console.log('handleMOIselect', selectedMOIs)
-    console.log(this.props)
-    // const { onChange } = this.props
-    // onChange({ modesOfInheritance: payload })
-    // this.selectedMOIs = selectedMOIs
     const { locusList, onChange } = this.props
     onChange({ locusListGuid: locusList.locusListGuid, selectedMOIs })
   }
@@ -99,11 +68,6 @@ class BaseLocusListDropdown extends React.Component {
   render() {
     const { locusList, projectLocusListOptions, selectedMOIs } = this.props
     const locusListGuid = locusList.locusListGuid || ''
-    // const selectedMOIs = this.selectedMOIs || []
-
-    // const selectedMOIs = this.props.selectedMOIs || 'g'.split()
-    // console.log('modesOfInheritance', modesOfInheritance)
-    // console.log('render props:', this.props)
 
     const options = [{
       text: 'Autosomal Dominant',
@@ -130,16 +94,13 @@ class BaseLocusListDropdown extends React.Component {
       return (
         <div>
           <Multiselect
-          // {...this.props}
-            // width={15}
             label="Modes of Inheritance"
             value={selectedMOIs}
             onChange={this.handleMOIselect}
             placeholder="Showing All MOIs"
-          // disabled={false}
             options={options}
             color="violet"
-            allowAdditions
+            // allowAdditions
           />
           <Dropdown
             inline
@@ -155,7 +116,7 @@ class BaseLocusListDropdown extends React.Component {
     }
 
     return (
-      <Form.Group inline widths="equal">
+      <div>
         <Dropdown
           inline
           selection
@@ -165,7 +126,7 @@ class BaseLocusListDropdown extends React.Component {
           onChange={this.handleDropdown}
           options={projectLocusListOptions}
         />
-      </Form.Group>
+      </div>
     )
   }
 
@@ -179,18 +140,12 @@ const LocusListDropdown = connect(mapStateToProps)(BaseLocusListDropdown)
 
 const SUBSCRIPTION = { values: true }
 
-// When onChange is called, this is the function that is called.
-// Values are passed here.
-const LocusListSelector = React.memo(({ value, ...props }) => {
-  console.log('selecting stuff')
-  console.log(value)
-  console.log(props)
-  return (
-    <LocusListItemsLoader locusListGuid={value.locusListGuid} reloadOnIdUpdate content hideLoading>
-      <LocusListDropdown selectedMOIs={value.selectedMOIs} {...props} />
-    </LocusListItemsLoader>
-  )
-})
+// When onChange is called, this selector will be called again to get the new value of the locusList
+const LocusListSelector = React.memo(({ value, ...props }) => (
+  <LocusListItemsLoader locusListGuid={value.locusListGuid} reloadOnIdUpdate content hideLoading>
+    <LocusListDropdown selectedMOIs={value.selectedMOIs} {...props} />
+  </LocusListItemsLoader>
+))
 
 LocusListSelector.propTypes = {
   value: PropTypes.object,

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -1,10 +1,13 @@
+/* eslint-disable react-perf/jsx-no-new-array-as-prop */
 import PropTypes from 'prop-types'
 import React from 'react'
 import { connect } from 'react-redux'
 import { FormSpy } from 'react-final-form'
-import { Dropdown } from 'shared/components/form/Inputs'
+import { Form } from 'semantic-ui-react'
+import { Dropdown, Multiselect } from 'shared/components/form/Inputs'
 import { LocusListItemsLoader } from 'shared/components/LocusListLoader'
 import { PANEL_APP_CONFIDENCE_LEVELS } from 'shared/utils/constants'
+import { moiToMoiInitials } from 'shared/utils/panelAppUtils'
 import { getSearchedProjectsLocusListOptions } from '../../selectors'
 
 class BaseLocusListDropdown extends React.Component {
@@ -13,27 +16,57 @@ class BaseLocusListDropdown extends React.Component {
     locusList: PropTypes.object,
     projectLocusListOptions: PropTypes.arrayOf(PropTypes.object),
     onChange: PropTypes.func,
+    selectedMOIs: PropTypes.arrayOf(PropTypes.string),
   }
 
+  // selectedMOIs = []
+
   shouldComponentUpdate(nextProps) {
-    const { locusList, projectLocusListOptions, onChange } = this.props
+    const { locusList, selectedMOIs, projectLocusListOptions, onChange } = this.props
+
     return nextProps.projectLocusListOptions !== projectLocusListOptions ||
+      nextProps.selectedMOIs !== selectedMOIs ||
       nextProps.onChange !== onChange ||
       nextProps.locusList.locusListGuid !== locusList.locusListGuid ||
       (!!locusList.locusListGuid && nextProps.locusList.rawItems !== locusList.rawItems)
   }
 
   componentDidUpdate(prevProps) {
-    const { locusList, onChange } = this.props
+    const { locusList, onChange, selectedMOIs } = this.props
 
-    if (prevProps.locusList.rawItems !== locusList.rawItems) {
+    console.log('running Component Did Update')
+    console.log(this.props)
+    console.log(prevProps)
+
+    if (prevProps.locusList.rawItems !== locusList.rawItems || prevProps.selectedMOIs !== selectedMOIs) {
       const { locusListGuid } = locusList
 
       if (locusList.paLocusList) {
-        const panelAppItems = locusList.items?.reduce((acc, item) => {
+        console.log('hey, I guess you picked a PanelApp list')
+        console.log('locusList', locusList)
+        console.log('the rest of the props', this.props)
+        console.log('selectedMOIs are:', selectedMOIs)
+        console.log('prevProps.selectedMOIs', prevProps.selectedMOIs)
+
+        const panelAppItems = locusList.items?.filter((item) => {
+          let result = true
+          if (prevProps.selectedMOIs) {
+            const initials = moiToMoiInitials(item.pagene.modeOfInheritance)
+            console.log(prevProps.selectedMOIs)
+            console.log('initials: ', initials)
+            result = prevProps.selectedMOIs.filter(moi => initials.includes(moi)).length
+          }
+          return result
+        }).reduce((acc, item) => {
+          console.log('item', item)
+
           const color = PANEL_APP_CONFIDENCE_LEVELS[item.pagene?.confidenceLevel] || PANEL_APP_CONFIDENCE_LEVELS[0]
           return { ...acc, [color]: [acc[color], item.display].filter(val => val).join(', ') }
         }, {})
+        console.log('about to run onChange', locusListGuid)
+        console.log('panelAppItems', panelAppItems)
+        console.log(this.props)
+
         onChange({ locusListGuid, panelAppItems })
       } else {
         const { rawItems } = locusList
@@ -42,26 +75,97 @@ class BaseLocusListDropdown extends React.Component {
     }
   }
 
-  onChange = (locusListGuid) => {
+  // ignore all other properties on wrapperObject, except locusListGuid
+  handleDropdown = (locusListGuid) => {
+    console.log('this gets called first')
+    console.log('running onChange in LocusListSelector', this.props)
+    console.log('locusListGuid', locusListGuid)
     const { onChange } = this.props
+
+    console.log('search.locus stuff:', this.props)
     onChange({ locusListGuid })
   }
 
+  handleMOIselect = (selectedMOIs) => {
+    console.log('handleMOIselect', selectedMOIs)
+    console.log(this.props)
+    // const { onChange } = this.props
+    // onChange({ modesOfInheritance: payload })
+    // this.selectedMOIs = selectedMOIs
+    const { locusList, onChange } = this.props
+    onChange({ locusListGuid: locusList.locusListGuid, selectedMOIs })
+  }
+
   render() {
-    const { locusList, projectLocusListOptions } = this.props
+    const { locusList, projectLocusListOptions, selectedMOIs } = this.props
     const locusListGuid = locusList.locusListGuid || ''
+    // const selectedMOIs = this.selectedMOIs || []
+
+    // const selectedMOIs = this.props.selectedMOIs || 'g'.split()
+    // console.log('modesOfInheritance', modesOfInheritance)
+    // console.log('render props:', this.props)
+
+    const options = [{
+      text: 'Autosomal Dominant',
+      value: 'AD',
+    },
+    {
+      text: 'Autosomal Recessive',
+      value: 'AR',
+    },
+    {
+      text: 'X-Linked Dominant',
+      value: 'XD',
+    },
+    {
+      text: 'X-Linked Recessive',
+      value: 'XR',
+    },
+    {
+      text: 'Other Mode of Inheritance',
+      value: 'other',
+    }]
+
+    if (projectLocusListOptions.find(option => option.value === locusListGuid)?.description === 'PanelApp') {
+      return (
+        <div>
+          <Multiselect
+          // {...this.props}
+            // width={15}
+            label="Modes of Inheritance"
+            value={selectedMOIs}
+            onChange={this.handleMOIselect}
+            placeholder="Showing All MOIs"
+          // disabled={false}
+            options={options}
+            color="violet"
+            allowAdditions
+          />
+          <Dropdown
+            inline
+            selection
+            search
+            label="Gene List"
+            value={locusListGuid}
+            onChange={this.handleDropdown}
+            options={projectLocusListOptions}
+          />
+        </div>
+      )
+    }
+
     return (
-      <div>
+      <Form.Group inline widths="equal">
         <Dropdown
           inline
           selection
           search
           label="Gene List"
           value={locusListGuid}
-          onChange={this.onChange}
+          onChange={this.handleDropdown}
           options={projectLocusListOptions}
         />
-      </div>
+      </Form.Group>
     )
   }
 
@@ -75,11 +179,18 @@ const LocusListDropdown = connect(mapStateToProps)(BaseLocusListDropdown)
 
 const SUBSCRIPTION = { values: true }
 
-const LocusListSelector = React.memo(({ value, ...props }) => (
-  <LocusListItemsLoader locusListGuid={value.locusListGuid} reloadOnIdUpdate content hideLoading>
-    <LocusListDropdown {...props} />
-  </LocusListItemsLoader>
-))
+// When onChange is called, this is the function that is called.
+// Values are passed here.
+const LocusListSelector = React.memo(({ value, ...props }) => {
+  console.log('selecting stuff')
+  console.log(value)
+  console.log(props)
+  return (
+    <LocusListItemsLoader locusListGuid={value.locusListGuid} reloadOnIdUpdate content hideLoading>
+      <LocusListDropdown selectedMOIs={value.selectedMOIs} {...props} />
+    </LocusListItemsLoader>
+  )
+})
 
 LocusListSelector.propTypes = {
   value: PropTypes.object,

--- a/ui/pages/Search/components/filters/LocusListSelector.jsx
+++ b/ui/pages/Search/components/filters/LocusListSelector.jsx
@@ -109,11 +109,11 @@ class BaseLocusListDropdown extends React.Component {
       return (
         <div className="inline fields" style={rightJustify}>
           <Multiselect
-            className="wide eight"
+            className="wide nine"
             label="Modes of Inheritance"
             value={selectedMOIs}
             onChange={this.handleMOIselect}
-            placeholder="Showing All MOIs"
+            placeholder="Showing all MOIs as listed in Panel App"
             options={this.moiOptions()}
             color="violet"
           />

--- a/ui/shared/components/form/Inputs.jsx
+++ b/ui/shared/components/form/Inputs.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Form, List, Button, Pagination as PaginationComponent, Search } from 'semantic-ui-react'
 
+import _ from 'lodash'
 import { helpLabel } from './FormHelpers'
 
 export class BaseSemanticInput extends React.Component {
@@ -110,7 +111,7 @@ export const Dropdown = React.memo(({ options, includeCategories, ...props }) =>
     noResultsMessage={null}
     tabIndex="0"
   />
-))
+), _.isEqual)
 
 Dropdown.propTypes = {
   options: PropTypes.arrayOf(PropTypes.object),
@@ -188,7 +189,7 @@ export class AddableSelect extends React.PureComponent {
 
   componentDidUpdate(prevProps) {
     const { options } = this.props
-    if (options.length !== prevProps.options.length) {
+    if (!_.isEqual(options, prevProps.options)) {
       this.resetOptions()
     }
   }

--- a/ui/shared/components/form/Inputs.jsx
+++ b/ui/shared/components/form/Inputs.jsx
@@ -58,6 +58,8 @@ const setIntVal = (onChange, min, max) => (stringVal) => {
   }
 }
 
+const stopPropagation = e => e.stopPropagation()
+
 export const IntegerInput = React.memo(({ onChange, min, max, value, ...props }) => (
   <BaseSemanticInput
     {...props}
@@ -67,6 +69,7 @@ export const IntegerInput = React.memo(({ onChange, min, max, value, ...props })
     min={min}
     max={max}
     onChange={setIntVal(onChange, min, max)}
+    onClick={stopPropagation}
   />
 ))
 

--- a/ui/shared/components/form/Inputs.jsx
+++ b/ui/shared/components/form/Inputs.jsx
@@ -22,11 +22,12 @@ export class BaseSemanticInput extends React.Component {
       if (nextProps.options.length !== (options || []).length) {
         return true
       }
-      Object.entries(nextProps.options).forEach(([i, opt]) => { // eslint-disable-line consistent-return
-        if (['value', 'text', 'color', 'disabled', 'description'].some(k => opt[k] !== options[i][k])) {
-          return true
-        }
-      })
+      if (Object.entries(nextProps.options)
+        .some(([i, opt]) => ['value', 'text', 'color', 'disabled', 'description']
+          .some(k => opt[k] !== options[i][k]))
+      ) {
+        return true
+      }
     }
     if (Object.keys(nextProps).filter(k => k !== 'onChange' && k !== 'options').some(
       k => nextProps[k] !== this.props[k], // eslint-disable-line react/destructuring-assignment

--- a/ui/shared/components/panel/search/VariantSearchFormPanels.jsx
+++ b/ui/shared/components/panel/search/VariantSearchFormPanels.jsx
@@ -68,6 +68,9 @@ const ToggleHeaderFieldColumn = styled(Grid.Column)`
     .icon {
       margin: -0.75em !important;
       transform: rotate(90deg) !important;
+      &.delete {
+        margin: 0 0 0 0.25em !important;
+      }
     }
   }
       

--- a/ui/shared/components/panel/search/VariantSearchFormPanels.jsx
+++ b/ui/shared/components/panel/search/VariantSearchFormPanels.jsx
@@ -227,14 +227,12 @@ export const QUALITY_PANEL = {
   fieldProps: { control: LazyLabeledSlider, format: val => val || null },
 }
 
-const stopPropagation = e => e.stopPropagation()
-
 const HeaderContent = React.memo(({ name, title, inputSize, inputProps }) => (
   <Grid>
     <Grid.Row>
       <Grid.Column width={inputSize ? 16 - inputSize : 8} verticalAlign="middle">{title}</Grid.Column>
       {inputProps && (
-        <ToggleHeaderFieldColumn width={inputSize || 3} floated="right" textAlign="right" onClick={stopPropagation}>
+        <ToggleHeaderFieldColumn width={inputSize || 3} floated="right" textAlign="right">
           {configuredField({ ...inputProps, name: `search.${name}` })}
         </ToggleHeaderFieldColumn>
       )}

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -1292,6 +1292,27 @@ export const PANEL_APP_CONFIDENCE_LEVEL_COLORS = Object.entries(PANEL_APP_CONFID
   (acc, [confidence, color]) => ({ ...acc, [confidence]: VARIANT_ICON_COLORS[color] }), {},
 )
 
+export const PANEL_APP_MOI_OPTIONS = [{
+  text: 'Autosomal Dominant',
+  value: 'AD',
+},
+{
+  text: 'Autosomal Recessive',
+  value: 'AR',
+},
+{
+  text: 'X-Linked Dominant',
+  value: 'XD',
+},
+{
+  text: 'X-Linked Recessive',
+  value: 'XR',
+},
+{
+  text: 'Other Mode of Inheritance',
+  value: 'other',
+}]
+
 // Users
 
 export const USER_NAME_FIELDS = [


### PR DESCRIPTION
PR for Issue #2770

MOI is displayed in variant search results, but users cannot filter on them.

I think the best place to give users this control is in the Location (locus) Search Form Panel.

In this PR, after a user has picked a Panel App gene list, a Multiselect appears, prompting the user to choose which Modes of Inheritance are relevant to their search. This dropdown does not appear if a regular gene list is chosen.

<img width="1680" alt="Screen Shot 2022-06-22 at 12 25 28 pm" src="https://user-images.githubusercontent.com/3320713/174940473-25500c00-bed5-46a8-b57c-2c3e287ecbaf.png">

The help text "Showing all MOIs as tagged in Panel App" should give hints to the user as to what this dropdown does. And the reactivity is quite visual. When a selection is made, the genes in the textboxes immediately change to reflect the user's choice.

MOIs that are not present in that genelist are disabled as a dropdown option.

Since there can be many MOIs per gene, the filter is inclusive/greedy. E.g. in the [Autism](https://panelapp.agha.umccr.org/panels/51/) panel, the gene MET is both AD and AR, so choosing either will display it.

Notes:

* I removed stopPropagation from the header because the hidden UI/reserved space was causing user frustration. I've moved it to IntegerInput and tested the other inputs to make sure they still work.
* Passing options with disabled switching between true/false was not detected by react memo, so I used [Lodash's isEqual](https://lodash.com/docs/4.17.15#isEqual) to compare some objects.
* BaseSemanticInput also was not properly comparing passed options, but I just fixed the bug and kept the logic. This could be replaced with _.isEqual(), or the comparitor could be extracted and reused on the other Inputs instead of _.isEqual() for better consistency.