### PR TITLE
Edit datasets button - no anvil

### DIFF
--- a/ui/pages/Project/components/EditDatasetButton.test.js
+++ b/ui/pages/Project/components/EditDatasetButton.test.js
@@ -3,19 +3,18 @@ import { shallow, configure } from 'enzyme'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 
 import EditDatasetsButton from './EditDatasetsButton'
-import { STATE_WITH_2_FAMILIES } from '../fixtures'
+import { STATE_WITH_2_FAMILIES, DATA_MANAGER_USER } from '../fixtures'
 
 configure({ adapter: new Adapter() })
 
-test('shallow-render without crashing', () => {
-  shallow(<EditDatasetsButton user={STATE_WITH_2_FAMILIES.user} />)
+const PROJECT = STATE_WITH_2_FAMILIES.projectsByGuid.R0237_1000_genomes_demo
+
+test('shallow-render edit datasets', () => {
+  shallow(<EditDatasetsButton project={PROJECT} user={DATA_MANAGER_USER} />)
 })
 
 test('shallow-render load workspace data', () => {
   shallow(
-    <EditDatasetsButton
-      project={STATE_WITH_2_FAMILIES.projectsByGuid.R0237_1000_genomes_demo}
-      user={STATE_WITH_2_FAMILIES.user}
-    />,
+    <EditDatasetsButton project={PROJECT} user={STATE_WITH_2_FAMILIES.user} />,
   )
 })

--- a/ui/pages/Project/components/EditDatasetsButton.jsx
+++ b/ui/pages/Project/components/EditDatasetsButton.jsx
@@ -172,7 +172,7 @@ const PANES = [
 const IGV_ONLY_PANES = [PANES[1]]
 
 const EditDatasetsButton = React.memo(({ project, user }) => {
-  const showLoadWorkspaceData = project.workspaceName && !project?.isAnalystProject && project?.canEdit
+  const showLoadWorkspaceData = project.workspaceName && !project.isAnalystProject && project.canEdit
   const showEditDatasets = user.isDataManager || user.isPm
   return (
     (showEditDatasets || showLoadWorkspaceData) ? (
@@ -194,7 +194,7 @@ const EditDatasetsButton = React.memo(({ project, user }) => {
 })
 
 EditDatasetsButton.propTypes = {
-  project: PropTypes.object,
+  project: PropTypes.object.isRequired,
   user: PropTypes.object,
 }
 

--- a/ui/pages/Project/components/EditDatasetsButton.jsx
+++ b/ui/pages/Project/components/EditDatasetsButton.jsx
@@ -172,22 +172,21 @@ const PANES = [
 const IGV_ONLY_PANES = [PANES[1]]
 
 const EditDatasetsButton = React.memo(({ project, user }) => {
-  const showLoadWorkspaceData = !project?.isAnalystProject && project?.canEdit
+  const showLoadWorkspaceData = project.workspaceName && !project?.isAnalystProject && project?.canEdit
+  const showEditDatasets = user.isDataManager || user.isPm
   return (
-    (user.isDataManager || user.isPm || showLoadWorkspaceData) ? (
+    (showEditDatasets || showLoadWorkspaceData) ? (
       <Modal
         modalName={MODAL_NAME}
-        title={showLoadWorkspaceData ? 'Load Additional Data From AnVIL Workspace' : 'Datasets'}
+        title={showEditDatasets ? 'Datasets' : 'Load Additional Data From AnVIL Workspace'}
         size="small"
-        trigger={<ButtonLink>{showLoadWorkspaceData ? 'Load Additional Data' : 'Edit Datasets'}</ButtonLink>}
+        trigger={<ButtonLink>{showEditDatasets ? 'Edit Datasets' : 'Load Additional Data'}</ButtonLink>}
       >
-        {showLoadWorkspaceData ? (
+        {showEditDatasets ? <Tab panes={user.isDataManager ? PANES : IGV_ONLY_PANES} /> : (
           <AddWorkspaceDataForm
             params={project}
             successMessage="Your request to load data has been submitted. Loading data from AnVIL to seqr is a slow process, and generally takes a week. You will receive an email letting you know once your new data is available."
           />
-        ) : (
-          <Tab panes={user.isDataManager ? PANES : IGV_ONLY_PANES} />
         )}
       </Modal>
     ) : null

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -342,6 +342,7 @@ export const STATE_WITH_2_FAMILIES = {
       deprecatedLastAccessedDate: '2017-03-14T15:15:42.580Z',
       description: '',
       isMmeEnabled: true,
+      canEdit: true,
       lastModifiedDate: '2017-03-14T17:37:32.712Z',
       mmePrimaryDataOwner: 'PI',
       mmeContactInstitution: 'Broad',
@@ -349,6 +350,8 @@ export const STATE_WITH_2_FAMILIES = {
       name: '1000 Genomes Demo',
       projectCategoryGuids: [],
       projectGuid: 'R0237_1000_genomes_demo',
+      workspaceName: 'test-namespace',
+      workspaceNamespace: 'test-workspace',
       collaborators: [
         {
           dateJoined: '2019-02-20T18:01:36.677Z',
@@ -1011,4 +1014,16 @@ export const STATE_WITH_2_FAMILIES = {
       username: 'test_user2',
     },
   },
+}
+
+export const DATA_MANAGER_USER = {
+  date_joined: '2015-02-19T20:22:50.633Z',
+  email: 'test@broadinstitute.org',
+  first_name: '',
+  id: 1,
+  isActive: true,
+  isDataManager: true,
+  last_login: '2017-03-14T17:44:53.403Z',
+  last_name: '',
+  username: 'test',
 }


### PR DESCRIPTION
This makes 2 necessary changes to the conditional logic for the new load anvil to project button:
1) Addds a check that the project already is associated with a workspace before allowing the user to request additional data
2) Shows the main edit datsets button to data mangers/ PMs so they can continue to do their jobs, instead of showing them the request additional data button