### PR TITLE
use the triggering workflow shasum

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -32,5 +32,5 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${GITHUB_SHA},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ github.event.workflow_run.head_sha }},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
 


### PR DESCRIPTION
This is a fixup for #2896 -- `$GITHUB_SHA` points to the latest commit of the default branch on workflows triggered by the workflow_run event. Instead, we need to use the `github.event.workflow_run.head_sha` in order to make sure we tag the docker image using the commit from the branch that actually triggered the workflow

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities (N/A)
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: (N/A)
- [x] Any database migrations are noted here, and will be run before deploying: (N/A)
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release (N/A)
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users (N/A)
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [x] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [ ] Any chages to non-seqr docker images have been built and pushed to the container registry
  - [ ] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [ ] All these changes have been vetted for potential vulnerabilities