### PR TITLE
clean up unreachable anvil welcome email code

### DIFF
--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -29,28 +29,16 @@ def _post_to_slack(channel, message):
 
 
 def send_welcome_email(user, referrer):
-    if anvil_enabled():
-        setup_message = 'Please make sure this account is registered in AnVIL by signing in to {} and registering.'.format(
-            ANVIL_UI_URL
-        )
-        setup_message += ' Once you are registered in AnVIL, you will be able to access seqr at {}'.format(BASE_URL)
-    else:
-        setup_message = 'Please click this link to set up your account:\n    {}login/set_password/{}'.format(
-            BASE_URL, user.password)
+    email_content = f"""
+    Hi there {user.get_full_name()}--
 
-    email_content = """
-    Hi there {full_name}--
+    {referrer.get_full_name() or referrer.email} has added you as a collaborator in seqr.
 
-    {referrer} has added you as a collaborator in seqr.
-
-    {setup_message}
+    Please click this link to set up your account:
+    {BASE_URL}login/set_password/{user.password}
 
     Thanks!
-    """.format(
-        full_name=user.get_full_name(),
-        referrer=referrer.get_full_name() or referrer.email,
-        setup_message=setup_message,
-    )
+    """
     user.email_user('Set up your seqr account', email_content, fail_silently=False)
 
 

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -114,10 +114,11 @@ class UsersAPITest(object):
 
     Test Manager User has added you as a collaborator in seqr.
 
-    {setup_message}
+    Please click this link to set up your account:
+    /login/set_password/{password_token}
 
     Thanks!
-    """.format(setup_message=self.EMAIL_SETUP_MESSAGE.format(password_token=user.password))
+    """.format(password_token=user.password)
         mock_send_mail.assert_called_with(
             'Set up your seqr account',
             expected_email_content,
@@ -262,7 +263,6 @@ class UsersAPITest(object):
 class LocalUsersAPITest(AuthenticationTestCase, UsersAPITest):
     fixtures = ['users', '1kg_project']
     COLLABORATOR_NAMES = {'test_user_manager', 'test_user_collaborator'}
-    EMAIL_SETUP_MESSAGE = 'Please click this link to set up your account:\n    /login/set_password/{password_token}'
 
     @mock.patch('django.contrib.auth.models.send_mail')
     def _test_forgot_password(self, url, mock_send_mail): # pylint: disable=arguments-differ


### PR DESCRIPTION
I just realized we forgot to clean this up when we switched access. This helper function can no longer be called if anvil is enabled so theres no need to support and anvil email