### PR TITLE
remove extra edit project button

### DIFF
--- a/ui/pages/Project/components/PageHeader.jsx
+++ b/ui/pages/Project/components/PageHeader.jsx
@@ -44,7 +44,6 @@ const PageHeader = React.memo((
   } else if (match.params.breadcrumb === 'family_page') {
     if (match.params.breadcrumbIdSection === 'matchmaker_exchange') {
       description = ''
-      button = <EditProjectButton project={project} />
     } else {
       description = family.description
     }


### PR DESCRIPTION
This button is missing a prop which is causing the matchmaker page render to fail, but actually that button shouldn't be ob on the matchmaker page anyways so I removed it