### PR TITLE
Add actions caching, update actions node to match docker

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - dev
-      - add-actions-caching # TODO: remove before merge
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -87,7 +87,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm install || true
+      - run: npm ci
         working-directory: ./ui
       - run: npm test
         working-directory: ./ui

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
+          cache-dependency-path: ui/package-lock.json
       - run: npm install -g npm@7.24.2
       - run: npm ci
         working-directory: ./ui

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -74,20 +74,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v3
-        id: npm-cache
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: "npm"
+      - run: npm install -g npm@7.24.2
       - run: npm ci
         working-directory: ./ui
       - run: npm test

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - dev
+      - add-actions-caching # TODO: remove before merge
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-    
+
     services:
       # Label used to access the service container
       postgres:
@@ -24,7 +24,7 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
-          POSTGRES_PASSWORD: 'pgtest'
+          POSTGRES_PASSWORD: "pgtest"
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -36,25 +36,32 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: actions/setup-java@v1
-      with:
-        java-version: '8' # The JDK version needed by hail
-        java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
-        architecture: x64 # (x64 or x86) - defaults to x64
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip wheel
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-    - name: Run coverage tests
-      run: |
-        coverage run --source="./matchmaker","./seqr","./reference_data","./panelapp" --omit="*/migrations/*","*/apps.py" manage.py test -p '*_tests.py' -v 2 reference_data seqr matchmaker panelapp
-        coverage report --fail-under=99
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "8" # The JDK version needed by hail
+          java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
+          architecture: x64 # (x64 or x86) - defaults to x64
+      - name: Use pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Run coverage tests
+        run: |
+          coverage run --source="./matchmaker","./seqr","./reference_data","./panelapp" --omit="*/migrations/*","*/apps.py" manage.py test -p '*_tests.py' -v 2 reference_data seqr matchmaker panelapp
+          coverage report --fail-under=99
 
   nodejs:
     runs-on: ubuntu-latest
@@ -64,12 +71,23 @@ jobs:
         node-version: [11.8.0]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install || true
-      working-directory: ./ui
-    - run: npm test
-      working-directory: ./ui
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm install || true
+        working-directory: ./ui
+      - run: npm test
+        working-directory: ./ui

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -68,7 +68,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [11.8.0]
+        node-version: [14]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This adds some caching steps to the pip and npm installs to hopefully shave some time off the unit tests pipeline.

I also noticed that we were running a much older version of nodejs in our actions tests than we do in the seqr docker image, so I updated that to version 14 to match.

Last change was updating the `npm install || true` to a [`npm ci`](https://docs.npmjs.com/cli/v7/commands/npm-ci), which we also do in docker. I think this is the preferred way to run NPM in automated environments, according to the docs, since it only installs explicitly what's in the lockfile, rather than upgrading everything in the dependency tree like `install` does. It's also much faster.

Fixes #2895 