### PR TITLE
do not cache unlimited data manager project guids

### DIFF
--- a/seqr/views/apis/dashboard_api_tests.py
+++ b/seqr/views/apis/dashboard_api_tests.py
@@ -46,19 +46,26 @@ class DashboardPageTest(object):
         self.login_analyst_user()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['projectsByGuid']), 3)
-
-        self.login_data_manager_user()
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['projectsByGuid']), 4)
+        response_json = response.json()
+        self.assertEqual(len(response_json['projectsByGuid']), 3)
+        mock_get_redis.assert_called_with('projects__test_user')
+        mock_set_redis.assert_called_with('projects__test_user', list(response_json['projectsByGuid'].keys()), expire=300)
 
         mock_get_redis.return_value = ['R0001_1kg']
         mock_set_redis.reset_mock()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertSetEqual(set(response.json()['projectsByGuid'].keys()), {'R0001_1kg'})
-        mock_get_redis.assert_called_with('projects__test_data_manager')
+        mock_get_redis.assert_called_with('projects__test_user')
+        mock_set_redis.assert_not_called()
+
+        mock_get_redis.reset_mock()
+        mock_set_redis.reset_mock()
+        self.login_data_manager_user()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.json()['projectsByGuid']), 4)
+        mock_get_redis.assert_not_called()
         mock_set_redis.assert_not_called()
 
         # Test all user projects

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -228,8 +228,7 @@ def check_multi_project_permissions(obj, user):
 
 
 def get_project_guids_user_can_view(user, limit_data_manager=True):
-    is_data_manager = user_is_data_manager(user)
-    if is_data_manager and not limit_data_manager:
+    if user_is_data_manager(user) and not limit_data_manager:
         return list(Project.objects.values_list('guid', flat=True))
 
     cache_key = 'projects__{}'.format(user)

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -228,24 +228,25 @@ def check_multi_project_permissions(obj, user):
 
 
 def get_project_guids_user_can_view(user, limit_data_manager=True):
+    is_data_manager = user_is_data_manager(user)
+    if is_data_manager and not limit_data_manager:
+        return list(Project.objects.values_list('guid', flat=True))
+
     cache_key = 'projects__{}'.format(user)
     project_guids = safe_redis_get_json(cache_key)
     if project_guids is not None:
         return project_guids
 
-    is_data_manager = user_is_data_manager(user)
-    projects = Project.objects.all()
-    if limit_data_manager or not is_data_manager:
-        if is_anvil_authenticated(user):
-            workspaces = ['/'.join([ws['workspace']['namespace'], ws['workspace']['name']]) for ws in
-                          list_anvil_workspaces(user)]
-            projects = projects.annotate(
-                workspace=Concat('workspace_namespace', Value('/', output_field=TextField()), 'workspace_name')
-            ).filter(workspace__in=workspaces)
-        else:
-            projects = get_objects_for_user(user, CAN_VIEW, projects)
+    if is_anvil_authenticated(user):
+        workspaces = ['/'.join([ws['workspace']['namespace'], ws['workspace']['name']]) for ws in
+                      list_anvil_workspaces(user)]
+        projects = Project.objects.annotate(
+            workspace=Concat('workspace_namespace', Value('/', output_field=TextField()), 'workspace_name')
+        ).filter(workspace__in=workspaces)
+    else:
+        projects = get_objects_for_user(user, CAN_VIEW, Project)
 
-        projects = projects | Project.objects.filter(all_user_demo=True, is_demo=True)
+    projects = projects | Project.objects.filter(all_user_demo=True, is_demo=True)
 
     project_guids = [p.guid for p in projects.distinct().only('guid')]
 


### PR DESCRIPTION
Currently, if `get_project_guids_user_can_view` is called for a data manager with `limit_data_manager=True` the limited projects are cached. Then if it is called again before the cache expires with `limit_data_manager=False` it returns the cached value which is the limited list and not the full list, which is an incorrect list of values. For the no limit case, theres no need to cache at all as there is no external requests or processing being done