### PR TITLE
Add Prod chart update workflow

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -24,7 +24,6 @@ jobs:
         id: 'auth'
         uses: google-github-actions/auth@v0
         with:
-          # workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/seqr-actions-pool/providers/seqr-github-actions'
           workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
           service_account: '${{ secrets.RUN_SA_EMAIL }}'
 
@@ -40,13 +39,6 @@ jobs:
     needs: docker
     steps:
       - uses: actions/checkout@v3
-      - name: get seqr version
-        run: |
-          seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
-          commit_id=$(git rev-parse --short HEAD)
-          echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v3
         with:
           repository: broadinstitute/seqr-helm
           ref: main
@@ -57,14 +49,20 @@ jobs:
         uses: mikefarah/yq@v4.22.1
         with:
           cmd: >
-            yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
+            yq -i '.appVersion = "${{ github.event.workflow_run.head_sha }}"' charts/seqr/Chart.yaml
 
-      - name: Commit and Push changes
-        uses: Andro999b/push@v1.3
+      - name: Create Pull Request
+        id: createpr
+        uses: peter-evans/create-pull-request@v3
         with:
-          repository: broadinstitute/seqr-helm
-          branch: main
-          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
-          author_email: ${{ github.actor }}@users.noreply.github.com
-          author_name: tgg-automation
-          message: 'Update appVersion with seqr version'
+          token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          commit-message: Update seqr appVersion to ${{ github.event.workflow_run.head_sha }}
+          committer: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          labels: automation
+          title: "Update seqr chart appversion to ${{ github.event.workflow_run.head_sha }}" 
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.createpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.createpr.outputs.pull-request-url }}"

--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -1,0 +1,70 @@
+name: seqr prod release
+on:
+  workflow_run:
+    workflows: ["Unit Tests"]
+    types:
+      - completed
+    branches:
+      - master
+
+permissions:
+  id-token: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: authenticate to google cloud
+        id: 'auth'
+        uses: google-github-actions/auth@v0
+        with:
+          # workload_identity_provider: 'projects/${{ secrets.GOOGLE_PROJECT_ID }}/locations/global/workloadIdentityPools/seqr-actions-pool/providers/seqr-github-actions'
+          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ secrets.RUN_SA_EMAIL }}'
+
+      - name: 'setup gcloud sdk'
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: Build and push images
+        run: |-
+          gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ github.event.workflow_run.head_sha }},_CUSTOM_BRANCH_TAG=gcloud-prod" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
+
+  run:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v3
+      - name: get seqr version
+        run: |
+          seqr_version=$(grep "SEQR_VERSION[ ]*=[ ]*'.*'" ./settings.py | sed -n "s/^.*'\(.*\)'/\1/p")
+          commit_id=$(git rev-parse --short HEAD)
+          echo "SEQR_VERSION=$seqr_version-$commit_id" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v3
+        with:
+          repository: broadinstitute/seqr-helm
+          ref: main
+          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
+
+      - name: Update appVersion in seqr Chart file
+        uses: mikefarah/yq@v4.22.1
+        with:
+          cmd: >
+            yq -i '.appVersion = "${{ env.SEQR_VERSION }}"' charts/seqr/Chart.yaml
+
+      - name: Commit and Push changes
+        uses: Andro999b/push@v1.3
+        with:
+          repository: broadinstitute/seqr-helm
+          branch: main
+          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          author_name: tgg-automation
+          message: 'Update appVersion with seqr version'


### PR DESCRIPTION
This adds a workflow intended to facilitate production releases after merges to master. Once the unit tests workflow succeeds on that branch, a docker build will trigger that pushes tags for the master commit ID and the gcloud-prod tags. Following that, a pull request will be opened on the seqr helm chart updating its appVersion.

We're not deploying prod with the helm chart yet, so this won't change anything with how we currently _ship_ prod with servctl. But, it will be responsible for doing the docker build for the master branch. Prior to merging, I'll need to disable the [old out-of-band cloudbuild trigger](https://github.com/broadinstitute/seqr-terraform/blob/main/prod/cloudbuild.tf) which won't be necessary anymore with Github Actions running the build.

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [x] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [ ] Any chages to non-seqr docker images have been built and pushed to the container registry
  - [ ] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [ ] All these changes have been vetted for potential vulnerabilities