### PR TITLE
update docker-compose redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
 
 
   redis:
-    image: gcr.io/seqr-project/redis:gcloud-prod
+    image: redis:6.2.7
     healthcheck:
       test: redis-cli ping
       interval: 3s


### PR DESCRIPTION
Now that we no longer are maintaining our own redis docker image, we shouldn't reference it in the local docker compose