### PR TITLE
handle case sensitivity for anvil groups

### DIFF
--- a/seqr/views/apis/users_api_tests.py
+++ b/seqr/views/apis/users_api_tests.py
@@ -434,7 +434,7 @@ class AnvilUsersAPITest(AnvilAuthenticationTestCase, UsersAPITest):
         self.mock_get_ws_access_level.assert_called_with(
             self.collaborator_user, 'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
         self.mock_get_groups.assert_not_called()
-        self.mock_get_group_members.assert_called_with(self.collaborator_user, 'analysts', use_sa_credentials=True)
+        self.mock_get_group_members.assert_called_with(self.collaborator_user, 'Analysts', use_sa_credentials=True)
 
 
     def test_set_password(self):

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -789,8 +789,9 @@ def get_project_collaborators_by_username(user, project, fields, include_permiss
 
     elif project_has_anvil(project):
         permission_levels = get_workspace_collaborator_perms(user, project.workspace_namespace, project.workspace_name)
-        if expand_user_groups and f'{ANALYST_USER_GROUP}@firecloud.org' in permission_levels:
-            analyst_permission = permission_levels.pop(f'{ANALYST_USER_GROUP}@firecloud.org')
+        analyst_email = f'{ANALYST_USER_GROUP}@firecloud.org'.lower()
+        if expand_user_groups and analyst_email in permission_levels:
+            analyst_permission = permission_levels.pop(analyst_email)
             permission_levels.update({email.lower(): analyst_permission for email in get_anvil_analyst_user_emails(user)})
 
         users_by_email = {u.email_lower: u for u in User.objects.annotate(email_lower=Lower('email')).filter(email_lower__in=permission_levels.keys())}

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -45,7 +45,7 @@ class AuthenticationTestCase(TestCase):
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.permissions_utils.ANALYST_USER_GROUP')
         self.mock_analyst_group = patcher.start()
-        self.mock_analyst_group.__str__.return_value = 'analysts'
+        self.mock_analyst_group.__str__.return_value = 'Analysts'
         self.mock_analyst_group.__eq__.side_effect = lambda s: str(self.mock_analyst_group) == s
         self.mock_analyst_group.__bool__.side_effect = lambda: bool(str(self.mock_analyst_group))
         self.mock_analyst_group.resolve_expression.return_value = 'analysts'
@@ -261,7 +261,7 @@ ANVIL_WORKSPACES = [{
             "canShare": False,
             "canCompute": True
         },
-        'analysts@firecloud.org': {
+        'Analysts@firecloud.org': {
             "accessLevel": "WRITER",
             "pending": False,
             "canShare": False,
@@ -294,7 +294,7 @@ ANVIL_WORKSPACES = [{
             "canShare": False,
             "canCompute": False
         },
-        'analysts@firecloud.org': {
+        'Analysts@firecloud.org': {
             "accessLevel": "WRITER",
             "pending": False,
             "canShare": False,
@@ -331,7 +331,7 @@ ANVIL_WORKSPACES = [{
     'workspace_name': TEST_EMPTY_PROJECT_WORKSPACE,
     'public': False,
     'acl': {
-        'analysts@firecloud.org': {
+        'Analysts@firecloud.org': {
             "accessLevel": "WRITER",
             "pending": False,
             "canShare": False,
@@ -366,7 +366,7 @@ ANVIL_WORKSPACES = [{
 
 ANVIL_GROUPS = {
     'project-managers': ['test_pm_user@test.com'],
-    'analysts': ['test_pm_user@test.com', 'test_user@broadinstitute.org'],
+    'Analysts': ['test_pm_user@test.com', 'test_user@broadinstitute.org'],
 }
 ANVIL_GROUP_LOOKUP = defaultdict(list)
 for group, users in ANVIL_GROUPS.items():
@@ -420,7 +420,7 @@ def get_workspaces_side_effect(user):
                 'name': ws['workspace_name']
             }
         } for ws in ANVIL_WORKSPACES if any(
-            email == k.lower() or k.lower().replace('@firecloud.org', '') in ANVIL_GROUP_LOOKUP[email]
+            email == k.lower() or k.replace('@firecloud.org', '') in ANVIL_GROUP_LOOKUP[email]
             for k in ws['acl'].keys())
     ]
 


### PR DESCRIPTION
`permission_levels` are always lower cased but the analyst group name in AnVIL is not all lower case so we are not correctly fetching anvil users for that group