### PR TITLE
Clean up analyst user json

### DIFF
--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -31,7 +31,6 @@ class FamilyAPITest(AuthenticationTestCase):
     fixtures = ['users', '1kg_project', 'reference_data']
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
-    @mock.patch('seqr.views.utils.orm_to_json_utils.ANALYST_USER_GROUP', 'analysts')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     def test_family_page_data(self, mock_analyst_group):
         url = reverse(family_page_data, args=[FAMILY_GUID])

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -587,7 +587,7 @@ def _parse_individual_hpo_terms(json_records, project, user):
     if any(record.get(ASSIGNED_ANALYST_COL) for record in json_records):
         allowed_assigned_analysts = {
             u['email'] for u in get_project_collaborators_by_username(
-                user, project, include_permissions=False, include_analysts=True, fields=['email'],
+                user, project, fields=['email'], include_analysts=True,
             ).values()
         }
 

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -308,7 +308,6 @@ class ProjectAPITest(object):
 
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
-    @mock.patch('seqr.views.utils.orm_to_json_utils.ANALYST_USER_GROUP', 'analysts')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     def test_project_families(self, mock_analyst_group):
         url = reverse(project_families, args=[PROJECT_GUID])
@@ -365,7 +364,6 @@ class ProjectAPITest(object):
 
 
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_PROJECT_CATEGORY', 'analyst-projects')
-    @mock.patch('seqr.views.utils.orm_to_json_utils.ANALYST_USER_GROUP', 'analysts')
     @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
     def test_project_individuals(self, mock_analyst_group):
         url = reverse(project_individuals, args=[PROJECT_GUID])
@@ -472,7 +470,7 @@ BASE_COLLABORATORS = [
      'hasEditPermissions': False, 'hasViewPermissions': True}]
 
 ANVIL_COLLABORATORS = deepcopy(BASE_COLLABORATORS) + [{
-    'displayName': False, 'email': 'test_user_pure_anvil@test.com', 'username': 'test_user_pure_anvil@test.com',
+    'displayName': '', 'email': 'test_user_pure_anvil@test.com', 'username': 'test_user_pure_anvil@test.com',
     'hasEditPermissions': False, 'hasViewPermissions': True, }]
 
 

--- a/seqr/views/apis/superuser_api.py
+++ b/seqr/views/apis/superuser_api.py
@@ -8,7 +8,10 @@ from seqr.views.utils.terra_api_utils import is_google_authenticated
 
 @superuser_required
 def get_all_users(request):
-    user_tups = [(user, _get_json_for_user(user, is_anvil=False)) for user in User.objects.exclude(email='')]
+    user_tups = [(user, _get_json_for_user(user, fields=[
+        'username', 'email', 'last_login', 'date_joined', 'id', 'display_name', 'is_superuser', 'is_active',
+        'is_analyst', 'is_data_manager', 'is_pm',
+    ])) for user in User.objects.exclude(email='')]
     users = [dict(hasGoogleAuth=is_google_authenticated(user), **user_json) for user, user_json in user_tups]
 
     return create_json_response({'users': users})

--- a/seqr/views/apis/superuser_api.py
+++ b/seqr/views/apis/superuser_api.py
@@ -1,17 +1,24 @@
 from django.contrib.auth.models import User
 
 from seqr.views.utils.json_utils import create_json_response
-from seqr.views.utils.orm_to_json_utils import _get_json_for_user
-from seqr.views.utils.permissions_utils import superuser_required
+from seqr.views.utils.orm_to_json_utils import get_json_for_user
+from seqr.views.utils.permissions_utils import superuser_required, get_analyst_users, get_pm_users
 from seqr.views.utils.terra_api_utils import is_google_authenticated
 
 
 @superuser_required
 def get_all_users(request):
