### PR TITLE
Update the `appVersion` in the seqr Helm Chart when there is a push the branches [dev, master]

### DIFF
--- a/.cloudbuild/seqr-docker.cloudbuild.yaml
+++ b/.cloudbuild/seqr-docker.cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   args:
   - --destination=gcr.io/seqr-project/seqr:${COMMIT_SHA}
   - --destination=gcr.io/seqr-project/seqr:${_CUSTOM_BRANCH_TAG}
-  - --destination=gcr.io/seqr-project/seqr:latest
+  # - --destination=gcr.io/seqr-project/seqr:latest # TODO uncomment after testing is done
   - --dockerfile=deploy/docker/seqr/Dockerfile
   - --cache=true
   - --cache-ttl=168h

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -8,23 +8,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: get seqr version
+      - name: collect seqr version info
         id: seqr
         run:
+          echo "::set-output name=seqr_version::$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm
       - name: Update appVersion in the seqr HelmChart Chart.yaml
         uses: fjogeleit/yaml-update-action@main
+        pre:
+          echo "SEQR_VERSION=${{ steps.seqr.outputs.seqr_version }}-${{ steps.seqr.outputs.commit_id }}" >> $GITHUB_ENV
         with:
           valueFile: 'charts/seqr/Chart.yaml'
           propertyPath: 'appVersion'
-          value: ${{ steps.seqr.outputs.commit_id }}
+          value: ${{ env.SEQR_VERSION }}
           repository: broadinstitute/seqr-helm
           masterBranchName: main
-          branch: seqr-version-${{ steps.seqr.outputs.commit_id }}
+          branch: seqr-version-${{ env.SEQR_VERSION }}
           targetBranch: main
           createPR: true
-          message: 'Update appVersion to ${{ steps.seqr.outputs.commit_id }}'
+          message: 'Update appVersion to ${{ env.SEQR_VERSION }}'
           token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -22,18 +22,13 @@ jobs:
         with:
           cmd: >
             yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
