### PR TITLE
fix the misplaced needs setting in the dev release flow

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -21,13 +21,13 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: authenticate to google cloud
-        id: 'auth'
+        id: "auth"
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
-          service_account: '${{ secrets.RUN_SA_EMAIL }}'
+          workload_identity_provider: "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
+          service_account: "${{ secrets.RUN_SA_EMAIL }}"
 
-      - name: 'setup gcloud sdk'
+      - name: "setup gcloud sdk"
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Build and push images
@@ -39,7 +39,6 @@ jobs:
     needs: docker
     steps:
       - name: Retrieve tgg-helm repo for broad seqr chart
-        needs: set
         uses: actions/checkout@v3
         with:
           repository: broadinstitute/tgg-helm
@@ -61,5 +60,4 @@ jobs:
           github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
           author_email: ${{ github.actor }}@users.noreply.github.com
           author_name: tgg-automation
-          message: 'Update seqr dev release docker tag to ${{ github.event.workflow_run.head_sha }}'
-
+          message: "Update seqr dev release docker tag to ${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
This should fix https://github.com/broadinstitute/seqr/actions/runs/2906358172/workflow

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [x] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [ ] Any chages to non-seqr docker images have been built and pushed to the container registry
  - [ ] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [ ] All these changes have been vetted for potential vulnerabilities