-    user_tups = [(user, _get_json_for_user(user, fields=[
-        'username', 'email', 'last_login', 'date_joined', 'id', 'display_name', 'is_superuser', 'is_active',
-        'is_analyst', 'is_data_manager', 'is_pm',
+    user_tups = [(user, get_json_for_user(user, fields=[
+        'username', 'email', 'last_login', 'date_joined', 'id', 'is_superuser', 'is_active',
+        'display_name', 'is_data_manager',
     ])) for user in User.objects.exclude(email='')]
-    users = [dict(hasGoogleAuth=is_google_authenticated(user), **user_json) for user, user_json in user_tups]
+    analyst_users = get_analyst_users()
+    pm_users = get_pm_users()
+    users = [dict(
+        hasGoogleAuth=is_google_authenticated(user),
+        isAnalyst=user in analyst_users,
+        isPm=user in pm_users,
+        **user_json
+    ) for user, user_json in user_tups]
 
     return create_json_response({'users': users})

--- a/seqr/views/apis/superuser_api_tests.py
+++ b/seqr/views/apis/superuser_api_tests.py
@@ -4,9 +4,9 @@ import mock
 from seqr.views.apis.superuser_api import get_all_users
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, USER_FIELDS
 
-SUPERUSER_FIELDS = {'hasGoogleAuth'}
-SUPERUSER_FIELDS.update(USER_FIELDS)
-SUPERUSER_FIELDS -= {'firstName', 'lastName', 'isAnvil'}
+ALL_USERS_USER_FIELDS = {'hasGoogleAuth'}
+ALL_USERS_USER_FIELDS.update(USER_FIELDS)
+ALL_USERS_USER_FIELDS -= {'firstName', 'lastName', 'isAnvil'}
 
 EXPECTED_USERS = {
     'test_user_manager', 'test_user_collaborator', 'test_user_no_access', 'test_user', 'test_local_user',
@@ -38,7 +38,7 @@ class SuperusersAPITest(object):
         self.assertSetEqual(set(users_by_username.keys()), EXPECTED_USERS)
 
         pm_user = users_by_username['test_pm_user']
-        self.assertSetEqual(set(pm_user.keys()), SUPERUSER_FIELDS)
+        self.assertSetEqual(set(pm_user.keys()), ALL_USERS_USER_FIELDS)
         self.assertEqual(pm_user['hasGoogleAuth'], self.HAS_GOOGLE_AUTH)
         self.assertEqual(pm_user['isPm'], analyst_enabled)
         self.assertEqual(pm_user['isAnalyst'], analyst_enabled)

--- a/seqr/views/apis/superuser_api_tests.py
+++ b/seqr/views/apis/superuser_api_tests.py
@@ -1,30 +1,47 @@
 from django.urls.base import reverse
+import mock
 
 from seqr.views.apis.superuser_api import get_all_users
-from seqr.views.utils.test_utils import AuthenticationTestCase, USER_FIELDS
+from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, USER_FIELDS
 
 SUPERUSER_FIELDS = {'hasGoogleAuth'}
 SUPERUSER_FIELDS.update(USER_FIELDS)
 SUPERUSER_FIELDS -= {'firstName', 'lastName', 'isAnvil'}
 
+EXPECTED_USERS = {
+    'test_user_manager', 'test_user_collaborator', 'test_user_no_access', 'test_user', 'test_local_user',
+    'test_superuser', 'test_data_manager', 'test_pm_user', 'test_user_inactive', 'test_user_no_policies',
+}
 
-class SuperusersAPITest(AuthenticationTestCase):
-    fixtures = ['users']
 
-    def test_get_all_users(self):
+class SuperusersAPITest(object):
+
+    @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
+    @mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
+    def test_get_all_users(self, mock_analyst_group, mock_pm_group):
         url = reverse(get_all_users)
         self.check_superuser_login(url)
 
         response = self.client.get(url)
+        self._test_superuser_response(response, analyst_enabled=False)
+
+        mock_analyst_group.resolve_expression.return_value = 'analysts'
+        mock_pm_group.resolve_expression.return_value = 'project-managers'
+        response = self.client.get(url)
+        self._test_superuser_response(response, analyst_enabled=True)
+
+    def _test_superuser_response(self, response, analyst_enabled):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'users'})
-        self.assertSetEqual(set(response_json['users'][0].keys()), SUPERUSER_FIELDS)
-        self.assertSetEqual({user['username'] for user in response_json['users']}, {
-            'test_user_manager', 'test_user_collaborator', 'test_user_no_access', 'test_user', 'test_local_user',
-            'test_superuser', 'test_data_manager', 'test_pm_user', 'test_user_inactive', 'test_user_no_policies',
-        })
+        users_by_username = {user['username']: user for user in response_json['users']}
+        self.assertSetEqual(set(users_by_username.keys()), EXPECTED_USERS)
 
+        pm_user = users_by_username['test_pm_user']
+        self.assertSetEqual(set(pm_user.keys()), SUPERUSER_FIELDS)
+        self.assertEqual(pm_user['hasGoogleAuth'], self.HAS_GOOGLE_AUTH)
+        self.assertEqual(pm_user['isPm'], analyst_enabled)
+        self.assertEqual(pm_user['isAnalyst'], analyst_enabled)
 
     def test_admin(self):
         url = 'http://localhost/admin/'
@@ -33,3 +50,14 @@ class SuperusersAPITest(AuthenticationTestCase):
 
         response = self.client.get(url)
         self.assertContains(response, 'Django administration', status_code=200)
+
+
+class LocalSuperusersAPITest(AuthenticationTestCase, SuperusersAPITest):
+    fixtures = ['users']
+    HAS_GOOGLE_AUTH = False
+
+
+class AnvilSuperusersAPITest(AnvilAuthenticationTestCase, SuperusersAPITest):
+    fixtures = ['users', 'social_auth']
+    HAS_GOOGLE_AUTH = True
+

--- a/seqr/views/apis/superuser_api_tests.py
+++ b/seqr/views/apis/superuser_api_tests.py
@@ -5,6 +5,8 @@ from seqr.views.utils.test_utils import AuthenticationTestCase, USER_FIELDS
 
 SUPERUSER_FIELDS = {'hasGoogleAuth'}
 SUPERUSER_FIELDS.update(USER_FIELDS)
+SUPERUSER_FIELDS -= {'firstName', 'lastName', 'isAnvil'}
+
 
 class SuperusersAPITest(AuthenticationTestCase):
     fixtures = ['users']

--- a/seqr/views/apis/users_api.py
+++ b/seqr/views/apis/users_api.py
@@ -103,7 +103,7 @@ def update_user(request):
     request_json = json.loads(request.body)
     _update_user_from_json(request.user, request_json)
 
-    return create_json_response(get_json_for_user(request.user, ['first_name', 'last_name', 'display_name']))
+    return create_json_response(get_json_for_user(request.user, {'first_name', 'last_name', 'display_name'}))
 
 
 @login_active_required

--- a/seqr/views/apis/users_api.py
+++ b/seqr/views/apis/users_api.py
@@ -11,7 +11,7 @@ from seqr.utils.communication_utils import send_welcome_email
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
-from seqr.views.utils.orm_to_json_utils import _get_json_for_user, get_json_for_project_collaborator_list, \
+from seqr.views.utils.orm_to_json_utils import get_json_for_user, get_json_for_project_collaborator_list, \
     get_project_collaborators_by_username
 from seqr.views.utils.permissions_utils import get_project_guids_user_can_view, get_project_and_check_permissions, \
     login_and_policies_required, login_active_required, active_user_has_policies_and_passes_test
@@ -32,7 +32,7 @@ def get_all_collaborator_options(request):
     collaborator_ids.update(projects.values_list('can_edit_group__user', flat=True))
 
     return create_json_response({
-        user.username: _get_json_for_user(user, fields={'first_name', 'last_name', 'username', 'email'})
+        user.username: get_json_for_user(user, fields={'first_name', 'last_name', 'username', 'email'})
         for user in User.objects.filter(id__in=collaborator_ids)
     })
 
@@ -41,8 +41,7 @@ def get_all_collaborator_options(request):
 def get_project_collaborator_options(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)
     users = get_project_collaborators_by_username(
-        request.user, project, include_permissions=False, include_analysts=True,
-        fields={'display_name', 'username', 'email'},
+        request.user, project, fields={'display_name', 'username', 'email'}, include_analysts=True,
     )
     return create_json_response(users)
 
@@ -104,7 +103,7 @@ def update_user(request):
     request_json = json.loads(request.body)
     _update_user_from_json(request.user, request_json)
 
-    return create_json_response(_get_json_for_user(request.user))
+    return create_json_response(get_json_for_user(request.user, ['first_name', 'last_name', 'display_name']))
 
 
 @login_active_required

--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -11,7 +11,7 @@ from seqr.models import UserPolicy, Project
 from seqr.views.apis.users_api import get_all_collaborator_options, set_password, \
     create_project_collaborator, update_project_collaborator, delete_project_collaborator, forgot_password, \
     get_project_collaborator_options, update_policies, update_user
-from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, USER_FIELDS
+from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase
 
 
 PROJECT_GUID = 'R0001_1kg'

--- a/seqr/views/react_app.py
+++ b/seqr/views/react_app.py
@@ -7,7 +7,7 @@ from django.template import loader
 from django.http import HttpResponse
 from settings import SEQR_VERSION, CSRF_COOKIE_NAME, DEBUG, LOGIN_URL, GA_TOKEN_ID
 from seqr.models import WarningMessage
-from seqr.views.utils.orm_to_json_utils import _get_json_for_user
+from seqr.views.utils.orm_to_json_utils import get_json_for_user, get_json_for_current_user
 from seqr.views.utils.permissions_utils import login_active_required
 from seqr.views.utils.terra_api_utils import google_auth_enabled
 
@@ -23,7 +23,9 @@ def no_login_main_app(request, *args, **kwargs):
     render_kwargs = {'include_user': False}
     user_token = kwargs.get('user_token')
     if user_token:
-        render_kwargs['additional_json'] = {'newUser': _get_json_for_user(User.objects.get(password=user_token))}
+        render_kwargs['additional_json'] = {'newUser': get_json_for_user(
+            User.objects.get(password=user_token), fields=['id', 'first_name', 'last_name', 'username', 'email'],
+        )}
     elif not request.user.is_anonymous:
         render_kwargs['include_user'] = True
     if not request.META.get(CSRF_COOKIE_NAME):
@@ -48,7 +50,7 @@ def render_app_html(request, additional_json=None, include_user=True, status=200
         'warningMessages': [message.json() for message in WarningMessage.objects.all()],
     }}
     if include_user:
-        initial_json['user'] = _get_json_for_user(request.user)
+        initial_json['user'] = get_json_for_current_user(request.user)
     if additional_json:
         initial_json.update(additional_json)
 

--- a/seqr/views/react_app_tests.py
+++ b/seqr/views/react_app_tests.py
@@ -11,11 +11,11 @@ class DashboardPageTest(AuthenticationTestCase):
     databases = '__all__'
     fixtures = ['users']
 
-    def _check_page_html(self, response,  user, google_enabled=False, user_key='user', ga_token_id=None):
+    def _check_page_html(self, response,  user, google_enabled=False, user_key='user', user_fields=USER_FIELDS, ga_token_id=None):
         self.assertEqual(response.status_code, 200)
         initial_json = self.get_initial_page_json(response)
         self.assertSetEqual(set(initial_json.keys()), {'meta', user_key})
-        self.assertSetEqual(set(initial_json[user_key].keys()), USER_FIELDS)
+        self.assertSetEqual(set(initial_json[user_key].keys()), user_fields)
         self.assertEqual(initial_json[user_key]['username'], user)
         self.assertDictEqual(initial_json['meta'], {
             'version': mock.ANY,
@@ -69,7 +69,10 @@ class DashboardPageTest(AuthenticationTestCase):
         response = self.client.get(
             '/login/set_password/pbkdf2_sha256$30000$y85kZgvhQ539$jrEC343555Itp+14w/T7U6u5XUxtpBZXKv8eh4=')
         self.assertEqual(response.status_code, 200)
-        self._check_page_html(response, 'test_user_manager', user_key='newUser')
+        self._check_page_html(
+            response, 'test_user_manager', user_key='newUser',
+            user_fields={'id', 'firstName', 'lastName', 'username', 'email'},
+        )
 
         response = self.client.get('/login/set_password/invalid_pwd')
         self.assertEqual(response.status_code, 404)

--- a/seqr/views/react_app_tests.py
+++ b/seqr/views/react_app_tests.py
@@ -11,7 +11,8 @@ class DashboardPageTest(AuthenticationTestCase):
     databases = '__all__'
     fixtures = ['users']
 
-    def _check_page_html(self, response,  user, google_enabled=False, user_key='user', user_fields=USER_FIELDS, ga_token_id=None):
+    def _check_page_html(self, response,  user, google_enabled=False, user_key='user', user_fields=None, ga_token_id=None):
+        user_fields = user_fields or USER_FIELDS
         self.assertEqual(response.status_code, 200)
         initial_json = self.get_initial_page_json(response)
         self.assertSetEqual(set(initial_json.keys()), {'meta', user_key})

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -15,9 +15,9 @@ from seqr.models import GeneNote, VariantNote, VariantTag, VariantFunctionalData
 from seqr.views.utils.json_utils import _to_camel_case
 from seqr.views.utils.permissions_utils import has_project_permissions, has_case_review_permissions, \
     project_has_anvil, get_workspace_collaborator_perms, user_is_analyst, user_is_data_manager, user_is_pm, \
-    project_has_analyst_access
+    project_has_analyst_access, get_analyst_users
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated, anvil_enabled
-from settings import ANALYST_PROJECT_CATEGORY, ANALYST_USER_GROUP, SERVICE_ACCOUNT_FOR_ANVIL
+from settings import ANALYST_PROJECT_CATEGORY, SERVICE_ACCOUNT_FOR_ANVIL
 
 
 def _get_model_json_fields(model_class, user, is_analyst, additional_model_fields):
@@ -103,43 +103,35 @@ def _get_empty_json_for_model(model_class):
     return {_to_camel_case(field): None for field in model_class._meta.json_fields}
 
 
-MAIN_USER_FIELDS = [
-    'username', 'email', 'first_name', 'last_name', 'last_login', 'date_joined', 'id'
+MODEL_USER_FIELDS = [
+    'username', 'email', 'first_name', 'last_name', 'last_login', 'date_joined', 'id', 'is_superuser', 'is_active',
 ]
-BOOL_USER_FIELDS = {
-    'is_superuser': False, 'is_active': True,
-}
-MODEL_USER_FIELDS = MAIN_USER_FIELDS + list(BOOL_USER_FIELDS.keys())
 COMPUTED_USER_FIELDS = {
-    'is_anvil': lambda user, is_anvil=None, **kwargs: is_anvil_authenticated(user) if is_anvil is None else is_anvil,
-    'display_name': lambda user, **kwargs: user.get_full_name(),
-    'is_analyst': lambda user, analyst_users=None, **kwargs: user in analyst_users if analyst_users is not None else user_is_analyst(user),
-    'is_data_manager': lambda user, **kwargs: user_is_data_manager(user),
-    'is_pm': lambda user, pm_users=None, **kwargs: user in pm_users if pm_users is not None else user_is_pm(user),
+    'display_name': lambda user: user.get_full_name(),
+    'is_data_manager': user_is_data_manager,
 }
 
-DEFAULT_COLLABORATOR_FIELDS = ['username', 'email', 'display_name']
 
-
-def _get_json_for_user(user, is_anvil=None, fields=None, analyst_users=None, pm_users=None, **kwargs):
-    """Returns JSON representation of the given User object
-
-    Args:
-        user (object): Django user model
-
-    Returns:
-        dict: json object
-    """
-
-    model_fields = [field for field in fields if field in MODEL_USER_FIELDS] if fields else MODEL_USER_FIELDS
-    computed_fields = [field for field in fields if field in COMPUTED_USER_FIELDS] if fields else COMPUTED_USER_FIELDS
+def get_json_for_user(user, fields):
+    invalid_fields = [field for field in fields if field not in MODEL_USER_FIELDS and field not in COMPUTED_USER_FIELDS]
+    if invalid_fields:
+        raise ValueError(f'Invalid user fields {", ".join(invalid_fields)}')
 
     user_json = {
-        _to_camel_case(field): getattr(user, field) for field in model_fields
+        _to_camel_case(field): getattr(user, field) for field in fields if field in MODEL_USER_FIELDS
     }
     user_json.update({
-        _to_camel_case(field): COMPUTED_USER_FIELDS[field](user, is_anvil=is_anvil, analyst_users=analyst_users, pm_users=pm_users)
-        for field in computed_fields
+        _to_camel_case(field): COMPUTED_USER_FIELDS[field](user) for field in fields if field in COMPUTED_USER_FIELDS
+    })
+    return user_json
+
+
+def get_json_for_current_user(user):
+    user_json = get_json_for_user(user, fields=MODEL_USER_FIELDS + list(COMPUTED_USER_FIELDS.keys()))
+    user_json.update({
+        'isAnvil': is_anvil_authenticated(user),
+        'isAnalyst': user_is_analyst(user),
+        'isPm': user_is_pm(user),
     })
     return user_json
 
@@ -789,29 +781,25 @@ def get_json_for_locus_list(locus_list, user):
 def get_json_for_project_collaborator_list(user, project):
     """Returns a JSON representation of the collaborators in the given project"""
     collaborator_list = list(
-        get_project_collaborators_by_username(user, project).values())
+        get_project_collaborators_by_username(
+            user, project, fields=['username', 'email', 'display_name'], include_permissions=True,
+        ).values())
 
     return sorted(collaborator_list, key=lambda collaborator: (
         not collaborator['hasEditPermissions'], (collaborator['displayName'] or collaborator['email']).lower()))
 
 
-def get_project_collaborators_by_username(user, project, include_permissions=True, include_analysts=False, fields=None):
+def get_project_collaborators_by_username(user, project, fields, include_permissions=False, include_analysts=False):
     """Returns a JSON representation of the collaborators in the given project"""
     collaborators = {}
-    fields = fields or DEFAULT_COLLABORATOR_FIELDS
-
-    analyst_users = None
-    if ANALYST_USER_GROUP and (include_analysts or 'is_analyst' in fields):
-        analyst_users = set(User.objects.filter(groups__name=ANALYST_USER_GROUP))
-
     if not anvil_enabled():
         for collaborator in project.can_view_group.user_set.all():
             collaborators[collaborator.username] = _get_collaborator_json(
-                collaborator, include_permissions, can_edit=False, analyst_users=analyst_users, fields=fields)
+                collaborator, fields, include_permissions, can_edit=False)
 
         for collaborator in project.can_edit_group.user_set.all():
             collaborators[collaborator.username] = _get_collaborator_json(
-                collaborator, include_permissions, can_edit=True, analyst_users=analyst_users, fields=fields)
+                collaborator, fields, include_permissions, can_edit=True)
     elif project_has_anvil(project):
         permission_levels = get_workspace_collaborator_perms(user, project.workspace_namespace, project.workspace_name)
         users_by_email = {u.email_lower: u for u in User.objects.annotate(email_lower=Lower('email')).filter(email_lower__in = permission_levels.keys())}
@@ -820,37 +808,40 @@ def get_project_collaborators_by_username(user, project, include_permissions=Tru
                 continue
             collaborator = users_by_email.get(email)
             collaborator_json = _get_collaborator_json(
-                collaborator, include_permissions, can_edit=permission==CAN_EDIT, analyst_users=analyst_users,
-                fields=fields, email=email, get_json_func=_get_json_for_user if collaborator else _get_anvil_user_json)
+                collaborator or email, fields, include_permissions, can_edit=permission == CAN_EDIT,
+                get_json_func=get_json_for_user if collaborator else _get_anvil_user_json)
             collaborators[collaborator_json['username']] = collaborator_json
 
-    if include_analysts and analyst_users and project_has_analyst_access(project):
+    if include_analysts and project_has_analyst_access(project):
+        analyst_users = get_analyst_users()
         collaborators.update({
             user.username: _get_collaborator_json(
-                user, include_permissions, can_edit=True, analyst_users=analyst_users, fields=fields,
+                user, fields, include_permissions, can_edit=True,
             ) for user in analyst_users
         })
 
     return collaborators
 
 
-def _get_anvil_user_json(collab, fields=None, email=None, **kwargs):
-    user = {
-        _to_camel_case(field): False if field in COMPUTED_USER_FIELDS or BOOL_USER_FIELDS else ''
-        for field in fields
-    }
-    user.update({field: email for field in ['username', 'email']})
+def _get_anvil_user_json(collaborator, fields):
+    user = {_to_camel_case(field): '' for field in fields}
+    user.update({field: collaborator for field in ['username', 'email']})
     return user
 
 
-def _get_collaborator_json(collaborator, include_permissions, can_edit, get_json_func=_get_json_for_user, **kwargs):
-    collaborator_json = get_json_func(collaborator, **kwargs)
+def _get_collaborator_json(collaborator, fields, include_permissions, can_edit, get_json_func=get_json_for_user):
+    collaborator_json = get_json_func(collaborator, fields)
+    return _set_collaborator_permissions(collaborator_json, include_permissions, can_edit)
+
+
+def _set_collaborator_permissions(collaborator_json, include_permissions, can_edit):
     if include_permissions:
         collaborator_json.update({
             'hasViewPermissions': True,
             'hasEditPermissions': can_edit,
         })
     return collaborator_json
+
 
 
 def get_json_for_saved_searches(searches, user):

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -115,7 +115,7 @@ COMPUTED_USER_FIELDS = {
 def get_json_for_user(user, fields):
     invalid_fields = [field for field in fields if field not in MODEL_USER_FIELDS and field not in COMPUTED_USER_FIELDS]
     if invalid_fields:
-        raise ValueError(f'Invalid user fields {", ".join(invalid_fields)}')
+        raise ValueError(f'Invalid user fields: {", ".join(invalid_fields)}')
 
     user_json = {
         _to_camel_case(field): getattr(user, field) for field in fields if field in MODEL_USER_FIELDS

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -117,13 +117,10 @@ def get_json_for_user(user, fields):
     if invalid_fields:
         raise ValueError(f'Invalid user fields: {", ".join(invalid_fields)}')
 
-    user_json = {
-        _to_camel_case(field): getattr(user, field) for field in fields if field in MODEL_USER_FIELDS
+    return {
+        _to_camel_case(field): COMPUTED_USER_FIELDS[field](user) if field in COMPUTED_USER_FIELDS else getattr(user, field)
+        for field in fields
     }
-    user_json.update({
-        _to_camel_case(field): COMPUTED_USER_FIELDS[field](user) for field in fields if field in COMPUTED_USER_FIELDS
-    })
-    return user_json
 
 
 def get_json_for_current_user(user):
@@ -806,7 +803,6 @@ def _set_collaborator_permissions(collaborator_json, include_permissions, can_ed
             'hasEditPermissions': can_edit,
         })
     return collaborator_json
-
 
 
 def get_json_for_saved_searches(searches, user):

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -131,9 +131,6 @@ def _get_json_for_user(user, is_anvil=None, fields=None, analyst_users=None, pm_
         dict: json object
     """
 
-    if hasattr(user, '_wrapped'):
-        user = user._wrapped   # Django request.user actually stores the Django User objects in a ._wrapped attribute
-
     model_fields = [field for field in fields if field in MODEL_USER_FIELDS] if fields else MODEL_USER_FIELDS
     computed_fields = [field for field in fields if field in COMPUTED_USER_FIELDS] if fields else COMPUTED_USER_FIELDS
 

--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -7,7 +7,7 @@ from seqr.models import Project, Family, Individual, Sample, IgvSample, SavedVar
 from seqr.views.utils.orm_to_json_utils import get_json_for_user, _get_json_for_project, _get_json_for_family, \
     _get_json_for_individual, get_json_for_sample, get_json_for_saved_variant, get_json_for_variant_tags, \
     get_json_for_variant_functional_data_tags, get_json_for_variant_note, get_json_for_locus_list, \
- get_json_for_saved_search, get_json_for_saved_variants_with_tags, get_json_for_current_user
+    get_json_for_saved_search, get_json_for_saved_variants_with_tags, get_json_for_current_user
 from seqr.views.utils.test_utils import PROJECT_FIELDS, FAMILY_FIELDS, INTERNAL_FAMILY_FIELDS, \
     INDIVIDUAL_FIELDS, INTERNAL_INDIVIDUAL_FIELDS, INDIVIDUAL_FIELDS_NO_FEATURES, SAMPLE_FIELDS, SAVED_VARIANT_FIELDS,  \
     FUNCTIONAL_FIELDS, SAVED_SEARCH_FIELDS, LOCUS_LIST_DETAIL_FIELDS, PA_LOCUS_LIST_FIELDS, IGV_SAMPLE_FIELDS, \

--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -8,7 +8,7 @@ from seqr.views.utils.orm_to_json_utils import get_json_for_user, _get_json_for_
     _get_json_for_individual, get_json_for_sample, get_json_for_saved_variant, get_json_for_variant_tags, \
     get_json_for_variant_functional_data_tags, get_json_for_variant_note, get_json_for_locus_list, \
  get_json_for_saved_search, get_json_for_saved_variants_with_tags, get_json_for_current_user
-from seqr.views.utils.test_utils import USER_FIELDS, PROJECT_FIELDS, FAMILY_FIELDS, INTERNAL_FAMILY_FIELDS, \
+from seqr.views.utils.test_utils import PROJECT_FIELDS, FAMILY_FIELDS, INTERNAL_FAMILY_FIELDS, \
     INDIVIDUAL_FIELDS, INTERNAL_INDIVIDUAL_FIELDS, INDIVIDUAL_FIELDS_NO_FEATURES, SAMPLE_FIELDS, SAVED_VARIANT_FIELDS,  \
     FUNCTIONAL_FIELDS, SAVED_SEARCH_FIELDS, LOCUS_LIST_DETAIL_FIELDS, PA_LOCUS_LIST_FIELDS, IGV_SAMPLE_FIELDS, \
     CASE_REVIEW_FAMILY_FIELDS, TAG_FIELDS, VARIANT_NOTE_FIELDS

--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -4,7 +4,7 @@ import mock
 from copy import deepcopy
 from seqr.models import Project, Family, Individual, Sample, IgvSample, SavedVariant, VariantTag, VariantFunctionalData, \
     VariantNote, LocusList, VariantSearch
-from seqr.views.utils.orm_to_json_utils import _get_json_for_user, _get_json_for_project, _get_json_for_family, \
+from seqr.views.utils.orm_to_json_utils import get_json_for_current_user, _get_json_for_project, _get_json_for_family, \
     _get_json_for_individual, get_json_for_sample, get_json_for_saved_variant, get_json_for_variant_tags, \
     get_json_for_variant_functional_data_tags, get_json_for_variant_note, get_json_for_locus_list, \
  get_json_for_saved_search, get_json_for_saved_variants_with_tags
@@ -19,7 +19,7 @@ class JSONUtilsTest(TestCase):
 
     def test_json_for_user(self):
         for user in User.objects.all():
-            user_json = _get_json_for_user(user)
+            user_json = get_json_for_current_user(user)
             user_json_keys = set(user_json.keys())
 
             self.assertSetEqual(user_json_keys, USER_FIELDS)

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -7,11 +7,10 @@ import openpyxl as xl
 from datetime import date
 from django.contrib.auth.models import User
 
-from settings import PM_USER_GROUP
 from seqr.utils.communication_utils import send_html_email
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.utils.middleware import ErrorsWarningsException
-from seqr.views.utils.permissions_utils import user_is_pm
+from seqr.views.utils.permissions_utils import user_is_pm, get_pm_users
 from seqr.models import Individual
 
 logger = SeqrLogger(__name__)
@@ -351,7 +350,7 @@ def _parse_merged_pedigree_sample_manifest_format(rows):
 
 def _send_sample_manifest(sample_manifest_rows, kit_id, original_filename, original_file_rows, user, project):
 
-    recipients = [u.email for u in User.objects.filter(groups__name=PM_USER_GROUP)]
+    recipients = [u.email for u in get_pm_users()]
 
     # write out the sample manifest file
     wb = xl.Workbook()

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -5,7 +5,6 @@ import json
 import tempfile
 import openpyxl as xl
 from datetime import date
-from django.contrib.auth.models import User
 
 from seqr.utils.communication_utils import send_html_email
 from seqr.utils.logging_utils import SeqrLogger

--- a/seqr/views/utils/pedigree_info_utils_tests.py
+++ b/seqr/views/utils/pedigree_info_utils_tests.py
@@ -100,7 +100,6 @@ class PedigreeInfoUtilsTest(TestCase):
         self.assertListEqual(ec.exception.errors, no_error_warnings)
 
 
-    @mock.patch('seqr.views.utils.pedigree_info_utils.PM_USER_GROUP', 'project-managers')
     @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
     @mock.patch('seqr.utils.communication_utils.EmailMultiAlternatives')
     def test_parse_sample_manifest(self, mock_email, mock_pm_group):

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import user_passes_test, login_required
+from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.db.models.functions import Concat
 from django.db.models import Value, TextField, Q
@@ -13,6 +14,15 @@ from settings import API_LOGIN_REQUIRED_URL, ANALYST_USER_GROUP, PM_USER_GROUP, 
     TERRA_WORKSPACE_CACHE_EXPIRE_SECONDS, SEQR_PRIVACY_VERSION, SEQR_TOS_VERSION, API_POLICY_REQUIRED_URL
 
 logger = SeqrLogger(__name__)
+
+
+def get_analyst_users():
+    return set(User.objects.filter(groups__name=ANALYST_USER_GROUP))
+
+
+def get_pm_users():
+    return set(User.objects.filter(groups__name=PM_USER_GROUP))
+
 
 def user_is_analyst(user):
     return bool(ANALYST_USER_GROUP) and user.groups.filter(name=ANALYST_USER_GROUP).exists()


### PR DESCRIPTION
This is a pprecursor clean up before I start working on https://github.com/broadinstitute/seqr-private/issues/1176
We were returning a lot of user fields to the client that we did not need, and the functions to get the json for users/ lists of users were needlessly complex. This does not actually change seqr behavior