-      - name: Create Pull Request
-        id: createpr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
-          commit-message: 'Update appVersion to ${{ env.SEQR_VERSION }}'
-          committer: shifa <shifa@broadinstitute.org>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          labels: automation
-          title: 'Update appVersion to ${{ env.SEQR_VERSION }}'
-          body: Automated changes triggered by a push to the release branch in the seqr [repo](https://github.com/broadinstitute/seqr).
-      - name: Check outputs
+      - name: Commit files
         run: |
-          echo "Pull Request Number - ${{ steps.createpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.createpr.outputs.pull-request-url }}"
+          git config --local user.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          git config --local user.name "tgg-automation"
+          git commit -m "Update seqr version" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          branch: main

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,64 +1,37 @@
-# name: seqr dev release
-# on:
-#   workflow_run:
-#     workflows: ["Unit Tests"]
-#     types:
-#       - completed
-#     branches:
-#       - seqr-helm-version # TODO: trigger this flow on dev
-
-# permissions:
-#   id-token: write
-
-# jobs:
-#   docker:
-#     runs-on: ubuntu-latest
-#     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-#     steps:
-#       - name: checkout
-#         uses: actions/checkout@v3
-
-#       - name: authenticate to google cloud
-#         id: 'auth'
-#         uses: google-github-actions/auth@v0
-#         with:
-#           workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/testing-actions-pool/providers/testing-github-actions'
-#           service_account: '${{ secrets.RUN_SA_EMAIL }}'
-
-#       - name: 'setup gcloud sdk'
-#         uses: google-github-actions/setup-gcloud@v0
-
-#       - name: Build and push images
-#         run: |-
-#           gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
-
-  # run:
-  #   runs-on: ubuntu-latest
-  #   needs: docker
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: get seqr version
-  #       run: |
-  #         seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
-  #         commit_id=$(git rev-parse --short HEAD)
-  #         echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         repository: broadinstitute/seqr-helm
-  #         ref: main
-  #         persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-  #         fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
-  #     - name: Update appVersion in seqr Chart file
-  #       uses: mikefarah/yq@v4.22.1
-  #       with:
-  #         cmd: >
-  #           yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
-  #     - name: Commit and Push changes
-  #       uses: Andro999b/push@v1.3
-  #       with:
-  #         repository: broadinstitute/seqr-helm
-  #         branch: main
-  #         github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
-  #         author_email: ${{ github.actor }}@users.noreply.github.com
-  #         author_name: tgg-automation
-  #         message: 'Update appVersion with seqr version'
+name: Update seqr Version
+on:
+  push:
+    branches:
+      # - seqr-helm-version  # for testing
+      - master
+      - dev
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: get seqr version
+        run: |
+          seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
+          commit_id=$(git rev-parse --short HEAD)
+          echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+        with:
+          repository: broadinstitute/seqr-helm
+          ref: main
+          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
+      - name: Update appVersion in seqr Chart file
+        uses: mikefarah/yq@v4.22.1
+        with:
+          cmd: >
+            yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
+      - name: Commit and Push changes
+        uses: Andro999b/push@v1.3
+        with:
+          repository: broadinstitute/seqr-helm
+          branch: main
+          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          author_name: tgg-automation
+          message: 'Update appVersion with seqr version'

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-logs-dir=gs://seqr-github-actions-logs/logs .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
 
   # run:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -30,5 +30,6 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
+          repository: broadinstitute/seqr-helm
           github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
           branch: main

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,10 +1,5 @@
 name: seqr dev release
 on:
-  # push:
-  #   branches:
-  #     - seqr-helm-version  # for testing
-  #     # - master
-  #     # - dev
   workflow_run:
     workflows: ["Unit Tests"]
     types:
@@ -17,7 +12,6 @@ permissions:
 
 jobs:
   docker:
-    # needs: unit-tests ?
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,10 +1,16 @@
 name: seqr dev release
 on:
-  push:
+  # push:
+  #   branches:
+  #     - seqr-helm-version  # for testing
+  #     # - master
+  #     # - dev
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types:
+      - completed
     branches:
-      - seqr-helm-version  # for testing
-      # - master
-      # - dev
+      - seqr-helm-version # TODO: trigger this flow on dev
 
 permissions:
   id-token: write
@@ -13,6 +19,7 @@ jobs:
   docker:
     # needs: unit-tests ?
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           repository: broadinstitute/seqr-helm
           ref: main
+          ssh-key: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          persist-credentials: true
       - name: Update appVersion in seqr Chart file
         uses: mikefarah/yq@v4.22.1
         with:
@@ -30,6 +32,6 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
+          ssh: true
           repository: broadinstitute/seqr-helm
-          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
           branch: main

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -26,5 +26,5 @@ jobs:
           branch: seqr-version-${{ steps.seqr.outputs.commit_id }}
           targetBranch: main
           createPR: true
-          message: 'Update appVersion to ${{ steps.seqr.outputs.commit_id }}
+          message: 'Update appVersion to ${{ steps.seqr.outputs.commit_id }}'
           token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -11,7 +11,7 @@ jobs:
       - name: collect seqr version info
         id: info
         run:
-          echo "::set-output name=seqr_version::$(grep SEQR_VERSION ./settings.py | sed -n \"s/^.*'\(.*\)'/\1/p\")"
+          echo "::set-output name=seqr_version::$(grep SEQR_VERSION ./settings.py | sed -n 's/^.*=[ ]*\(.*\)/\1/p')"
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - name: get seqr version env
         run:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: seqr
+        run:
+          git rev-parse --short HEAD
+      - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm
       - name: Update appVersion in the seqr HelmChart Chart.yaml

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -7,7 +7,9 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          repository: broadinstitute/seqr-helm
       - name: Update appVersion in the seqr HelmChart Chart.yaml
         uses: fjogeleit/yaml-update-action@main
         with:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,17 +1,11 @@
 name: seqr dev release
-# on:
-#   push:
-#     branches:
-#       - seqr-helm-version  # for testing
-#       # - master
-#       # - dev
-
 on:
-  workflow_dispatch:
-    inputs:
-      custom_branch_tag:
-        description: "custom tag to apply to the docker image"
-        required: true
+  push:
+    branches:
+      - seqr-helm-version  # for testing
+      # - master
+      # - dev
+
 jobs:
   docker:
     # needs: unit-tests ?
@@ -24,7 +18,7 @@ jobs:
         id: 'auth'
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/testing-actions-pool/providers/testing-github-actions'
           service_account: '${{ secrets.RUN_SA_EMAIL }}'
 
       - name: 'setup gcloud sdk'
@@ -32,7 +26,7 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ GITHUB_SHA }},_CUSTOM_BRANCH_TAG=${{ github.event.inputs.custom_branch_tag }}" -f seqr-docker.cloudbuild.yaml .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ GITHUB_SHA }},_CUSTOM_BRANCH_TAG=test-github-actions" -f seqr-docker.cloudbuild.yaml .
 
   # run:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -8,9 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: seqr
