### PR TITLE
support service account authorization for anvil access

### DIFF
--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -1,5 +1,6 @@
 """Provide python bindings for the AnVIL Terra API."""
 
+import google.auth.transport.requests
 import json
 import time
 import requests
@@ -11,7 +12,7 @@ from social_django.utils import load_strategy
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.utils.redis_utils import safe_redis_get_json, safe_redis_set_json
 
-from settings import SEQR_VERSION, TERRA_API_ROOT_URL, TERRA_PERMS_CACHE_EXPIRE_SECONDS, \
+from settings import SEQR_VERSION, TERRA_API_ROOT_URL, TERRA_PERMS_CACHE_EXPIRE_SECONDS, SERVICE_ACCOUNT_CREDENTIALS, \
     TERRA_WORKSPACE_CACHE_EXPIRE_SECONDS, SOCIAL_AUTH_GOOGLE_OAUTH2_KEY, SERVICE_ACCOUNT_FOR_ANVIL, SOCIAL_AUTH_PROVIDER
 
 SEQR_USER_AGENT = "seqr/" + SEQR_VERSION
@@ -117,6 +118,12 @@ def _get_social_access_token(user):
             logger.warning('Refresh token failed. {}'.format(str(ee)), user)
             raise TerraRefreshTokenFailedException('Refresh token failed. {}'.format(str(ee)))
     return social.extra_data['access_token']
+
+
+def _get_service_account_access_token():
+    if (not SERVICE_ACCOUNT_CREDENTIALS.token) or (SERVICE_ACCOUNT_CREDENTIALS.expiry - datetime.now()).seconds < 60:
+        SERVICE_ACCOUNT_CREDENTIALS.refresh(google.auth.transport.requests.Request())
+    return SERVICE_ACCOUNT_CREDENTIALS.token
 
 
 def anvil_call(method, path, access_token, user=None, headers=None, root_url=None, data=None, handle_errors=False):
@@ -270,3 +277,10 @@ def has_service_account_access(user, workspace_namespace, workspace_name):
     acl = user_get_workspace_acl(user, workspace_namespace, workspace_name)
     service_account = acl.get(SERVICE_ACCOUNT_FOR_ANVIL)
     return bool(service_account and (not service_account['pending']))
+
+
+def get_anvil_group_members(user, group, use_sa_credentials=False):
+    path = f'api/groups/{group}'
+    access_token = _get_service_account_access_token() if use_sa_credentials else _get_social_access_token(user)
+    r = anvil_call('get', path, access_token, user)
+    return r['adminEmails'] + r['membersEmails']

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -1,5 +1,6 @@
 """Provide python bindings for the AnVIL Terra API."""
 
+from datetime import datetime
 import google.auth.transport.requests
 import json
 import time

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -122,7 +122,8 @@ def _get_social_access_token(user):
 
 
 def _get_service_account_access_token():
-    if (not SERVICE_ACCOUNT_CREDENTIALS.token) or (SERVICE_ACCOUNT_CREDENTIALS.expiry - datetime.now()).seconds < 60:
+    if (not SERVICE_ACCOUNT_CREDENTIALS.token) or \
+            (SERVICE_ACCOUNT_CREDENTIALS.expiry - datetime.now()).total_seconds() < 60:
         SERVICE_ACCOUNT_CREDENTIALS.refresh(google.auth.transport.requests.Request())
     return SERVICE_ACCOUNT_CREDENTIALS.token
 

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -283,4 +283,4 @@ def get_anvil_group_members(user, group, use_sa_credentials=False):
     path = f'api/groups/{group}'
     access_token = _get_service_account_access_token() if use_sa_credentials else _get_social_access_token(user)
     r = anvil_call('get', path, access_token, user)
-    return r['adminEmails'] + r['membersEmails']
+    return [email for email in r['adminEmails'] + r['membersEmails'] if email != SERVICE_ACCOUNT_FOR_ANVIL]

--- a/seqr/views/utils/terra_api_utils.py
+++ b/seqr/views/utils/terra_api_utils.py
@@ -283,4 +283,4 @@ def get_anvil_group_members(user, group, use_sa_credentials=False):
     path = f'api/groups/{group}'
     access_token = _get_service_account_access_token() if use_sa_credentials else _get_social_access_token(user)
     r = anvil_call('get', path, access_token, user)
-    return [email for email in r['adminEmails'] + r['membersEmails'] if email != SERVICE_ACCOUNT_FOR_ANVIL]
+    return [email for email in r['adminsEmails'] + r['membersEmails'] if email != SERVICE_ACCOUNT_FOR_ANVIL]

