### PR TITLE
Fix kubectl helpers

### DIFF
--- a/deploy/kubectl_helpers/restore_local_db.sh
+++ b/deploy/kubectl_helpers/restore_local_db.sh
@@ -6,7 +6,7 @@ DEPLOYMENT_TARGET=$1
 DB=$2
 
 FILENAME=${DB}_${DEPLOYMENT_TARGET}_backup_$(date +"%Y-%m-%d__%H-%M-%S").gz
-GS_FILE=gs://seqr-backups/${FILENAME}
+GS_FILE=gs://seqr-temp/${FILENAME}
 
 gcloud sql export sql postgres-"${DEPLOYMENT_TARGET}" "${GS_FILE}" --database="${DB}" --offload
 gsutil mv "${GS_FILE}" .

--- a/deploy/kubectl_helpers/shell.sh
+++ b/deploy/kubectl_helpers/shell.sh
@@ -4,6 +4,13 @@ DIR=$(dirname "$BASH_SOURCE")
 
 set -x -e
 
+COMPONENT=$2
+
 POD_NAME=$("${DIR}"/utils/get_pod_name.sh "$@")
 
-kubectl exec -it "${POD_NAME}" -- /bin/bash
+case ${COMPONENT} in
+  seqr) CONTAINER=seqr-pod ;;
+  *) CONTAINER=${COMPONENT} ;;
+esac
+
+kubectl exec -it "${POD_NAME}" -c "${CONTAINER}" -- /bin/bash

--- a/deploy/kubectl_helpers/utils/get_pod_info.sh
+++ b/deploy/kubectl_helpers/utils/get_pod_info.sh
@@ -2,9 +2,7 @@
 
 set -u
 
-DEPLOYMENT_TARGET=$1
-COMPONENT=$2
-JSON_PATH=$3
+COMPONENT=$1
+JSON_PATH=$2
 
-
-kubectl get pod -l "name=${COMPONENT},deployment=gcloud-${DEPLOYMENT_TARGET}" -o "jsonpath=${JSON_PATH}"
+kubectl get pod -l "app.kubernetes.io/name=${COMPONENT}" -o "jsonpath=${JSON_PATH}"

--- a/deploy/kubectl_helpers/utils/get_pod_name.sh
+++ b/deploy/kubectl_helpers/utils/get_pod_name.sh
@@ -2,14 +2,17 @@
 
 set -e
 
+DEPLOYMENT_TARGET=$1
+COMPONENT=$2
+
 DIR=$(dirname "$BASH_SOURCE")
 
-"${DIR}"/check_context.sh "$@"
+"${DIR}"/check_context.sh "${DEPLOYMENT_TARGET}"
 
-STATUS=$("${DIR}"/get_pod_info.sh "$@" "{.items[0].status.phase}")
+STATUS=$("${DIR}"/get_pod_info.sh "${COMPONENT}" "{.items[0].status.phase}")
 if [ "${STATUS}" != "Running" ]; then
     echo "Invalid pod status: ${STATUS}"
     exit 1
 fi
 
-"${DIR}"/get_pod_info.sh "$@" "{.items[0].metadata.name}"
+"${DIR}"/get_pod_info.sh "${COMPONENT}" "{.items[0].metadata.name}"


### PR DESCRIPTION
The latest helm release changes the labels for the pods, so this updates the helper scripts to correctly access them, and also fixes a long standing issue with setting the container name when shelling into a pod