+      - name: get seqr version
+        id: seqr
         run:
-          git rev-parse --short HEAD
+          echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm
@@ -19,11 +20,11 @@ jobs:
         with:
           valueFile: 'charts/seqr/Chart.yaml'
           propertyPath: 'appVersion'
-          value: '1.0-toBeUpdated'  # todo: add seqr step ${{ steps.seqr.outputs.version }}
+          value: ${{ steps.seqr.outputs.commit_id }}
           repository: broadinstitute/seqr-helm
           masterBranchName: main
-          branch: seqr-version-pr  # todo: update the branch name to something like deployment/${{ steps.image.outputs.version }}
+          branch: seqr-version-${{ steps.seqr.outputs.commit_id }}
           targetBranch: main
           createPR: true
-          message: 'Update appVersion to #seqr-version#'  # todo: change #seqr-version# to ${{ steps.image.outputs.version }}'
+          message: 'Update appVersion to ${{ steps.seqr.outputs.commit_id }}
           token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,0 +1,23 @@
+name: Update seqr Version
+on:
+  push:
+    branches:
+      - seqr-helm-version
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update appVersion in the seqr HelmChart Chart.yaml
+        uses: fjogeleit/yaml-update-action@main
+        with:
+          valueFile: 'charts/seqr/Chart.yaml'
+          propertyPath: 'appVersion'
+          value: '1.0-toBeUpdated'  # todo: add seqr step ${{ steps.seqr.outputs.version }}
+          repository: broadinstitute/seqr-helm
+          masterBranchName: main
+          branch: seqr-version-pr  # todo: update the branch name to something like deployment/${{ steps.image.outputs.version }}
+          targetBranch: main
+          createPR: true
+          message: 'Update appVersion to #seqr-version#'  # todo: change #seqr-version# to ${{ steps.image.outputs.version }}'
+          token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -11,7 +11,7 @@ jobs:
       - name: collect seqr version info
         id: info
         run:
-          echo "::set-output name=seqr_version::$(grep SEQR_VERSION[ ]*=[ ]*'.*' ./settings.py | sed -n \"s/^.*'\(.*\)'/\1/p\")"
+          echo "::set-output name=seqr_version::$(grep \"SEQR_VERSION[ ]*=[ ]*'.*'\" ./settings.py | sed -n \"s/^.*'\(.*\)'/\1/p\")"
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - name: get seqr version env
         run:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -17,21 +17,19 @@ jobs:
         with:
           repository: broadinstitute/seqr-helm
           ref: main
-          ssh-key: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
-          persist-credentials: true
+          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
       - name: Update appVersion in seqr Chart file
         uses: mikefarah/yq@v4.22.1
         with:
           cmd: >
             yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
-      - name: Commit files
-        run: |
-          git config --local user.email "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
-          git config --local user.name "tgg-automation"
-          git commit -m "Update seqr version" -a
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+      - name: Commit and Push changes
+        uses: Andro999b/push@v1.3
         with:
-          ssh: true
           repository: broadinstitute/seqr-helm
           branch: main
+          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          author_name: tgg-automation
+          message: 'Update appVersion with seqr version'

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,36 +1,36 @@
-name: seqr dev release
-on:
-  workflow_run:
-    workflows: ["Unit Tests"]
-    types:
-      - completed
-    branches:
-      - seqr-helm-version # TODO: trigger this flow on dev
+# name: seqr dev release
+# on:
+#   workflow_run:
+#     workflows: ["Unit Tests"]
+#     types:
+#       - completed
+#     branches:
+#       - seqr-helm-version # TODO: trigger this flow on dev
 
-permissions:
-  id-token: write
+# permissions:
+#   id-token: write
 
-jobs:
-  docker:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
+# jobs:
+#   docker:
+#     runs-on: ubuntu-latest
+#     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#     steps:
+#       - name: checkout
+#         uses: actions/checkout@v3
 
-      - name: authenticate to google cloud
-        id: 'auth'
-        uses: google-github-actions/auth@v0
-        with:
-          workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/testing-actions-pool/providers/testing-github-actions'
-          service_account: '${{ secrets.RUN_SA_EMAIL }}'
+#       - name: authenticate to google cloud
+#         id: 'auth'
+#         uses: google-github-actions/auth@v0
+#         with:
+#           workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/testing-actions-pool/providers/testing-github-actions'
+#           service_account: '${{ secrets.RUN_SA_EMAIL }}'
 