--- a/seqr/views/utils/terra_api_utils_tests.py
+++ b/seqr/views/utils/terra_api_utils_tests.py
@@ -1,6 +1,8 @@
+import json
 import mock
 import responses
 
+from datetime import datetime
 from django.test import TestCase
 from django.contrib.auth.models import User
 
@@ -9,13 +11,14 @@ from seqr.views.utils.test_utils import TEST_TERRA_API_ROOT_URL, GOOGLE_TOKEN_RE
 from seqr.views.utils.terra_api_utils import list_anvil_workspaces, user_get_workspace_acl,\
     anvil_call, user_get_workspace_access_level, TerraNotFoundException, TerraAPIException, \
     TerraRefreshTokenFailedException,  is_anvil_authenticated, is_google_authenticated, remove_token, \
-    add_service_account, has_service_account_access
+    add_service_account, has_service_account_access, get_anvil_group_members
 
 GET_WORKSPACE_PATH = 'api/workspaces?fields=public,workspace.name,workspace.namespace'
 AUTH_EXTRA_DATA = {"expires": 3599, "auth_time": TOKEN_AUTH_TIME, "token_type": "Bearer", "access_token": "ya29.EXAMPLE"}
 LIST_WORKSPACE_RESPONSE = '[{"accessLevel": "PROJECT_OWNER", "public": false, "workspace": {"attributes": {"description": "Workspace for seqr project"}, "authorizationDomain": [], "bucketName": "fc-237998e6-663d-40b9-bd13-57c3bb6ac593", "createdBy": "test1@test.com", "createdDate": "2020-09-09T15:10:32.816Z", "isLocked": false, "lastModified": "2020-09-09T15:10:32.818Z", "name": "1000 Genomes Demo", "namespace": "my-seqr-billing", "workflowCollectionName": "237998e6-663d-40b9-bd13-57c3bb6ac593", "workspaceId": "237998e6-663d-40b9-bd13-57c3bb6ac593" }, "workspaceSubmissionStats": {"runningSubmissionsCount": 0}},\
 {"accessLevel": "READER","public": true, "workspace": {"attributes": {"tag:tags": {"itemsType": "AttributeValue","items": ["differential-expression","tutorial"]},"description": "[DEGenome](https://github.com/eweitz/degenome) transforms differential expression data into inputs for [exploratory genome analysis with Ideogram.js](https://eweitz.github.io/ideogram/differential-expression?annots-url=https://www.googleapis.com/storage/v1/b/degenome/o/GLDS-4_array_differential_expression_ideogram_annots.json).  \\n\\nTry the [Notebook tutorial](https://app.terra.bio/#workspaces/degenome/degenome/notebooks/launch/degenome-tutorial.ipynb), where you can step through using DEGenome to analyze expression for mice flown in space!"},"authorizationDomain": [],"bucketName": "fc-2706d493-5fce-4fb2-9993-457c30364a06","createdBy": "test2@test.com","createdDate": "2020-01-14T10:21:14.575Z","isLocked": false,"lastModified": "2020-02-01T13:28:27.309Z","name": "degenome","namespace": "degenome","workflowCollectionName": "2706d493-5fce-4fb2-9993-457c30364a06","workspaceId": "2706d493-5fce-4fb2-9993-457c30364a06"},"workspaceSubmissionStats": {"runningSubmissionsCount": 0}},\
 {"accessLevel": "PROJECT_OWNER","public": false, "workspace": {"attributes": {"description": "A workspace for seqr project"},"authorizationDomain": [],"bucketName": "fc-6a048145-c134-4004-a009-42824f826ee8","createdBy": "test3@test.com","createdDate": "2020-09-09T15:12:30.142Z","isLocked": false,"lastModified": "2020-09-09T15:12:30.145Z","name": "seqr-project 1000 Genomes Demo","namespace": "my-seqr-billing","workflowCollectionName": "6a048145-c134-4004-a009-42824f826ee8","workspaceId": "6a048145-c134-4004-a009-42824f826ee8"},"workspaceSubmissionStats": {"runningSubmissionsCount": 0}}]'
+USERS_GROUP = 'TGG_USERS'
 
 class TerraApiUtilsHelpersCase(TestCase):
     fixtures = ['users', 'social_auth']
@@ -268,3 +271,41 @@ class TerraApiUtilsCallsCase(TestCase):
         r = has_service_account_access(user, 'my-seqr-billing', 'my-seqr-workspace')
         self.assertFalse(r)
 
