### PR TITLE
Fix yq tag, authenticated git pull

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: broadinstitute/tgg-helm
+          token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
           ref: main
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: update image tag in the broad seqr chart
-        uses: mikefarah/yq@4.22.1
+        uses: mikefarah/yq@v4.22.1
         with:
           cmd: >
             yq -i '.seqr.image.tag = "${{ github.event.workflow_run.head_sha }}"' charts/broad-seqr/values-dev.yaml


### PR DESCRIPTION
One day, github will allow you to test and/or validate workflows like this without them being on the default branch. But today is not that day. 🤦 

The version tag of the yq action was incorrect, and the git pull of our tgg-helm repo needed to be authenticated. I pushed a test version of this workflow that I could trigger manually and validated that it was working there: https://github.com/broadinstitute/seqr/runs/7979089669?check_suite_focus=true

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [x] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [ ] Any chages to non-seqr docker images have been built and pushed to the container registry
  - [ ] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [ ] All these changes have been vetted for potential vulnerabilities