-      - name: 'setup gcloud sdk'
-        uses: google-github-actions/setup-gcloud@v0
+#       - name: 'setup gcloud sdk'
+#         uses: google-github-actions/setup-gcloud@v0
 
-      - name: Build and push images
-        run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
+#       - name: Build and push images
+#         run: |-
+#           gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
 
   # run:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: get seqr version
         run: |
-          seqr_version=$(grep SEQR_VERSION ./settings.py | sed -n "s/^.*=[ ]*'\(.*\)'/\1/p")
+          seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
           commit_id=$(git rev-parse --short HEAD)
           echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
       - uses: actions/checkout@v3

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -11,7 +11,7 @@ jobs:
       - name: collect seqr version info
         id: info
         run:
-          echo "::set-output name=seqr_version::$(grep \"SEQR_VERSION[ ]*=[ ]*'.*'\" ./settings.py | sed -n \"s/^.*'\(.*\)'/\1/p\")"
+          echo "::set-output name=seqr_version::$(grep SEQR_VERSION ./settings.py | sed -n \"s/^.*'\(.*\)'/\1/p\")"
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - name: get seqr version env
         run:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -31,6 +31,8 @@ jobs:
           committer: shifa <shifa@broadinstitute.org>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           labels: automation
+          title: 'Update appVersion to ${{ env.SEQR_VERSION }}'
+          body: Automated changes triggered by a push to the release branch in the seqr [repo](https://github.com/broadinstitute/seqr).
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ steps.createpr.outputs.pull-request-number }}"

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -10,8 +10,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: collect seqr version info
         id: info
-        run:
+        - run:
           echo "::set-output name=seqr_version::$(grep SEQR_VERSION ./settings.py | sed -n 's/^.*=[ ]*\(.*\)/\1/p')"
+        - run:
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - name: get seqr version env
         run:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -2,7 +2,9 @@ name: Update seqr Version
 on:
   push:
     branches:
-      - seqr-helm-version
+      - seqr-helm-version  # for testing
+      - master
+      - dev
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
           commit-message: 'Update appVersion to ${{ env.SEQR_VERSION }}'
-          committer: shifa@broadinstitute.org
+          committer: shifa <shifa@broadinstitute.org>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           labels: automation
       - name: Check outputs

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -11,7 +11,7 @@ jobs:
       - name: collect seqr version info
         id: info
         run:
-          echo "::set-output name=seqr_version::$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
+          echo "::set-output name=seqr_version::$(grep SEQR_VERSION[ ]*=[ ]*'.*' ./settings.py | sed -n \"s/^.*'\(.*\)'/\1/p\")"
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
       - name: get seqr version env
         run:

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -9,17 +9,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: collect seqr version info
-        id: seqr
+        id: info
         run:
           echo "::set-output name=seqr_version::$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
           echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
+      - name: get seqr version env
+        run:
+          echo "SEQR_VERSION=${{ steps.info.outputs.seqr_version }}-${{ steps.info.outputs.commit_id }}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm
       - name: Update appVersion in the seqr HelmChart Chart.yaml
         uses: fjogeleit/yaml-update-action@main
-        pre:
-          echo "SEQR_VERSION=${{ steps.seqr.outputs.seqr_version }}-${{ steps.seqr.outputs.commit_id }}" >> $GITHUB_ENV
         with:
           valueFile: 'charts/seqr/Chart.yaml'
           propertyPath: 'appVersion'

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
           commit-message: 'Update appVersion to ${{ env.SEQR_VERSION }}'
-          committer: tgg-automation
+          committer: shifa@broadinstitute.org
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           labels: automation
       - name: Check outputs

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -6,6 +6,9 @@ on:
       # - master
       # - dev
 
+permissions:
+  id-token: write
+
 jobs:
   docker:
     # needs: unit-tests ?

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-logs-dir=gs://seqr-github-actions-logs/logs .
 
   # run:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -8,15 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: collect seqr version info
-        id: info
-        - run:
-          echo "::set-output name=seqr_version::$(grep SEQR_VERSION ./settings.py | sed -n 's/^.*=[ ]*\(.*\)/\1/p')"
-        - run:
-          echo "::set-output name=commit_id::$(git rev-parse --short HEAD)"
-      - name: get seqr version env
-        run:
-          echo "SEQR_VERSION=${{ steps.info.outputs.seqr_version }}-${{ steps.info.outputs.commit_id }}" >> $GITHUB_ENV
+      - name: get seqr version
+        run: |
+          seqr_version=$(grep SEQR_VERSION ./settings.py | sed -n "s/^.*=[ ]*'\(.*\)'/\1/p")
+          commit_id=$(git rev-parse --short HEAD)
+          echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
       - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" -f seqr-docker.cloudbuild.yaml .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml .
 
   # run:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -1,37 +1,66 @@