+    @responses.activate
+    @mock.patch('seqr.views.utils.terra_api_utils.SERVICE_ACCOUNT_CREDENTIALS')
+    @mock.patch('seqr.views.utils.terra_api_utils.datetime')
+    @mock.patch('seqr.views.utils.terra_api_utils.logger')
+    def test_get_anvil_group_members(self, mock_logger, mock_datetime, mock_credentials):
+        user = User.objects.get(username='test_user')
+
+        url = '{}{}'.format(TEST_TERRA_API_ROOT_URL, 'api/groups/TGG_USERS')
+        responses.add(responses.GET, url, status=200, body=json.dumps({
+            'adminsEmails': ['test_user@broadinstitute.org'],
+            'groupEmail': 'TGG_USERS@firecloud.org',
+            'membersEmails': ['test@test.com', TEST_SERVICE_ACCOUNT]
+        }))
+        members = get_anvil_group_members(user, USERS_GROUP)
+        self.assertListEqual(members, ['test_user@broadinstitute.org', 'test@test.com'])
+        mock_logger.info.assert_called_with('GET https://terra.api/api/groups/TGG_USERS 200 175', user)
+        self.assertEqual(len(mock_logger.method_calls), 1)
+        responses.assert_call_count(url, 1)
+        self.assertEqual(responses.calls[0].request.headers['Authorization'], 'Bearer ya29.EXAMPLE')
+
+        # test with service account credentials
+        mock_datetime.now.return_value = datetime(2021, 1, 1)
+        mock_credentials.expiry = datetime(2021, 1, 2)
+        mock_credentials.token = 'ya29.SA_EXAMPLE'
+        get_anvil_group_members(user, USERS_GROUP, use_sa_credentials=True)
+        self.assertEqual(responses.calls[1].request.headers['Authorization'], 'Bearer ya29.SA_EXAMPLE')
+        mock_credentials.refresh.assert_not_called()
+
+        mock_credentials.expiry = datetime(2021, 1, 1)
+        get_anvil_group_members(user, USERS_GROUP, use_sa_credentials=True)
+        mock_credentials.refresh.assert_called_once()
+
+        responses.add(responses.GET, url, status=401)
+        with self.assertRaises(TerraAPIException) as ec:
+            get_anvil_group_members(user, USERS_GROUP)
+        self.assertEqual(
+            str(ec.exception),
+            'Error: called Terra API: GET /api/groups/TGG_USERS got status: 401 with a reason: Unauthorized')

--- a/settings.py
+++ b/settings.py
@@ -405,11 +405,12 @@ AIRFLOW_API_AUDIENCE = os.environ.get('AIRFLOW_API_AUDIENCE')
 AIRFLOW_WEBSERVER_URL = os.environ.get('AIRFLOW_WEBSERVER_URL')
 
 if TERRA_API_ROOT_URL:
-    if not os.path.exists('/.config/service-account-key.json'):
+    service_account_file = '/.config/service-account-key.json'
+    if not os.path.exists(service_account_file):
         raise Exception('Error starting seqr - gcloud auth is not properly configured')
 
     SERVICE_ACCOUNT_CREDENTIALS = service_account.Credentials.from_service_account_file(
-        '/.config/service-account-key.json', scopes=SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE)
+        service_account_file, scopes=SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE)
     SERVICE_ACCOUNT_FOR_ANVIL = SERVICE_ACCOUNT_CREDENTIALS.service_account_email
     if not SERVICE_ACCOUNT_FOR_ANVIL:
         raise Exception('Error starting seqr - gcloud auth credentials are not properly configured')
@@ -419,7 +420,7 @@ if TERRA_API_ROOT_URL:
                                                capture_output=True, text=True, shell=True).stdout.split('\n')[0] # nosec
     if not activated_service_account:
             auth_output = subprocess.run([
-                'gcloud', 'auth', 'activate-service-account', '--key-file', '/.config/service-account-key.json'
+                'gcloud', 'auth', 'activate-service-account', '--key-file', service_account_file
             ], capture_output=True, text=True).stderr  # nosec
             activated_service_account = re.findall(r'\[(.*)\]', auth_output)[0]
     if activated_service_account != SERVICE_ACCOUNT_FOR_ANVIL:

--- a/settings.py
+++ b/settings.py
@@ -413,7 +413,7 @@ if TERRA_API_ROOT_URL:
         SERVICE_ACCOUNT_CREDENTIALS = service_account.Credentials.from_service_account_file(
             service_account_file, scopes=SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE)
         SERVICE_ACCOUNT_FOR_ANVIL = SERVICE_ACCOUNT_CREDENTIALS.service_account_email
-   except Exception:
+    except Exception:
         raise Exception('Error starting seqr - gcloud auth credentials are not properly configured')
 
     # activate command line account if failed on start up

--- a/settings.py
+++ b/settings.py
@@ -417,10 +417,10 @@ if TERRA_API_ROOT_URL:
     activated_service_account = subprocess.run(['gcloud auth list --filter=status:ACTIVE --format="value(account)"'],
                                                capture_output=True, text=True, shell=True).stdout.split('\n')[0] # nosec
     if not activated_service_account:
-            auth_output = subprocess.run([  # nosec
-                'gcloud', 'auth', 'activate-service-account', '--key-file', service_account_file
-            ], capture_output=True, text=True).stderr
-            activated_service_account = re.findall(r'\[(.*)\]', auth_output)[0]
+        auth_output = subprocess.run([  # nosec
+            'gcloud', 'auth', 'activate-service-account', '--key-file', service_account_file
+        ], capture_output=True, text=True).stderr
+        activated_service_account = re.findall(r'\[(.*)\]', auth_output)[0]
     if activated_service_account != SERVICE_ACCOUNT_FOR_ANVIL:
         raise Exception('Error starting seqr - attempt to authenticate gcloud cli failed')
 

--- a/settings.py
+++ b/settings.py
@@ -406,9 +406,6 @@ AIRFLOW_WEBSERVER_URL = os.environ.get('AIRFLOW_WEBSERVER_URL')
 
 if TERRA_API_ROOT_URL:
     service_account_file = '/.config/service-account-key.json'
-    if not os.path.exists(service_account_file):
-        raise Exception('Error starting seqr - gcloud auth is not properly configured')
-
     try:
         SERVICE_ACCOUNT_CREDENTIALS = service_account.Credentials.from_service_account_file(
             service_account_file, scopes=SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE)

--- a/settings.py
+++ b/settings.py
@@ -419,9 +419,9 @@ if TERRA_API_ROOT_URL:
     activated_service_account = subprocess.run(['gcloud auth list --filter=status:ACTIVE --format="value(account)"'],
                                                capture_output=True, text=True, shell=True).stdout.split('\n')[0] # nosec
     if not activated_service_account:
-            auth_output = subprocess.run([
+            auth_output = subprocess.run([  # nosec
                 'gcloud', 'auth', 'activate-service-account', '--key-file', service_account_file
-            ], capture_output=True, text=True).stderr  # nosec
+            ], capture_output=True, text=True).stderr
             activated_service_account = re.findall(r'\[(.*)\]', auth_output)[0]
     if activated_service_account != SERVICE_ACCOUNT_FOR_ANVIL:
         raise Exception('Error starting seqr - attempt to authenticate gcloud cli failed')

--- a/settings.py
+++ b/settings.py
@@ -409,10 +409,11 @@ if TERRA_API_ROOT_URL:
     if not os.path.exists(service_account_file):
         raise Exception('Error starting seqr - gcloud auth is not properly configured')
 
-    SERVICE_ACCOUNT_CREDENTIALS = service_account.Credentials.from_service_account_file(
-        service_account_file, scopes=SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE)
-    SERVICE_ACCOUNT_FOR_ANVIL = SERVICE_ACCOUNT_CREDENTIALS.service_account_email
-    if not SERVICE_ACCOUNT_FOR_ANVIL:
+    try:
+        SERVICE_ACCOUNT_CREDENTIALS = service_account.Credentials.from_service_account_file(
+            service_account_file, scopes=SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE)
+        SERVICE_ACCOUNT_FOR_ANVIL = SERVICE_ACCOUNT_CREDENTIALS.service_account_email
+   except Exception:
         raise Exception('Error starting seqr - gcloud auth credentials are not properly configured')
 
     # activate command line account if failed on start up


### PR DESCRIPTION
For https://github.com/broadinstitute/seqr-private/issues/1176 we will need the ability to query a list of group members as the seqr service account. This is because users need to be able to see the list of seqr analysts even if they are not themselves an analyst/ an admin on the analyst group. In order to use google OAuth's recommended service account credentials library, I reworked how we do the initial service account oauth in the setting file so I wanted to have this reviewed separately from the coming-soon much larger analyst reworking PR