### PR TITLE
Text fixture update

### DIFF
--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -44,7 +44,7 @@ class ExternalAPITest(TestCase):
             'metrics': {
                 'numberOfCases': 4,
                 'numberOfSubmitters': 2,
-                'numberOfUniqueGenes': 4,
+                'numberOfUniqueGenes': 3,
                 'numberOfUniqueFeatures': 4,
                 'numberOfRequestsReceived': 3,
                 'numberOfPotentialMatchesSent': 1,
@@ -63,7 +63,7 @@ class ExternalAPITest(TestCase):
                 'id': '12345',
                 'contact': {'institution': 'Test Institute', 'href': 'test@test.com', 'name': 'PI'},
                 'genomicFeatures': [{'gene': {'id': 'ENSG00000237613'}}, {
-                    'gene': {'id': 'OR4F29'},
+                    'gene': {'id': 'RP11'},
                     'zygosity': 1,
                     'variant': {'start': 77027549, 'end': 77027550, 'referenceName': '14'},
                 }],
@@ -159,7 +159,7 @@ class ExternalAPITest(TestCase):
                 'genomicFeatures': [
                     {
                         'gene': {
-                            'id': 'ENSG00000186092'
+                            'id': 'ENSG00000135953'
                         },
                         'variant': {
                             'end': 77027548,
@@ -194,7 +194,7 @@ class ExternalAPITest(TestCase):
                 'genomicFeatures': [
                     {
                         'gene': {
-                            'id': 'ENSG00000186092'
+                            'id': 'ENSG00000135953'
                         }, 'variant': {
                             'referenceName': '14',
                             'start': 77027630
@@ -202,17 +202,12 @@ class ExternalAPITest(TestCase):
                     },
                     {
                         'gene': {
-                            'id': 'ENSG00000233750'
+                            'id': 'ENSG00000240361'
                         }
                     },
                     {
                         'gene': {
                             'id': 'ENSG00000223972'
-                        }
-                    },
-                    {
-                        'gene': {
-                            'id': 'ABC'
                         }
                     }
                 ],
@@ -231,7 +226,7 @@ class ExternalAPITest(TestCase):
     matchbox found a match between a patient from Test Institute and the following 3 case(s) 
     in matchbox. The following information was included with the query,
 
-    genes: FAM138A, OR4F29, OR4F5
+    genes: FAM138A, RP11
     phenotypes: HP:0001252 (Muscular hypotonia), HP:0003273 (Hip contracture)
     contact: PI
     email: test@test.com

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -101,7 +101,7 @@ NEW_MATCH_JSON = {
         "genomicFeatures": [
             {
                 "gene": {
-                    "id": "OR4F29"
+                    "id": "RP11"
                 }
             }
         ],
@@ -125,7 +125,7 @@ PARSED_NEW_MATCH_JSON = {
     'patient': NEW_MATCH_JSON['patient'],
     'submissionGuid': SUBMISSION_GUID,
     'phenotypes': [{'observed': 'yes', 'id': 'HP:0012469', 'label': 'Infantile spasms'}],
-    'geneVariants': [{'geneId': 'ENSG00000235249'}],
+    'geneVariants': [{'geneId': 'ENSG00000135953'}],
     'matchStatus': {
         'matchmakerResultGuid': mock.ANY,
         'comments': None,
@@ -216,7 +216,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
                 {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'yes'}
             ],
             'geneVariants': [{
-                'geneId': 'ENSG00000186092',
+                'geneId': 'ENSG00000135953',
                 'alt': 'C',
                 'ref': 'CCACT',
                 'chrom': '14',
@@ -327,7 +327,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'id': 'P0004517',
             'score': 0.35,
             'patient': {
-                'genomicFeatures': [{'gene': {'id': 'ENSG00000186092'}}],
+                'genomicFeatures': [{'gene': {'id': 'ENSG00000135953'}}],
                 'features': None,
                 'contact': {
                     'href': 'mailto:matchmaker@broadinstitute.org',
@@ -343,7 +343,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'phenotypes': [],
             'geneVariants': [
                 {
-                    'geneId': 'ENSG00000186092',
+                    'geneId': 'ENSG00000135953',
                 }
             ],
             'matchStatus': {
@@ -373,7 +373,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
                 {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'yes'}
             ],
             'geneVariants': [{
-                'geneId': 'ENSG00000186092',
+                'geneId': 'ENSG00000135953',
                 'alt': 'C',
                 'ref': 'CCACT',
                 'chrom': '14',
@@ -391,7 +391,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
 
         self.assertSetEqual(
             set(response_json['genesById'].keys()),
-            {'ENSG00000186092', 'ENSG00000233750', 'ENSG00000223972', 'ENSG00000235249'}
+            {'ENSG00000135953', 'ENSG00000240361', 'ENSG00000223972'}
         )
         # non-analyst users can't see contact notes
         self.assertDictEqual(response_json['mmeContactNotes'], {'st georges, university of london': {}})
@@ -417,7 +417,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
                     {'id': 'HP:0012469', 'observed': 'yes'}
                 ],
                 'genomicFeatures': [{
-                    'gene': {'id': 'ENSG00000186092'},
+                    'gene': {'id': 'ENSG00000135953'},
                     'variant': {
                         'end': 77027548, 'start': 77027549, 'assembly': 'GRCh38', 'referenceName': '14',
                         'alternateBases': 'C', 'referenceBases': 'CCACT',
@@ -443,9 +443,9 @@ class MatchmakerAPITest(AuthenticationTestCase):
         message = """
     A search from a seqr user from project 1kg project n\xe5me with uni\xe7\xf8de individual NA19675_1 had the following new match(es):
     
-     - From Sam Baxter at institution Broad Center for Mendelian Genomics with genes OR4F5.
+     - From Sam Baxter at institution Broad Center for Mendelian Genomics with genes RP11.
 
- - From Reza Maroofian at institution St Georges, University of London with genes OR4F29 with phenotypes HP:0012469 (Infantile spasms).
+ - From Reza Maroofian at institution St Georges, University of London with genes RP11 with phenotypes HP:0012469 (Infantile spasms).
     
     /project/R0001_1kg/family_page/F000001_1/matchmaker_exchange
     """

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -806,6 +806,8 @@
         "last_modified_date": "2017-03-13T09:07:50.270Z",
         "family": 12,
         "individual_id": "NA20889",
+        "population": "ASJ",
+        "features": [{"id": "HP:0011675"}, {"id": "HP:0001509"}],
         "mother_id": null,
         "father_id": null,
         "sex": "F",
@@ -1688,7 +1690,7 @@
                         "aminoAcids": "V/M", "cdnaPosition": "3955"}
                 ]
             }, "chrom": "1", "genotypes": {
-                "I000015_na20885": {"sampleId": "NA20885", "ab": 0.0, "ad": "71,0", "gq": 99.0, "dp": "71", "pl": "0,213,1918", "numAlt": 1}}},
+                "I000017_na20889": {"sampleId": "NA20885", "ab": 0.0, "ad": "71,0", "gq": 99.0, "dp": "71", "pl": "0,213,1918", "numAlt": 1}}},
         "family": 12
     }
 },
@@ -1716,7 +1718,7 @@
             "genomeVersion": "37", "genotypeFilters": [],
             "ref": null,
             "genotypes": {
-                "I000015_na20885": { "cn": 1, "sampleId": "NA20885", "numAlt": -1,  "defragged": false, "qs": 33, "numExon": 2}
+                "I000017_na20889": { "cn": 1, "sampleId": "NA20885", "numAlt": -1,  "defragged": false, "qs": 33, "numExon": 2}
             },
             "liftedOverPos": null,
             "liftedOverChrom": null,

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1689,7 +1689,7 @@
                 ]
             }, "chrom": "1", "genotypes": {
                 "I000015_na20885": {"sampleId": "NA20885", "ab": 0.0, "ad": "71,0", "gq": 99.0, "dp": "71", "pl": "0,213,1918", "numAlt": 1}}},
-        "family": 11
+        "family": 12
     }
 },
 {
@@ -1723,9 +1723,9 @@
             "svType": "DEL",
             "variantId": "prefix_19107_DEL",
             "chrom": "12",
-            "transcripts": {"ENSG00000240361": [], "ENSG00000135953": []}
+            "transcripts": {"ENSG00000240361": [], "ENSG00000135953": [], "ENSG00000223972":  []}
         },
-        "family": 11
+        "family": 12
     }
 },
 {
@@ -2083,7 +2083,7 @@
         "genomic_features": [
             {
                 "gene": {
-                    "id": "ENSG00000186092"
+                    "id": "ENSG00000135953"
                 },
                 "variant": {
                     "end": 77027548,
@@ -2102,7 +2102,7 @@
     "model": "matchmaker.matchmakersubmission",
     "pk": 2,
     "fields": {
-        "individual": 15,
+        "individual": 17,
         "guid": "MS000015_na20885",
         "created_date": "2019-02-05T06:42:55.397Z",
         "last_modified_date": "2019-02-05T06:42:55.397Z",
@@ -2125,7 +2125,7 @@
         "genomic_features": [
             {
                 "gene": {
-                    "id": "ENSG00000227232"
+                    "id": "ENSG00000240361"
                 },
                 "variant": {
                     "end": 38739601,
@@ -2155,7 +2155,7 @@
         "genomic_features": [
             {
                 "gene": {
-                    "id": "ENSG00000186092"
+                    "id": "ENSG00000135953"
                 }, "variant": {
                     "referenceName": "14",
                     "start": 77027630
@@ -2163,17 +2163,12 @@
             },
             {
                 "gene": {
-                    "id": "ENSG00000233750"
+                    "id": "ENSG00000240361"
                 }
             },
             {
                 "gene": {
                     "id": "ENSG00000223972"
-                }
-            },
-            {
-                "gene": {
-                    "id": "ABC"
                 }
             }
         ]
@@ -2194,7 +2189,7 @@
         "genomic_features": [
             {
                 "gene": {
-                    "id": "ENSG00000186092"
+                    "id": "ENSG00000135953"
                 }
             }
         ]

--- a/seqr/fixtures/reference_data.json
+++ b/seqr/fixtures/reference_data.json
@@ -944,7 +944,7 @@
     "pk": 48,
     "fields": {
         "gene_id": "ENSG00000135953",
-        "gene_symbol": "RP11-206L10.5",
+        "gene_symbol": "RP11",
         "chrom_grch37": "1",
         "start_grch37": 694412,
         "end_grch37": 700305,

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -50,7 +50,7 @@ class ReloadSavedVariantJsonTest(TestCase):
             mock.call(
                 [family_1, family_2], ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T', '21-3343353-GAGA-G'], user=None,
             ),
-            mock.call([Family.objects.get(id=11)], ['12-48367227-TC-T', 'prefix_19107_DEL'], user=None),
+            mock.call([Family.objects.get(id=12)], ['12-48367227-TC-T', 'prefix_19107_DEL'], user=None),
             mock.call([Family.objects.get(id=14)], ['12-48367227-TC-T'], user=None)
         ], any_order=True)
 

--- a/seqr/views/apis/awesomebar_api_tests.py
+++ b/seqr/views/apis/awesomebar_api_tests.py
@@ -85,15 +85,15 @@ class AwesomebarAPITest(object):
         self.assertEqual(len(genes), 5)
         self.assertListEqual(
             [g['title'] for g in genes],
-            ['ENSG00000186092', 'ENSG00000185097', 'DDX11L1', 'ENSG00000237613', 'ENSG00000240361'],
+            ['ENSG00000135953', 'ENSG00000186092', 'ENSG00000185097', 'DDX11L1', 'ENSG00000237613'],
         )
-        self.assertDictEqual(genes[0], {
+        self.assertDictEqual(genes[1], {
             'key': 'ENSG00000186092',
             'title': 'ENSG00000186092',
             'description': '(OR4F5)',
             'href': '/summary_data/gene_info/ENSG00000186092',
         })
-        self.assertDictEqual(genes[2], {
+        self.assertDictEqual(genes[3], {
             'key': 'ENSG00000223972',
             'title': 'DDX11L1',
             'description': '(ENSG00000223972)',

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -269,6 +269,15 @@ class IndividualAPITest(AuthenticationTestCase):
             pm_required_delete_individuals_url, content_type='application/json', data=json.dumps({
                 'individuals': [PM_REQUIRED_INDIVIDUAL_UPDATE_DATA]
             }))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertListEqual(response.json()['errors'], ['Unable to delete individuals with active MME submission: NA20889'])
+
+        response = self.client.post(
+            pm_required_delete_individuals_url, content_type='application/json', data=json.dumps({
+                'individuals': [{'individualGuid': 'I000015_na20885'}]
+            }))
+
         self.assertEqual(response.status_code, 200)
 
     @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP', 'project-managers')

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -284,7 +284,7 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json()['familyTagTypeCounts'],
-            {'F000011_11': {'Tier 1 - Novel gene and phenotype': 1}},
+            {'F000012_12': {'Tier 1 - Novel gene and phenotype': 1}},
         )
 
         # Test empty project

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -26,7 +26,7 @@ EXPECTED_DISCOVERY_SHEET_ROW = \
      't0': '2017-02-05T06:42:55.397Z', 'months_since_t0': 38, 'sample_source': 'CMG',
      'integument': 'N', 'voice': 'N', 'skeletal_system': 'N',
      'expected_inheritance_model': 'Autosomal recessive inheritance',
-     'extras_variant_tag_list': ['21-3343353-GAGA-G  RP11-206L10.5  tier 1 - novel gene and phenotype'],
+     'extras_variant_tag_list': ['21-3343353-GAGA-G  RP11  tier 1 - novel gene and phenotype'],
      'protein_interaction': 'N', 'n_kindreds': '1', 'num_individuals_sequenced': 3,
      'musculature': 'Y', 'sequencing_approach': 'WES', 'neoplasm': 'N',
      'collaborator': '1kg project n\xe5me with uni\xe7\xf8de',
@@ -44,26 +44,26 @@ EXPECTED_DISCOVERY_SHEET_ROW = \
      't0_copy': '2017-02-05T06:42:55.397Z', 'extras_pedigree_url': '/media/ped_1.png',
      'family_id': '1', 'genitourinary_system': 'N', 'coded_phenotype': 'myopathy',
      'animal_model': 'N', 'non_human_cell_culture_model': 'N', 'expression': 'N',
-     'gene_name': 'RP11-206L10.5', 'breast': 'N'}
+     'gene_name': 'RP11', 'breast': 'N'}
 
 EXPECTED_DISCOVERY_SHEET_COMPOUND_HET_ROW = {
     'project_guid': 'R0003_test', 'pubmed_ids': '', 'posted_publicly': '', 'solved': 'TIER 1 GENE', 'head_or_neck': 'N',
     'analysis_complete_status': 'complete', 'cardiovascular_system': 'Y',
     'n_kindreds_overlapping_sv_similar_phenotype': 'NA', 'biochemical_function': 'N', 'omim_number_post_discovery': 'NA',
-    'genome_wide_linkage': 'NA', 'metabolism_homeostasis': 'N', 'growth': 'N', 't0': '2020-02-05T06:42:55.397Z',
-    'months_since_t0': 2, 'sample_source': 'CMG', 'integument': 'N', 'voice': 'N', 'skeletal_system': 'N',
-    'expected_inheritance_model': 'multiple', 'num_individuals_sequenced': 1, 'sequencing_approach': 'REAN',
+    'genome_wide_linkage': 'NA', 'metabolism_homeostasis': 'N', 'growth': 'N', 't0': '2017-02-05T06:42:55.397Z',
+    'months_since_t0': 38, 'sample_source': 'CMG', 'integument': 'N', 'voice': 'N', 'skeletal_system': 'N',
+    'expected_inheritance_model': 'multiple', 'num_individuals_sequenced': 2, 'sequencing_approach': 'REAN',
     'extras_variant_tag_list': ['1-248367227-TC-T  OR4G11P  tier 1 - novel gene and phenotype',
         'prefix_19107_DEL  OR4G11P  tier 1 - novel gene and phenotype'], 'protein_interaction': 'N', 'n_kindreds': '1',
     'neoplasm': 'N', 'collaborator': 'Test Reprocessed Project', 'actual_inheritance_model': 'AR-comphet',
     'novel_mendelian_gene': 'Y', 'endocrine_system': 'N', 'komp_early_release': 'N', 'connective_tissue': 'N',
-    'prenatal_development_or_birth': 'N', 'rescue': 'N', 'family_guid': 'F000011_11', 'immune_system': 'N',
+    'prenatal_development_or_birth': 'N', 'rescue': 'N', 'family_guid': 'F000012_12', 'immune_system': 'N',
     'analysis_summary': '', 'gene_count': 'NA', 'gene_id': 'ENSG00000240361', 'abdomen': 'N', 'limbs': 'N',
     'phenotype_class': 'New', 'submitted_to_mme': 'Y', 'n_unrelated_kindreds_with_causal_variants_in_gene': '1',
-    'blood': 'N',  'row_id': 'F000011_11ENSG00000240361', 'eye_defects': 'N', 'omim_number_initial': 'NA',
+    'blood': 'N',  'row_id': 'F000012_12ENSG00000240361', 'eye_defects': 'N', 'omim_number_initial': 'NA',
     'p_value': 'NA', 'respiratory': 'N', 'nervous_system': 'N', 'ear_defects': 'N', 'thoracic_cavity': 'N',
-    'non_patient_cell_model': 'N', 't0_copy': '2020-02-05T06:42:55.397Z', 'extras_pedigree_url': '/media/ped.png',
-    'family_id': '11', 'genitourinary_system': 'N', 'coded_phenotype': '', 'animal_model': 'N', 'expression': 'N',
+    'non_patient_cell_model': 'N', 't0_copy': '2017-02-05T06:42:55.397Z', 'extras_pedigree_url': '',
+    'family_id': '12', 'genitourinary_system': 'N', 'coded_phenotype': '', 'animal_model': 'N', 'expression': 'N',
     'non_human_cell_culture_model': 'N', 'gene_name': 'OR4G11P', 'breast': 'N', 'musculature': 'N', 'patient_cells': 'N',}
 
 AIRTABLE_SAMPLE_RECORDS = {
@@ -152,7 +152,7 @@ EXPECTED_SAMPLE_METADATA_ROW = {
     "num_saved_variants": 2,
     "dbgap_submission": "No",
     "solve_state": "Tier 1",
-    "sample_id": "NA20885",
+    "sample_id": "NA20889",
     "Gene_Class-1": "Tier 1 - Candidate",
     "Gene_Class-2": "Tier 1 - Candidate",
     "sample_provider": "",
@@ -162,7 +162,7 @@ EXPECTED_SAMPLE_METADATA_ROW = {
     "novel_mendelian_gene-1": "Y",
     "novel_mendelian_gene-2": "Y",
     "hgvsc-1": "c.3955G>A",
-    "date_data_generation": "2020-02-05",
+    "date_data_generation": "2017-02-05",
     "Zygosity-1": "Heterozygous",
     "Zygosity-2": "Heterozygous",
     "variant_genome_build-1": "GRCh37",
@@ -175,29 +175,30 @@ EXPECTED_SAMPLE_METADATA_ROW = {
     "maternal_id": "",
     "paternal_id": "",
     "hgvsp-1": "c.1586-17C>G",
-    "entity:family_id": "11",
-    "entity:discovery_id": "NA20885",
+    "entity:family_id": "12",
+    "entity:discovery_id": "NA20889",
     "project_id": "Test Reprocessed Project",
     "Pos-1": "248367227",
     "data_type": "WES",
-    "family_guid": "F000011_11",
+    "family_guid": "F000012_12",
     "congenital_status": "Unknown",
+    "family_history": "Yes",
     "hpo_present": "HP:0011675 (Arrhythmia)|HP:0001509 ()",
     "Transcript-1": "ENST00000505820",
     "ancestry": "Ashkenazi Jewish",
     "phenotype_group": "",
-    "sex": "Male",
-    "entity:subject_id": "NA20885",
-    "entity:sample_id": "NA20885",
+    "sex": "Female",
+    "entity:subject_id": "NA20889",
+    "entity:sample_id": "NA20889",
     "Chrom-1": "1",
     "Alt-1": "T",
     "Gene-1": "OR4G11P",
     "pmid_id": "",
     "phenotype_description": "",
     "affected_status": "Affected",
-    "family_id": "11",
+    "family_id": "12",
     "MME": "Y",
-    "subject_id": "NA20885",
+    "subject_id": "NA20889",
     "proband_relationship": "",
     "consanguinity": "None suspected",
     "sequencing_center": "Broad",
@@ -292,7 +293,9 @@ class ReportAPITest(object):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'rows', 'errors'})
-        self.assertListEqual(response_json['errors'], ['HPO category field not set for some HPO terms in 11'])
+        self.assertListEqual(response_json['errors'], [
+            'HPO category field not set for some HPO terms in 11', 'HPO category field not set for some HPO terms in 12',
+        ])
         self.assertEqual(len(response_json['rows']), 2)
         self.assertIn(EXPECTED_DISCOVERY_SHEET_COMPOUND_HET_ROW, response_json['rows'])
 
@@ -367,10 +370,10 @@ class ReportAPITest(object):
             '10-Ref', '11-Alt', '12-hgvsc', '13-hgvsp', '14-Transcript', '15-sv_name', '16-sv_type',
             '17-significance', '18-discovery_notes'])
         self.assertIn([
-            'HG00731', 'HG00731', 'HG00731', 'RP11-206L10.5', 'Known', 'Autosomal recessive (homozygous)',
+            'HG00731', 'HG00731', 'HG00731', 'RP11', 'Known', 'Autosomal recessive (homozygous)',
             'Homozygous', 'GRCh37', '1', '248367227', 'TC', 'T', '-', '-', '-', '-', '-', '-', '-'], discovery_file)
         self.assertIn([
-            'NA19675_1', 'NA19675_1', 'NA19675', 'RP11-206L10.5', 'Tier 1 - Candidate', 'de novo',
+            'NA19675_1', 'NA19675_1', 'NA19675', 'RP11', 'Tier 1 - Candidate', 'de novo',
             'Heterozygous', 'GRCh37', '21', '3343353', 'GAGA', 'G', 'c.375_377delTCT', 'p.Leu126del', 'ENST00000258436',
             '-', '-', '-', '-'], discovery_file)
         self.assertIn([

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -259,7 +259,7 @@ class SavedVariantAPITest(object):
         self.assertListEqual(variants['SV0000002_1248367227_r0390_100']['discoveryTags'], [{
             'savedVariant': {
                 'variantGuid': 'SV0000006_1248367227_r0003_tes',
-                'familyGuid': 'F000011_11',
+                'familyGuid': 'F000012_12',
                 'projectGuid': 'R0003_test',
             },
             'tagGuid': 'VT1726961_2103343353_r0003_tes',

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -14,7 +14,7 @@ EXPECTED_SUCCESS_STORY = {'project_guid': 'R0001_1kg', 'family_guid': 'F000013_1
 
 EXPECTED_MME_DETAILS_METRICS = {
     u'numberOfPotentialMatchesSent': 1,
-    u'numberOfUniqueGenes': 4,
+    u'numberOfUniqueGenes': 3,
     u'numberOfCases': 4,
     u'numberOfRequestsReceived': 3,
     u'numberOfSubmitters': 2,
@@ -45,9 +45,9 @@ class SummaryDataAPITest(object):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'genesById', 'submissions'})
-        self.assertEqual(len(response_json['genesById']), 4)
+        self.assertEqual(len(response_json['genesById']), 3)
         self.assertSetEqual(set(response_json['genesById'].keys()),
-                            {'ENSG00000233750', 'ENSG00000227232', 'ENSG00000223972', 'ENSG00000186092'})
+                            {'ENSG00000240361', 'ENSG00000223972', 'ENSG00000135953'})
         self.assertEqual(len(response_json['submissions']), self.NUM_MANAGER_SUBMISSIONS)
 
         # Test analyst behavior
@@ -58,8 +58,8 @@ class SummaryDataAPITest(object):
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'metrics', 'genesById', 'submissions'})
         self.assertDictEqual(response_json['metrics'], EXPECTED_MME_DETAILS_METRICS)
-        self.assertEqual(len(response_json['genesById']), 4)
-        self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000233750', 'ENSG00000227232', 'ENSG00000223972', 'ENSG00000186092'})
+        self.assertEqual(len(response_json['genesById']), 3)
+        self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000240361', 'ENSG00000223972', 'ENSG00000135953'})
         self.assertEqual(len(response_json['submissions']), 3)
 
     def test_success_story(self):

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -26,7 +26,7 @@ VARIANTS_WITH_DISCOVERY_TAGS = deepcopy(VARIANTS)
 VARIANTS_WITH_DISCOVERY_TAGS[2]['discoveryTags'] = [{
     'savedVariant': {
         'variantGuid': 'SV0000006_1248367227_r0003_tes',
-        'familyGuid': 'F000011_11',
+        'familyGuid': 'F000012_12',
         'projectGuid': 'R0003_test',
     },
     'tagGuid': 'VT1726961_2103343353_r0003_tes',
@@ -389,7 +389,7 @@ class VariantSearchAPITest(object):
         response_json = response.json()
         expected_search_results = deepcopy(EXPECTED_SEARCH_RESPONSE)
         expected_search_results['searchedVariants'] = VARIANTS_WITH_DISCOVERY_TAGS
-        expected_search_results['familiesByGuid'] = {'F000011_11': mock.ANY}
+        expected_search_results['familiesByGuid'] = {'F000012_12': mock.ANY}
         self.assertSetEqual(set(response_json.keys()), set(expected_search_results.keys()))
         self.assertDictEqual(response_json, expected_search_results)
         self._assert_expected_results_context(response_json)


### PR DESCRIPTION
For an upcoming update to matchmaker submissions, submissions will need to be associated with saved variants. This updates the text fixtures and any affected tests to make it possible to test that new functionality.