-name: Update seqr Version
+name: seqr dev release
+# on:
+#   push:
+#     branches:
+#       - seqr-helm-version  # for testing
+#       # - master
+#       # - dev
+
 on:
-  push:
-    branches:
-      - seqr-helm-version  # for testing
-      - master
-      - dev
+  workflow_dispatch:
+    inputs:
+      custom_branch_tag:
+        description: "custom tag to apply to the docker image"
+        required: true
 jobs:
-  run:
+  docker:
+    # needs: unit-tests ?
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: get seqr version
-        run: |
-          seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
-          commit_id=$(git rev-parse --short HEAD)
-          echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
-      - uses: actions/checkout@v3
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: authenticate to google cloud
+        id: 'auth'
+        uses: google-github-actions/auth@v0
         with:
-          repository: broadinstitute/seqr-helm
-          ref: main
-          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-          fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
-      - name: Update appVersion in seqr Chart file
-        uses: mikefarah/yq@v4.22.1
-        with:
-          cmd: >
-            yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
-      - name: Commit and Push changes
-        uses: Andro999b/push@v1.3
-        with:
-          repository: broadinstitute/seqr-helm
-          branch: main
-          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
-          author_email: ${{ github.actor }}@users.noreply.github.com
-          author_name: tgg-automation
-          message: 'Update appVersion with seqr version'
+          workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/my-pool/providers/my-provider'
+          service_account: '${{ secrets.RUN_SA_EMAIL }}'
+
+      - name: 'setup gcloud sdk'
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: Build and push images
+        run: |-
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ GITHUB_SHA }},_CUSTOM_BRANCH_TAG=${{ github.event.inputs.custom_branch_tag }}" -f seqr-docker.cloudbuild.yaml .
+
+  # run:
+  #   runs-on: ubuntu-latest
+  #   needs: docker
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: get seqr version
+  #       run: |
+  #         seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
+  #         commit_id=$(git rev-parse --short HEAD)
+  #         echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         repository: broadinstitute/seqr-helm
+  #         ref: main
+  #         persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+  #         fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
+  #     - name: Update appVersion in seqr Chart file
+  #       uses: mikefarah/yq@v4.22.1
+  #       with:
+  #         cmd: >
+  #           yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
+  #     - name: Commit and Push changes
+  #       uses: Andro999b/push@v1.3
+  #       with:
+  #         repository: broadinstitute/seqr-helm
+  #         branch: main
+  #         github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+  #         author_email: ${{ github.actor }}@users.noreply.github.com
+  #         author_name: tgg-automation
+  #         message: 'Update appVersion with seqr version'

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ GITHUB_SHA }},_CUSTOM_BRANCH_TAG=test-github-actions" -f seqr-docker.cloudbuild.yaml .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" -f seqr-docker.cloudbuild.yaml .
 
   # run:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/update-seqr-helm-version.yml
+++ b/.github/workflows/update-seqr-helm-version.yml
@@ -16,16 +16,22 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm
-      - name: Update appVersion in the seqr HelmChart Chart.yaml
-        uses: fjogeleit/yaml-update-action@main
+          ref: main
+      - name: Update appVersion in seqr Chart file
+        uses: mikefarah/yq@v4.22.1
         with:
-          valueFile: 'charts/seqr/Chart.yaml'
-          propertyPath: 'appVersion'
-          value: ${{ env.SEQR_VERSION }}
-          repository: broadinstitute/seqr-helm
-          masterBranchName: main
-          branch: seqr-version-${{ env.SEQR_VERSION }}
-          targetBranch: main
-          createPR: true
-          message: 'Update appVersion to ${{ env.SEQR_VERSION }}'
+          cmd: >
+            yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
+      - name: Create Pull Request
+        id: createpr
+        uses: peter-evans/create-pull-request@v3
+        with:
           token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          commit-message: 'Update appVersion to ${{ env.SEQR_VERSION }}'
+          committer: tgg-automation
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          labels: automation
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.createpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.createpr.outputs.pull-request-url }}"


### PR DESCRIPTION
The newly added Github workflow creates a PR in the [seqr-helm repo](https://github.com/broadinstitute/seqr-helm) to update the `appVersion` in the seqr Helm Chart when there is a push the release branch. Here is an example of the PR: https://github.com/broadinstitute/seqr-helm/pull/9