### PR TITLE
add a dev release workflow for testing

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: authenticate to google cloud
         id: 'auth'

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,34 @@
+name: seqr dev release
+on:
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types:
+      - completed
+    branches:
+      - seqr-helm-version # TODO: trigger this flow on dev
+
+permissions:
+  id-token: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: authenticate to google cloud
+        id: 'auth'
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/testing-actions-pool/providers/testing-github-actions'
+          service_account: '${{ secrets.RUN_SA_EMAIL }}'
+
+      - name: 'setup gcloud sdk'
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: Build and push images
+        run: |-
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
+


### PR DESCRIPTION
This adds a docker build workflow that is triggered off of successful completions of the Unit Tests workflow on the seqr-helm-version branch. This will allow me to test our dev release workflow when I push changes to that PR/branch. Our normal dev/master docker builds are still in place, and this should have no effect on them.

This has to go into the master branch, because apparently workflow_run triggers only work if the workflow you're defining exists on the repo's default branch (see the Note [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)).
