### PR TITLE
remove PR step from helm chart update and use a commit

### DIFF
--- a/.github/workflows/prod-release.yaml
+++ b/.github/workflows/prod-release.yaml
@@ -21,20 +21,20 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: authenticate to google cloud
-        id: 'auth'
+        id: "auth"
         uses: google-github-actions/auth@v0
         with:
-          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
-          service_account: '${{ secrets.RUN_SA_EMAIL }}'
+          workload_identity_provider: "${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}"
+          service_account: "${{ secrets.RUN_SA_EMAIL }}"
 
-      - name: 'setup gcloud sdk'
+      - name: "setup gcloud sdk"
         uses: google-github-actions/setup-gcloud@v0
 
       - name: Build and push images
         run: |-
           gcloud builds submit --quiet --substitutions="COMMIT_SHA=${{ github.event.workflow_run.head_sha }},_CUSTOM_BRANCH_TAG=gcloud-prod" --config .cloudbuild/seqr-docker.cloudbuild.yaml --gcs-log-dir=gs://seqr-github-actions-logs/logs .
 
-  run:
+  helm_update:
     runs-on: ubuntu-latest
     needs: docker
     steps:
@@ -42,8 +42,8 @@ jobs:
         with:
           repository: broadinstitute/seqr-helm
           ref: main
-          persist-credentials: false  # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-          fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Update appVersion in seqr Chart file
         uses: mikefarah/yq@v4.22.1
@@ -51,18 +51,12 @@ jobs:
           cmd: >
             yq -i '.appVersion = "${{ github.event.workflow_run.head_sha }}"' charts/seqr/Chart.yaml
 
-      - name: Create Pull Request
-        id: createpr
-        uses: peter-evans/create-pull-request@v3
+      - name: Commit and Push changes
+        uses: Andro999b/push@v1.3
         with:
-          token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
-          commit-message: Update seqr appVersion to ${{ github.event.workflow_run.head_sha }}
-          committer: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          labels: automation
-          title: "Update seqr chart appversion to ${{ github.event.workflow_run.head_sha }}" 
-
-      - name: Check outputs
-        run: |
-          echo "Pull Request Number - ${{ steps.createpr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.createpr.outputs.pull-request-url }}"
+          repository: broadinstitute/seqr-helm
+          branch: main
+          github_token: ${{ secrets.SEQR_VERSION_UPDATE_TOKEN }}
+          author_email: ${{ github.actor }}@users.noreply.github.com
+          author_name: tgg-automation
+          message: "Update seqr chart appVersion to ${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
As discussed in standup, releasing the prod environment after this automation makes its changes to the helm will still require  a manual approval from us. Given that, opening a PR in seqr-helm feels like an unnecessary gate. This changes the workflow so that it just pushes a chart update commit instead.

- [x] All unit test are passing and coverage has not substantively dropped
- [x] No new dependency vulnerabilities have been introduced
- [x] Any changes to the docker image have been vetted for potential vulnerabilities
- [x] If any python requirements are updated, they are noted and here and will be updated before deploying: 
- [x] Any database migrations are noted here, and will be run before deploying: 
- [x] All major changes are recorded in the changelog, and the changelog has been updated to reflect the latest release
- [x] Any new endpoints are explicitly tested to ensure they are only accessible to correctly permissioned users
- [x] No secrets have been committed
- [x] Infrastructure changes: 
  - [x] No changes to the required seqr infrastructure are included in this change 
   
  OR 
  
  - [ ] Any chages to non-seqr docker images have been built and pushed to the container registry
  - [ ] Any changes to kubernetes configurations will be deployed through a full seqr kubernetes deployment after merging. All these changes have been tested on dev
  - [ ] All these changes have been vetted for potential vulnerabilities