### PR TITLE
500 error when terra refresh fails

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -345,6 +345,8 @@ urlpatterns += [
     url(API_POLICY_REQUIRED_URL.lstrip('/'), policies_required_error),
 ]
 
+handler401 = 'seqr.views.apis.auth_api.app_login_required_error'
+
 kibana_urls = '^(?:{})'.format('|'.join([
     'app', '\d+/built_assets', '\d+/bundles', 'bundles', 'elasticsearch', 'es_admin', 'node_modules/@kbn', 'internal',
     'plugins', 'translations', 'ui', 'api/apm', 'api/console', 'api/core', 'api/index_management', 'api/index_patterns',

--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -58,6 +58,11 @@ def logout_view(request):
     return redirect('/')
 
 
+def app_login_required_error(request, exception=None):
+    """Redirect to login for unhandled 401 error on non-API request"""
+    return redirect(f'{LOGIN_URL}?next={request.path}')
+
+
 def login_required_error(request):
     """Returns an HttpResponse with a 401 UNAUTHORIZED error message.
 


### PR DESCRIPTION
Previously, the app rendering views never made calls to terra, and all the exception handling for terra was handles by to API error handling. However, now that analyst/pm status is fetched from anvil, the current user json fetched for the main app html makes calls to AnVIL and therefore needs exception handling when refreshing the token fails