### PR TITLE
use generic load options select class

### DIFF
--- a/ui/shared/components/form/AnvilFileSelector.jsx
+++ b/ui/shared/components/form/AnvilFileSelector.jsx
@@ -1,55 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Message } from 'semantic-ui-react'
-
-import { HttpRequestHelper } from 'shared/utils/httpRequestHelper'
-import { Select } from 'shared/components/form/Inputs'
 import { FormSpy } from 'react-final-form'
-import DataLoader from '../DataLoader'
+import LoadOptionsSelect from './LoadOptionsSelect'
 
-class AnvilFileSelector extends React.PureComponent {
+const AnvilFileSelector = ({ namespace, name, ...props }) => (
+  <LoadOptionsSelect
+    url={`/api/create_project_from_workspace/${namespace}/${name}/get_vcf_list`}
+    optionsResponseKey="dataPathList"
+    errorHeader="Error loading workspace files"
+    validationErrorHeader="No joint called VCF found in workspace"
+    validationErrorMessage="There are no joint called VCFs in the Files section of this workspace. VCFs must have a .vcf, .vcf.gz, or .vcf.bgz file extension. Please add a VCF to your workspace before proceeding with loading."
+    {...props}
+  />
+)
 
-  static propTypes = {
-    namespace: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-  }
-
-  state = {
-    dataPathList: null,
-    loading: false,
-    errorHeader: null,
-    error: null,
-  }
-
-  load = () => {
-    const { namespace, name } = this.props
-    this.setState({ loading: true })
-    new HttpRequestHelper(`/api/create_project_from_workspace/${namespace}/${name}/get_vcf_list`,
-      (responseJson) => {
-        this.setState({ loading: false, dataPathList: responseJson.dataPathList })
-        if (responseJson.dataPathList?.length === 0) {
-          this.setState({
-            errorHeader: 'No joint called VCF found in workspace',
-            error: 'There are no joint called VCFs in the Files section of this workspace. VCFs must have a .vcf, .vcf.gz, or .vcf.bgz file extension. Please add a VCF to your workspace before proceeding with loading.',
-          })
-        }
-      },
-      (e) => {
-        this.setState({ loading: false, errorHeader: 'Error loading workspace files', error: e.message })
-      }).get()
-  }
-
-  render() {
-    const { dataPathList, loading, errorHeader, error } = this.state
-    const options = dataPathList?.map(file => ({ name: file, value: file }))
-    const errorMessage = error ? <Message visible error header={errorHeader} content={error} /> : null
-    return (
-      <DataLoader content={dataPathList} loading={loading} load={this.load} errorMessage={errorMessage}>
-        <Select {...this.props} options={options} />
-      </DataLoader>
-    )
-  }
-
+AnvilFileSelector.propTypes = {
+  namespace: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
 }
 
 const SUBSCRIPTION = { values: true }

--- a/ui/shared/components/form/LoadOptionsSelect.jsx
+++ b/ui/shared/components/form/LoadOptionsSelect.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Message } from 'semantic-ui-react'
+
+import { HttpRequestHelper } from 'shared/utils/httpRequestHelper'
+import { Select } from 'shared/components/form/Inputs'
+import DataLoader from '../DataLoader'
+
+class LoadOptionsSelect extends React.PureComponent {
+
+  static propTypes = {
+    url: PropTypes.string.isRequired,
+    optionsResponseKey: PropTypes.string.isRequired,
+    errorHeader: PropTypes.string,
+    validationErrorHeader: PropTypes.string,
+    validationErrorMessage: PropTypes.string,
+  }
+
+  state = {
+    options: null,
+    loading: false,
+    errorHeader: null,
+    error: null,
+  }
+
+  load = () => {
+    const { url, errorHeader, validationErrorHeader, validationErrorMessage, optionsResponseKey } = this.props
+    this.setState({ loading: true })
+    new HttpRequestHelper(url,
+      (responseJson) => {
+        const options = responseJson[optionsResponseKey]?.map(value => ({ name: value, value }))
+        if (!options || options.length === 0) {
+          this.setState({
+            errorHeader: validationErrorHeader,
+            error: validationErrorMessage,
+          })
+        }
+        this.setState({ loading: false, options })
+      },
+      (e) => {
+        this.setState({ loading: false, errorHeader, error: e.message })
+      }).get()
+  }
+
+  render() {
+    const { options, loading, errorHeader, error } = this.state
+    const errorMessage = error ? <Message visible error header={errorHeader} content={error} /> : null
+    return (
+      <DataLoader content={options} loading={loading} load={this.load} errorMessage={errorMessage}>
+        <Select {...this.props} options={options} />
+      </DataLoader>
+    )
+  }
+
+}
+
+export default LoadOptionsSelect


### PR DESCRIPTION
makes the VCF loader select generic so it can be used for any dropdown that should load its own options without adding them to the redux state. This will be user more broadly in my upcoming PR, but this is a stand alone change so it wil be easier to review it separately