### PR TITLE
Adds helm chart update workflow for dev releases

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -5,7 +5,7 @@ on:
     types:
       - completed
     branches:
-      - seqr-helm-version # TODO: trigger this flow on dev
+      - dev
 
 permissions:
   id-token: write
@@ -24,7 +24,7 @@ jobs:
         id: 'auth'
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/testing-actions-pool/providers/testing-github-actions'
+          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
           service_account: '${{ secrets.RUN_SA_EMAIL }}'
 
       - name: 'setup gcloud sdk'
@@ -32,5 +32,34 @@ jobs:
 
       - name: Build and push images
         run: |-
-          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ github.event.workflow_run.head_sha }},_CUSTOM_BRANCH_TAG=test-github-actions" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ github.event.workflow_run.head_sha }},_CUSTOM_BRANCH_TAG=gcloud-dev" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
+
+  helm_update:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - name: Retrieve tgg-helm repo for broad seqr chart
+        needs: set
+        uses: actions/checkout@v3
+        with:
+          repository: broadinstitute/tgg-helm
+          ref: main
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: update image tag in the broad seqr chart
+        uses: mikefarah/yq@4.22.1
+        with:
+          cmd: >
+            yq -i '.seqr.image.tag = "${{ github.event.workflow_run.head_sha }}"' charts/broad-seqr/values-dev.yaml
+
+      - name: Commit and Push changes
+        uses: Andro999b/push@v1.3
+        with:
+          repository: broadinstitute/tgg-helm
+          branch: main
+          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          author_name: tgg-automation
+          message: 'Update seqr dev release docker tag to ${{ github.event.workflow_run.head_sha }}'
 


### PR DESCRIPTION
This updates the dev release workflow to track the dev branch, and adds a step that updates the docker image tag in the broad-seqr helm chart for eventual release. Once this merges, we'll want to remove the google cloudbuild trigger that we have for dev, as this will now be the thing responsible for kicking off the docker build there. The prod cloudbuild trigger will stay intact, and there'll be a PR similar to this one to add the prod release workflow once we're ready to release that.

Again, this has to merge into master, since github requires `workflow_run` style jobs like this one to be defined in master/the repo's default branch.

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [x] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [ ] Any chages to non-seqr docker images have been built and pushed to the container registry
  - [ ] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [ ] All these changes have been vetted for potential vulnerabilities