### PR TITLE
Mme performance

### DIFF
--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -52,7 +52,7 @@ def get_individual_mme_matches(request, submission_guid):
 
     hpo_terms_by_id = get_hpo_terms_by_id(
         {feature['id'] for feature in (submission.features or []) if feature.get('id')})
-    phenotypes = parse_mme_features(submission.features, hpo_terms_by_id),
+    phenotypes = parse_mme_features(submission.features, hpo_terms_by_id)
     response_json.update(_get_submission_detail_response(submission, phenotypes))
 
     return _parse_mme_results(
@@ -100,7 +100,7 @@ def search_local_individual_mme_matches(request, submission_guid):
             update_model_from_json(saved_result, {'result_data': result, 'match_removed': False}, user, updated_fields={'last_modified_date'})
         saved_results[result['patient']['id']] = saved_result
 
-    logger.info('Found {} local matches for {} ({} new)'.format(len(results), submission.submission_id, new_count, user))
+    logger.info('Found {} local matches for {} ({} new)'.format(len(results), submission.submission_id, new_count), user)
 
     return _parse_mme_results(submission, list(saved_results.values()), user)
 

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -135,7 +135,7 @@ def finalize_mme_search(request, submission_guid):
     new_results = submission_results.filter(originating_query=originating_query)
     if new_results:
         try:
-            _generate_notification_for_seqr_match(submission, new_results)
+            _generate_notification_for_seqr_match(submission, [r.result_data for r in new_results])
         except Exception as e:
             logger.error('Unable to create notification for new MME match: {}'.format(str(e)), user)
 

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -550,7 +550,6 @@ def _parse_mme_results(submission, saved_results, user, additional_genes=None, r
 
     submission_json = get_json_for_matchmaker_submission(submission)
     submission_json.update({
-        'mmeResultGuids': list(parsed_results_gy_guid.keys()),
         'phenotypes': parse_mme_features(submission.features, hpo_terms_by_id),
         'geneVariants': get_submission_gene_variants(submission),
     })

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -25,6 +25,9 @@ from settings import BASE_URL, MME_ACCEPT_HEADER, MME_NODES, MME_DEFAULT_CONTACT
 logger = SeqrLogger(__name__)
 
 
+MME_NODES_BY_NAME = {node['name']: node for node in MME_NODES.values() if node.get('url')}
+
+
 @login_and_policies_required
 def get_individual_mme_matches(request, submission_guid):
     """
@@ -52,12 +55,91 @@ def get_individual_mme_matches(request, submission_guid):
 
 
 @login_and_policies_required
-def search_individual_mme_matches(request, submission_guid):
+def get_mme_nodes(request):
+    return create_json_response({'mmeNodes': list(MME_NODES_BY_NAME.keys())})
+
+
+@login_and_policies_required
+def search_local_individual_mme_matches(request, submission_guid):
+    raise NotImplementedException
+
+    submission = MatchmakerSubmission.objects.get(guid=submission_guid)
+    user = request.user
+    check_mme_permissions(submission, user)
+    patient_data = get_submission_json_for_external_match(submission)
+
+    nodes_to_query = [node for node in MME_NODES.values() if node.get('url')]
+    if not nodes_to_query:
+        message = 'No external MME nodes are configured'
+        logger.error(message, user)
+        return create_json_response({'error': message}, status=400, reason=message)
+
+    external_results = _search_external_matches(nodes_to_query, patient_data, user)
+    local_results, incoming_query = get_mme_matches(patient_data, user=user, originating_submission=submission)
+
+    results = local_results + external_results
+
+    initial_saved_results = {
+        result.result_data['patient']['id']: result for result in MatchmakerResult.objects.filter(submission=submission)
+    }
+
+    local_result_submissions = {
+        s.submission_id: s for s in MatchmakerSubmission.objects.filter(matchmakerresult__originating_submission=submission)
+    }
+
+    new_results = []
+    saved_results = {}
+    for result in results:
+        result_patient_id = result['patient']['id']
+        saved_result = initial_saved_results.get(result_patient_id)
+        if not saved_result:
+            saved_result = create_model_from_json(MatchmakerResult, {
+                'submission': submission,
+                'originating_submission': local_result_submissions.get(result_patient_id),
+                'originating_query': incoming_query,
+                'result_data': result,
+                'last_modified_by': user,
+            }, user)
+            new_results.append(result)
+        else:
+            update_model_from_json(saved_result, {'result_data': result, 'match_removed': False}, user)
+        saved_results[result['patient']['id']] = saved_result
+
+    if new_results:
+        try:
+            _generate_notification_for_seqr_match(submission, new_results)
+        except Exception as e:
+            logger.error('Unable to create notification for new MME match: {}'.format(str(e)), user)
+
+    logger.info('Found {} matches for {} ({} new)'.format(len(results), submission.submission_id, len(new_results)), user)
+
+    removed_patients = set(initial_saved_results.keys()) - set(saved_results.keys())
+    removed_count = 0
+    for patient_id in removed_patients:
+        saved_result = initial_saved_results[patient_id]
+        if saved_result.we_contacted or saved_result.host_contacted or saved_result.comments:
+            if not saved_result.match_removed:
+                update_model_from_json(saved_result, {'match_removed': True}, user)
+                removed_count += 1
+            saved_results[patient_id] = saved_result
+        else:
+            saved_result.delete_model(user, user_can_delete=True)
+            removed_count += 1
+
+    if removed_count:
+        logger.info('Removed {} old matches for {}'.format(removed_count, submission.submission_id), user)
+
+    return _parse_mme_results(submission, list(saved_results.values()), user)
+
+
+@login_and_policies_required
+def search_individual_mme_matches(request, submission_guid, node):
     """
     Looks for matches for the given submission.
     Returns:
         Status code and results
     """
+    raise NotImplementedException
 
     submission = MatchmakerSubmission.objects.get(guid=submission_guid)
     user = request.user

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -88,9 +88,10 @@ def _search_node_matches(submission_guid, node, user, is_local=False, incoming_q
     else:
         results = _search_external_matches(MME_NODES_BY_NAME[node], patient_data, user)
 
-    # TODO filter for found patient IDs
+    result_patient_ids = [result['patient']['id'] for result in results]
     initial_saved_results = {
-        result.result_data['patient']['id']: result for result in MatchmakerResult.objects.filter(submission=submission)
+        result.result_data['patient']['id']: result
+        for result in MatchmakerResult.objects.filter(submission=submission, result_data__patient__id__in=result_patient_ids)
     }
 
     local_result_submissions = {

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -210,6 +210,84 @@ def search_individual_mme_matches(request, submission_guid, node):
     return _parse_mme_results(submission, list(saved_results.values()), user)
 
 
+@login_and_policies_required
+def remove_individual_mme_matches(request, submission_guid):
+    """
+    Looks for matches for the given submission.
+    Returns:
+        Status code and results
+    """
+    raise NotImplementedException
+
+    submission = MatchmakerSubmission.objects.get(guid=submission_guid)
+    user = request.user
+    check_mme_permissions(submission, user)
+    patient_data = get_submission_json_for_external_match(submission)
+
+    nodes_to_query = [node for node in MME_NODES.values() if node.get('url')]
+    if not nodes_to_query:
+        message = 'No external MME nodes are configured'
+        logger.error(message, user)
+        return create_json_response({'error': message}, status=400, reason=message)
+
+    external_results = _search_external_matches(nodes_to_query, patient_data, user)
+    local_results, incoming_query = get_mme_matches(patient_data, user=user, originating_submission=submission)
+
+    results = local_results + external_results
+
+    initial_saved_results = {
+        result.result_data['patient']['id']: result for result in MatchmakerResult.objects.filter(submission=submission)
+    }
+
+    local_result_submissions = {
+        s.submission_id: s for s in MatchmakerSubmission.objects.filter(matchmakerresult__originating_submission=submission)
+    }
+
+    new_results = []
+    saved_results = {}
+    for result in results:
+        result_patient_id = result['patient']['id']
+        saved_result = initial_saved_results.get(result_patient_id)
+        if not saved_result:
+            saved_result = create_model_from_json(MatchmakerResult, {
+                'submission': submission,
+                'originating_submission': local_result_submissions.get(result_patient_id),
+                'originating_query': incoming_query,
+                'result_data': result,
+                'last_modified_by': user,
+            }, user)
+            new_results.append(result)
+        else:
+            update_model_from_json(saved_result, {'result_data': result, 'match_removed': False}, user)
+        saved_results[result['patient']['id']] = saved_result
+
+    if new_results:
+        try:
+            _generate_notification_for_seqr_match(submission, new_results)
+        except Exception as e:
+            logger.error('Unable to create notification for new MME match: {}'.format(str(e)), user)
+
+    logger.info('Found {} matches for {} ({} new)'.format(len(results), submission.submission_id, len(new_results)), user)
+
+    removed_patients = set(initial_saved_results.keys()) - set(saved_results.keys())
+    removed_count = 0
+    for patient_id in removed_patients:
+        saved_result = initial_saved_results[patient_id]
+        if saved_result.we_contacted or saved_result.host_contacted or saved_result.comments:
+            if not saved_result.match_removed:
+                update_model_from_json(saved_result, {'match_removed': True}, user)
+                removed_count += 1
+            saved_results[patient_id] = saved_result
+        else:
+            saved_result.delete_model(user, user_can_delete=True)
+            removed_count += 1
+
+    if removed_count:
+        logger.info('Removed {} old matches for {}'.format(removed_count, submission.submission_id), user)
+
+    return _parse_mme_results(submission, list(saved_results.values()), user)
+
+
 def _search_external_matches(nodes_to_query, patient_data, user):
     body = {'_disclaimer': MME_DISCLAIMER}
     body.update(patient_data)

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -132,7 +132,7 @@ def finalize_mme_search(request, submission_guid):
     originating_query = MatchmakerIncomingQuery.objects.get(guid=request.GET['incomingQueryGuid'])
     submission_results = MatchmakerResult.objects.filter(submission=submission)
 
-    new_results = submission_results.filter(originating_query=originating_query)
+    new_results = submission_results.filter(originating_query=originating_query).order_by('created_date')
     if new_results:
         try:
             _generate_notification_for_seqr_match(submission, [r.result_data for r in new_results])

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -82,8 +82,8 @@ def _search_node_matches(submission_guid, node, user, is_local=False):
     if is_local:
         results, incoming_query = get_mme_matches(patient_data, user=user, originating_submission=submission)
     else:
-        # TODO
         results = _search_external_matches(MME_NODES_BY_NAME[node], patient_data, user)
+        raise NotImplementedError
         incoming_query = None  # TODO
 
     # TODO filter for found patient IDs

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -468,7 +468,6 @@ def _parse_mme_results(submission, saved_results, user, additional_genes=None, r
     response = {
         'mmeResultsByGuid': parsed_results_gy_guid,
         'mmeContactNotes': contact_notes,
-        'individualsByGuid': {submission.individual.guid: {'mmeSubmissionGuid': submission.guid}},
         'genesById': genes_by_id,
     }
     if response_json:

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -10,6 +10,7 @@ from matchmaker.models import MatchmakerResult, MatchmakerContactNotes, Matchmak
 from matchmaker.matchmaker_utils import MME_DISCLAIMER
 from matchmaker.views.matchmaker_api import get_individual_mme_matches, search_individual_mme_matches, \
     update_mme_submission, delete_mme_submission, update_mme_result_status, send_mme_contact_email, \
+    get_mme_nodes, search_local_individual_mme_matches, finalize_mme_search, \
     update_mme_contact_note, update_mme_project_contact
 from seqr.views.utils.test_utils import AuthenticationTestCase
 
@@ -154,6 +155,10 @@ MISMATCHED_GENE_NEW_MATCH_JSON['patient']['id'] = '987'
 
 MOCK_SLACK_TOKEN = 'xoxp-123'
 
+MOCK_NODES_BY_NAME = {
+    'Node A': {'name': 'Node A', 'token': 'abc', 'url': 'http://node_a.com/match'},
+    'Node B': {'name': 'Node B', 'token': 'xyz', 'url': 'http://node_b.mme.org/api'},
+}
 
 class EmailException(Exception):
 
@@ -250,67 +255,48 @@ class MatchmakerAPITest(AuthenticationTestCase):
         self.assertDictEqual(response_json['mmeResultsByGuid'][RESULT_STATUS_GUID], PARSED_RESULT)
         self.assertFalse('originatingSubmission' in response_json['mmeResultsByGuid']['MR0007228_VCGS_FAM50_156'])
 
+    @mock.patch('matchmaker.views.matchmaker_api.MME_NODES_BY_NAME', MOCK_NODES_BY_NAME)
+    @responses.activate
+    def test_get_mme_nodes(self):
+        url = reverse(get_mme_nodes)
+        self.check_require_login(url)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), {'mmeNodes': ['Node A', 'Node B']})
+
     @mock.patch('seqr.utils.communication_utils.SLACK_TOKEN', MOCK_SLACK_TOKEN)
+    @mock.patch('matchmaker.views.matchmaker_api.MME_NODES_BY_NAME', MOCK_NODES_BY_NAME)
     @mock.patch('seqr.utils.communication_utils.logger')
     @mock.patch('seqr.utils.communication_utils.Slacker')
     @mock.patch('matchmaker.views.matchmaker_api.logger')
     @mock.patch('matchmaker.views.matchmaker_api.EmailMessage')
-    @mock.patch('matchmaker.views.matchmaker_api.MME_NODES')
     @responses.activate
-    def test_search_individual_mme_matches(self, mock_nodes, mock_email, mock_logger, mock_slacker, mock_communication_logger):
+    def test_search_individual_mme_matches(self, mock_email, mock_logger, mock_slacker, mock_communication_logger):
         mock_slacker.return_value.chat.post_message.side_effect = ValueError('Unable to connect to slack')
         mock_email.return_value.send.side_effect = Exception('Email error')
 
-        url = reverse(search_individual_mme_matches, args=[SUBMISSION_GUID])
-        self.check_collaborator_login(url)
+        local_search_url = reverse(search_local_individual_mme_matches, args=[SUBMISSION_GUID])
+        self.check_collaborator_login(local_search_url)
 
         responses.add(responses.POST, 'http://node_a.com/match', body='Failed request', status=400)
         invalid_results = [INVALID_NEW_MATCH_JSON, INVALID_FEATURES_NEW_MATCH_JSON, INVALID_GENE_NEW_MATCH_JSON]
         results = [NEW_MATCH_JSON, MISMATCHED_GENE_NEW_MATCH_JSON] + invalid_results
         responses.add(responses.POST, 'http://node_b.mme.org/api', status=200, json={'results': results})
 
-        # Test invalid inputs
-        mock_nodes.values.return_value = []
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.reason_phrase, 'No external MME nodes are configured')
-        mock_logger.error.assert_called_with('No external MME nodes are configured', self.collaborator_user)
-
-        mock_logger.reset_mock()
-        mock_nodes.values.return_value = [{'name': 'My node'}]
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.reason_phrase, 'No external MME nodes are configured')
-        mock_logger.error.assert_called_with('No external MME nodes are configured', self.collaborator_user)
-
-        # Test successful search
-        mock_logger.reset_mock()
-        mock_nodes.values.return_value = [
-            {'name': 'My node'},
-            {'name': 'Node A', 'token': 'abc', 'url': 'http://node_a.com/match'},
-            {'name': 'Node B', 'token': 'xyz', 'url': 'http://node_b.mme.org/api'},
-        ]
-        response = self.client.get(url)
+        # Test successful local match search
+        response = self.client.get(local_search_url)
 
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {
-            'mmeResultsByGuid', 'individualsByGuid', 'genesById', 'mmeContactNotes', 'mmeSubmissionsByGuid',
+            'mmeResultsByGuid', 'individualsByGuid', 'genesById', 'mmeContactNotes', 'incomingQueryGuid',
         })
+        incoming_query_guid = response_json['incomingQueryGuid']
 
-        self.assertEqual(len(response_json['mmeResultsByGuid']), 4)
-        existing_result_guids = {'MR0004688_RGP_105_3', RESULT_STATUS_GUID}
-        for guid in existing_result_guids:
-            self.assertTrue(guid in response_json['mmeResultsByGuid'])
-        new_result_guid = next(
-            k for k, v in response_json['mmeResultsByGuid'].items()
-            if k not in existing_result_guids and v['id'] == '33845')
-        new_internal_match_guid  = next(
-            k for k, v in response_json['mmeResultsByGuid'].items()
-            if k not in existing_result_guids and v['id'] == 'P0004517')
-
-        self.assertDictEqual(response_json['mmeResultsByGuid'][new_result_guid], PARSED_NEW_MATCH_JSON)
-        self.assertTrue(response_json['mmeResultsByGuid']['MR0004688_RGP_105_3']['matchStatus']['matchRemoved'])
+        self.assertEqual(len(response_json['mmeResultsByGuid']), 2)
+        self.assertSetEqual({r['submissionGuid'] for r in response_json['mmeResultsByGuid'].values()}, {SUBMISSION_GUID})
+        self.assertTrue(RESULT_STATUS_GUID in response_json['mmeResultsByGuid'])
+        new_internal_match_guid = next(k for k in response_json['mmeResultsByGuid'].keys() if k != RESULT_STATUS_GUID)
         self.assertFalse(response_json['mmeResultsByGuid'][RESULT_STATUS_GUID]['matchStatus']['matchRemoved'])
         self.assertDictEqual(response_json['mmeResultsByGuid'][new_internal_match_guid], {
             'id': 'P0004517',
@@ -364,39 +350,62 @@ class MatchmakerAPITest(AuthenticationTestCase):
                 'createdDate': mock.ANY,
             },
         })
-        self.assertDictEqual(response_json['mmeSubmissionsByGuid'], {SUBMISSION_GUID: {
-            'mmeResultGuids': mock.ANY,
-            'individualGuid': INDIVIDUAL_GUID,
-            'submissionGuid': SUBMISSION_GUID,
-            'createdDate': '2018-05-23T09:07:49.719Z',
-            'lastModifiedDate': '2018-05-23T09:07:49.719Z',
-            'deletedDate': None,
-            'contactName': 'Sam Baxter',
-            'contactHref': 'mailto:matchmaker@broadinstitute.org,test_user@broadinstitute.org',
-            'submissionId': 'NA19675_1_01',
-            'phenotypes': [
-                {'id': 'HP:0001252', 'label': 'Muscular hypotonia', 'observed': 'yes'},
-                {'id': 'HP:0001263', 'label': 'Global developmental delay', 'observed': 'no'},
-                {'id': 'HP:0012469', 'label': 'Infantile spasms', 'observed': 'yes'}
-            ],
-            'geneVariants': [{
-                'geneId': 'ENSG00000135953',
-                'variantGuid': 'SV0000001_2103343353_r0390_100',
-            }],
-        }})
+
+        # TODO not needed in search response, needed for update
         self.assertDictEqual(response_json['individualsByGuid'], {INDIVIDUAL_GUID: {
             'mmeSubmissionGuid': SUBMISSION_GUID,
         }})
         self.assertSetEqual(
-            set(response_json['mmeSubmissionsByGuid'][SUBMISSION_GUID]['mmeResultGuids']),
-            set(response_json['mmeResultsByGuid'].keys()))
-
-        self.assertSetEqual(
             set(response_json['genesById'].keys()),
             {'ENSG00000135953', 'ENSG00000240361', 'ENSG00000223972'}
         )
+        self.assertDictEqual(response_json['mmeContactNotes'], {})
+
+        # The results for internal submissions should link to one another
+        internal_result = MatchmakerResult.objects.get(guid=new_internal_match_guid)
+        self.assertEqual(internal_result.submission.guid, SUBMISSION_GUID)
+        self.assertEqual(internal_result.originating_submission.guid, 'MS000018_P0004517')
+        matched_result = MatchmakerResult.objects.get(submission__guid='MS000018_P0004517')
+        self.assertEqual(matched_result.originating_submission.guid, SUBMISSION_GUID)
+
+        # Test external matches
+        node_a_match_url = reverse(search_individual_mme_matches, args=[SUBMISSION_GUID, 'Node A'])
+        response = self.client.get(node_a_match_url, {'incomingQueryGuid': incoming_query_guid})
+        # TODO should return error status
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json()['mmeResultsByGuid'], {})
+
+        node_b_match_url = reverse(search_individual_mme_matches, args=[SUBMISSION_GUID, 'Node B'])
+        response = self.client.get(node_b_match_url, {'incomingQueryGuid': incoming_query_guid})
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertSetEqual(set(response_json.keys()), {
+            'mmeResultsByGuid', 'individualsByGuid', 'genesById', 'mmeContactNotes',
+        })
+
+        self.assertEqual(len(response_json['mmeResultsByGuid']), 1)
+        new_result_guid = next(k for k in response_json['mmeResultsByGuid'].keys())
+        self.assertDictEqual(response_json['mmeResultsByGuid'][new_result_guid], PARSED_NEW_MATCH_JSON)
+        self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953'})
         # non-analyst users can't see contact notes
         self.assertDictEqual(response_json['mmeContactNotes'], {'st georges, university of london': {}})
+
+        # Test new result model created
+        result_model = MatchmakerResult.objects.get(guid=new_result_guid)
+        self.assertDictEqual(result_model.result_data, NEW_MATCH_JSON)
+
+        # Test notifications and removed result cleanup
+        finalize_search_url = reverse(finalize_mme_search, args=[SUBMISSION_GUID])
+        response = self.client.get(finalize_search_url, {'incomingQueryGuid': incoming_query_guid})
+
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertSetEqual(set(response_json.keys()), {'mmeResultsByGuid'})
+        self.assertDictEqual(response_json['mmeResultsByGuid'], {
+            'MR0004688_RGP_105_3': {'matchStatus': mock.ANY},
+            'MR0007228_VCGS_FAM50_156': None,
+        })
+        self.assertTrue(response_json['mmeResultsByGuid']['MR0004688_RGP_105_3']['matchStatus']['matchRemoved'])
 
         #  Test removed match is deleted
         self.assertEqual(MatchmakerResult.objects.filter(guid='MR0007228_VCGS_FAM50_156').count(), 0)
@@ -496,17 +505,6 @@ class MatchmakerAPITest(AuthenticationTestCase):
             'Found 3 matches for NA19675_1_01 (2 new)',
             'Removed 2 old matches for NA19675_1_01',
         ]])
-
-        # Test new result model created
-        result_model = MatchmakerResult.objects.get(guid=new_result_guid)
-        self.assertDictEqual(result_model.result_data, NEW_MATCH_JSON)
-
-        # The results for internal submissions should link to one another
-        internal_result = MatchmakerResult.objects.get(guid=new_internal_match_guid)
-        self.assertEqual(internal_result.submission.guid, SUBMISSION_GUID)
-        self.assertEqual(internal_result.originating_submission.guid, 'MS000018_P0004517')
-        matched_result = MatchmakerResult.objects.get(submission__guid='MS000018_P0004517')
-        self.assertEqual(matched_result.originating_submission.guid, SUBMISSION_GUID)
 
         # analyst users should see contact notes
         self.login_analyst_user()

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -194,11 +194,11 @@ class MatchmakerAPITest(AuthenticationTestCase):
         self.assertSetEqual(
             set(response_json['mmeResultsByGuid'].keys()), {'MR0007228_VCGS_FAM50_156', 'MR0004688_RGP_105_3', RESULT_STATUS_GUID}
         )
+        self.assertSetEqual({r['submissionGuid'] for r in response_json['mmeResultsByGuid'].values()}, {SUBMISSION_GUID})
 
         self.assertDictEqual(response_json['mmeResultsByGuid'][RESULT_STATUS_GUID], PARSED_RESULT)
         self.assertFalse('originatingSubmission' in response_json['mmeResultsByGuid']['MR0007228_VCGS_FAM50_156'])
         self.assertDictEqual(response_json['mmeSubmissionsByGuid'], {SUBMISSION_GUID: {
-            'mmeResultGuids': mock.ANY,
             'submissionGuid': SUBMISSION_GUID,
             'individualGuid': INDIVIDUAL_GUID,
             'createdDate': '2018-05-23T09:07:49.719Z',
@@ -220,9 +220,6 @@ class MatchmakerAPITest(AuthenticationTestCase):
         self.assertDictEqual(response_json['individualsByGuid'], {INDIVIDUAL_GUID: {
             'mmeSubmissionGuid': SUBMISSION_GUID,
         }})
-        self.assertSetEqual(
-            set(response_json['mmeSubmissionsByGuid'][SUBMISSION_GUID]['mmeResultGuids']),
-            {'MR0007228_VCGS_FAM50_156', 'MR0004688_RGP_105_3', RESULT_STATUS_GUID})
 
         self.assertSetEqual(
             set(response_json['genesById'].keys()),

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -351,10 +351,6 @@ class MatchmakerAPITest(AuthenticationTestCase):
             },
         })
 
-        # TODO not needed in search response, needed for update
-        self.assertDictEqual(response_json['individualsByGuid'], {INDIVIDUAL_GUID: {
-            'mmeSubmissionGuid': SUBMISSION_GUID,
-        }})
         self.assertSetEqual(
             set(response_json['genesById'].keys()),
             {'ENSG00000135953', 'ENSG00000240361', 'ENSG00000223972'}
@@ -379,9 +375,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
         response = self.client.get(node_b_match_url, {'incomingQueryGuid': incoming_query_guid})
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
-        self.assertSetEqual(set(response_json.keys()), {
-            'mmeResultsByGuid', 'individualsByGuid', 'genesById', 'mmeContactNotes',
-        })
+        self.assertSetEqual(set(response_json.keys()), {'mmeResultsByGuid', 'genesById', 'mmeContactNotes'})
 
         self.assertEqual(len(response_json['mmeResultsByGuid']), 1)
         new_result_guid = next(k for k in response_json['mmeResultsByGuid'].keys())

--- a/matchmaker/views/matchmaker_api_tests.py
+++ b/matchmaker/views/matchmaker_api_tests.py
@@ -191,7 +191,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {
-            'mmeResultsByGuid', 'individualsByGuid', 'genesById', 'savedVariantsByGuid', 'variantTagsByGuid',
+            'mmeResultsByGuid', 'genesById', 'savedVariantsByGuid', 'variantTagsByGuid',
             'variantNotesByGuid', 'variantFunctionalDataByGuid', 'mmeContactNotes',
             'mmeSubmissionsByGuid',
         })
@@ -221,9 +221,6 @@ class MatchmakerAPITest(AuthenticationTestCase):
                 'geneId': 'ENSG00000135953',
                 'variantGuid': 'SV0000001_2103343353_r0390_100',
             }],
-        }})
-        self.assertDictEqual(response_json['individualsByGuid'], {INDIVIDUAL_GUID: {
-            'mmeSubmissionGuid': SUBMISSION_GUID,
         }})
 
         self.assertSetEqual(
@@ -289,7 +286,7 @@ class MatchmakerAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {
-            'mmeResultsByGuid', 'individualsByGuid', 'genesById', 'mmeContactNotes', 'incomingQueryGuid',
+            'mmeResultsByGuid', 'genesById', 'mmeContactNotes', 'incomingQueryGuid',
         })
         incoming_query_guid = response_json['incomingQueryGuid']
 

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -272,7 +272,7 @@ api_endpoints = {
     'matchmaker/get_mme_matches/(?P<submission_guid>[\w.|-]+)': get_individual_mme_matches,
     'matchmaker/get_mme_nodes': get_mme_nodes,
     'matchmaker/search_local_mme_matches/(?P<submission_guid>[\w.|-]+)': search_local_individual_mme_matches,
-    'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)/(?P<node>[\w.|-]+)': search_individual_mme_matches,
+    'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)/(?P<node>.+)': search_individual_mme_matches,
     'matchmaker/finalize_mme_search/(?P<submission_guid>[\w.|-]+)': finalize_mme_search,
     'matchmaker/submission/create': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/update': update_mme_submission,

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -80,6 +80,8 @@ from seqr.views.apis.locus_list_api import \
 
 from matchmaker.views.matchmaker_api import \
     get_individual_mme_matches, \
+    get_mme_nodes, \
+    search_local_individual_mme_matches, \
     search_individual_mme_matches, \
     update_mme_submission, \
     delete_mme_submission, \
@@ -267,7 +269,9 @@ api_endpoints = {
     'project/(?P<project_guid>[^/]+)/delete_locus_lists': delete_project_locus_lists,
 
     'matchmaker/get_mme_matches/(?P<submission_guid>[\w.|-]+)': get_individual_mme_matches,
-    'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)': search_individual_mme_matches,
+    'matchmaker/get_mme_nodes': get_mme_nodes,
+    'matchmaker/search_local_mme_matches/(?P<submission_guid>[\w.|-]+)': search_local_individual_mme_matches,
+    'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)/(?P<node>[\w.|-]+)': search_individual_mme_matches,
     'matchmaker/submission/create': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/update': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/delete': delete_mme_submission,

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -271,9 +271,9 @@ api_endpoints = {
 
     'matchmaker/get_mme_matches/(?P<submission_guid>[\w.|-]+)': get_individual_mme_matches,
     'matchmaker/get_mme_nodes': get_mme_nodes,
-    'matchmaker/search_local_mme_matches/(?P<submission_guid>[\w.|-]+)': search_local_individual_mme_matches,
-    'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)/(?P<node>.+)': search_individual_mme_matches,
-    'matchmaker/finalize_mme_search/(?P<submission_guid>[\w.|-]+)': finalize_mme_search,
+    'matchmaker/search_local_mme_matches/(?P<submission_guid>[^/]+)': search_local_individual_mme_matches,
+    'matchmaker/search_mme_matches/(?P<submission_guid>[^/]+)/(?P<node>[^/]+)': search_individual_mme_matches,
+    'matchmaker/finalize_mme_search/(?P<submission_guid>[^/]+)': finalize_mme_search,
     'matchmaker/submission/create': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/update': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/delete': delete_mme_submission,

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -83,6 +83,7 @@ from matchmaker.views.matchmaker_api import \
     get_mme_nodes, \
     search_local_individual_mme_matches, \
     search_individual_mme_matches, \
+    remove_individual_mme_matches, \
     update_mme_submission, \
     delete_mme_submission, \
     update_mme_result_status, \
@@ -272,6 +273,7 @@ api_endpoints = {
     'matchmaker/get_mme_nodes': get_mme_nodes,
     'matchmaker/search_local_mme_matches/(?P<submission_guid>[\w.|-]+)': search_local_individual_mme_matches,
     'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)/(?P<node>[\w.|-]+)': search_individual_mme_matches,
+    'matchmaker/remove_stale_mme_matches/(?P<submission_guid>[\w.|-]+)': remove_individual_mme_matches,
     'matchmaker/submission/create': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/update': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/delete': delete_mme_submission,

--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -83,7 +83,7 @@ from matchmaker.views.matchmaker_api import \
     get_mme_nodes, \
     search_local_individual_mme_matches, \
     search_individual_mme_matches, \
-    remove_individual_mme_matches, \
+    finalize_mme_search, \
     update_mme_submission, \
     delete_mme_submission, \
     update_mme_result_status, \
@@ -273,7 +273,7 @@ api_endpoints = {
     'matchmaker/get_mme_nodes': get_mme_nodes,
     'matchmaker/search_local_mme_matches/(?P<submission_guid>[\w.|-]+)': search_local_individual_mme_matches,
     'matchmaker/search_mme_matches/(?P<submission_guid>[\w.|-]+)/(?P<node>[\w.|-]+)': search_individual_mme_matches,
-    'matchmaker/remove_stale_mme_matches/(?P<submission_guid>[\w.|-]+)': remove_individual_mme_matches,
+    'matchmaker/finalize_mme_search/(?P<submission_guid>[\w.|-]+)': finalize_mme_search,
     'matchmaker/submission/create': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/update': update_mme_submission,
     'matchmaker/submission/(?P<submission_guid>[\w.|-]+)/delete': delete_mme_submission,

--- a/ui/pages/Project/components/Matchmaker.jsx
+++ b/ui/pages/Project/components/Matchmaker.jsx
@@ -28,7 +28,12 @@ import {
 import { camelcaseToTitlecase } from 'shared/utils/stringUtils'
 
 import {
-  loadMmeMatches, updateMmeSubmission, updateMmeSubmissionStatus, sendMmeContactEmail, updateMmeContactNotes,
+  searchMmeMatches,
+  getMmeMatches,
+  updateMmeSubmission,
+  updateMmeSubmissionStatus,
+  sendMmeContactEmail,
+  updateMmeContactNotes,
 } from '../reducers'
 import {
   getMatchmakerMatchesLoading,
@@ -510,8 +515,8 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  load: () => dispatch(loadMmeMatches(ownProps.individual.mmeSubmissionGuid, false)),
-  searchMme: () => dispatch(loadMmeMatches(ownProps.individual.mmeSubmissionGuid, true)),
+  load: () => dispatch(getMmeMatches(ownProps.individual.mmeSubmissionGuid)),
+  searchMme: () => dispatch(searchMmeMatches(ownProps.individual.mmeSubmissionGuid)),
   onSubmit: values => dispatch(updateMmeSubmission({
     ...values,
     submissionGuid: ownProps.individual.mmeSubmissionGuid,

--- a/ui/pages/Project/components/Matchmaker.jsx
+++ b/ui/pages/Project/components/Matchmaker.jsx
@@ -468,7 +468,7 @@ const BaseMatchmakerIndividual = React.memo((
             defaultSortColumn="createdDate"
             defaultSortDescending
             columns={DISPLAY_FIELDS}
-            data={mmeResults.active}
+            data={mmeResults?.active}
             loading={loading}
             emptyContent="No matches found"
             downloadFileName={`MME_matches_${individual.displayName}`}

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -882,7 +882,6 @@ export const STATE_WITH_2_FAMILIES = {
     MS021475_na19675_1: {
       submissionGuid: 'MS021475_na19675_1',
       individualGuid: 'I021475_na19675_1',
-      mmeResultGuids: ['MR0005038_HK018_0047','MR0004688_RGP_105_3'],
       createdDate: '2018-05-09T10:29:00.000Z',
       submissionId: 'NA19675_1',
       contactHref: 'mailto:matchmaker@broadinstitute.org,test@test.com',

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -229,7 +229,7 @@ export const updateAnalysisGroup = values => updateEntity(
 export const getMmeMatches = submissionGuid => (dispatch, getState) => {
   const state = getState()
   const submission = state.mmeSubmissionsByGuid[submissionGuid]
-  if (submission && !submission.mmeResultGuids) {
+  if (submission && !submission.geneVariants) {
     const { familyGuid } = state.individualsByGuid[submission.individualGuid]
     dispatch({ type: REQUEST_MME_MATCHES })
     new HttpRequestHelper(`/api/matchmaker/get_mme_matches/${submissionGuid}`,

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -19,6 +19,7 @@ const UPDATE_CURRENT_PROJECT = 'UPDATE_CURRENT_PROJECT'
 const RECEIVE_SAVED_VARIANT_FAMILIES = 'RECEIVE_SAVED_VARIANT_FAMILIES'
 const UPDATE_SAVED_VARIANT_TABLE_STATE = 'UPDATE_VARIANT_STATE'
 const REQUEST_MME_MATCHES = 'REQUEST_MME_MATCHES'
+const RECEIVE_MME_MATCHES = 'RECEIVE_MME_MATCHES'
 const REQUEST_RNA_SEQ_DATA = 'REQUEST_RNA_SEQ_DATA'
 const REQUEST_PROJECT_OVERVIEW = 'REQUEST_PROJECT_OVERVIEW'
 const RECEIVE_PROJECT_OVERVIEW = 'RECEIVE_PROJECT_OVERVIEW'
@@ -225,13 +226,13 @@ export const updateAnalysisGroup = values => updateEntity(
   values, RECEIVE_DATA, null, 'analysisGroupGuid', null, state => `/api/project/${state.currentProjectGuid}/analysis_groups`,
 )
 
-export const loadMmeMatches = (submissionGuid, search) => (dispatch, getState) => {
+export const getMmeMatches = submissionGuid => (dispatch, getState) => {
   const state = getState()
   const submission = state.mmeSubmissionsByGuid[submissionGuid]
-  if (submission && (!submission.mmeResultGuids || search)) {
+  if (submission && !submission.mmeResultGuids) {
     const { familyGuid } = state.individualsByGuid[submission.individualGuid]
     dispatch({ type: REQUEST_MME_MATCHES })
-    new HttpRequestHelper(`/api/matchmaker/${search ? 'search' : 'get'}_mme_matches/${submissionGuid}`,
+    new HttpRequestHelper(`/api/matchmaker/get_mme_matches/${submissionGuid}`,
       (responseJson) => {
         dispatch({
           type: RECEIVE_SAVED_VARIANT_FAMILIES, updates: { [familyGuid]: { loaded: true, noteVariants: true } },
@@ -240,11 +241,27 @@ export const loadMmeMatches = (submissionGuid, search) => (dispatch, getState) =
           type: RECEIVE_DATA,
           updatesById: responseJson,
         })
+        dispatch({ type: RECEIVE_MME_MATCHES, updatesById: {} })
       },
       (e) => {
-        dispatch({ type: RECEIVE_DATA, error: e.message, updatesById: {} })
+        dispatch({ type: RECEIVE_MME_MATCHES, error: e.message, updatesById: {} })
       }).get()
   }
+}
+
+export const searchMmeMatches = submissionGuid => (dispatch) => {
+  dispatch({ type: REQUEST_MME_MATCHES })
+  new HttpRequestHelper(`/api/matchmaker/search_mme_matches/${submissionGuid}`,
+    (responseJson) => {
+      dispatch({
+        type: RECEIVE_DATA,
+        updatesById: responseJson,
+      })
+      dispatch({ type: RECEIVE_MME_MATCHES, updatesById: {} })
+    },
+    (e) => {
+      dispatch({ type: RECEIVE_MME_MATCHES, error: e.message, updatesById: {} })
+    }).get()
 }
 
 export const loadRnaSeqData = individualGuid => (dispatch, getState) => {
@@ -266,7 +283,7 @@ export const loadRnaSeqData = individualGuid => (dispatch, getState) => {
 
 export const updateMmeSubmission = (values) => {
   const onSuccess = values.delete ? null : (responseJson, dispatch, getState) => (
-    loadMmeMatches(Object.keys(responseJson.mmeSubmissionsByGuid)[0], true)(dispatch, getState)
+    searchMmeMatches(Object.keys(responseJson.mmeSubmissionsByGuid)[0])(dispatch, getState)
   )
   return updateEntity(values, RECEIVE_DATA, '/api/matchmaker/submission', 'submissionGuid', null, null, onSuccess)
 }
@@ -306,7 +323,7 @@ export const updateSavedVariantTable = updates => ({ type: UPDATE_SAVED_VARIANT_
 
 export const reducers = {
   currentProjectGuid: createSingleValueReducer(UPDATE_CURRENT_PROJECT, null),
-  matchmakerMatchesLoading: loadingReducer(REQUEST_MME_MATCHES, RECEIVE_DATA),
+  matchmakerMatchesLoading: loadingReducer(REQUEST_MME_MATCHES, RECEIVE_MME_MATCHES),
   mmeContactNotes: createObjectsByIdReducer(RECEIVE_DATA, 'mmeContactNotes'),
   rnaSeqDataLoading: loadingReducer(REQUEST_RNA_SEQ_DATA, RECEIVE_DATA),
   familyTagTypeCounts: createObjectsByIdReducer(RECEIVE_DATA, 'familyTagTypeCounts'),

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -261,14 +261,20 @@ export const searchMmeMatches = submissionGuid => (dispatch) => {
       Promise.all(urls.map(url => new HttpRequestHelper(
         url,
         (responseJson) => {
-          dispatch({
-            type: RECEIVE_DATA,
-            updatesById: responseJson,
-          })
+          dispatch({ type: RECEIVE_DATA, updatesById: responseJson })
         },
         e => errors.add(e.message),
       ).get())).then(() => {
-        dispatch({ type: RECEIVE_MME_MATCHES, error: [...errors].join(', '), updatesById: {} })
+        new HttpRequestHelper(
+          `/api/matchmaker/remove_stale_mme_matches/${submissionGuid}`,
+          (responseJson) => {
+            dispatch({ type: RECEIVE_DATA, updatesById: responseJson })
+            dispatch({ type: RECEIVE_MME_MATCHES, error: [...errors].join(', '), updatesById: {} })
+          },
+          (e) => {
+            dispatch({ type: RECEIVE_MME_MATCHES, error: e.message, updatesById: {} })
+          },
+        ).get()
       })
     },
     (e) => {

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -256,7 +256,7 @@ export const searchMmeMatches = submissionGuid => (dispatch) => {
       const errors = new Set()
       const urls = [
         `/api/matchmaker/search_local_mme_matches/${submissionGuid}`,
-        ...mmeNodes.map(node => `/api/matchmaker/search_mme_matches/${node}/${submissionGuid}`),
+        ...mmeNodes.map(node => `/api/matchmaker/search_mme_matches/${submissionGuid}/${node}`),
       ]
       Promise.all(urls.map(url => new HttpRequestHelper(
         url,

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -252,14 +252,14 @@ export const getMmeMatches = submissionGuid => (dispatch, getState) => {
 export const searchMmeMatches = submissionGuid => (dispatch) => {
   dispatch({ type: REQUEST_MME_MATCHES })
   const errors = new Set()
-  let queryGuid
+  const queryParams = {}
 
   new HttpRequestHelper('/api/matchmaker/get_mme_nodes',
     ({ mmeNodes }) => {
       new HttpRequestHelper(
         `/api/matchmaker/search_local_mme_matches/${submissionGuid}`,
         ({ incomingQueryGuid, ...responseJson }) => {
-          queryGuid = incomingQueryGuid
+          queryParams.incomingQueryGuid = incomingQueryGuid
           dispatch({ type: RECEIVE_DATA, updatesById: responseJson })
         },
         e => errors.add(e.message),
@@ -270,7 +270,7 @@ export const searchMmeMatches = submissionGuid => (dispatch) => {
             dispatch({ type: RECEIVE_DATA, updatesById: responseJson })
           },
           e => errors.add(e.message),
-        ).get({ incomingQueryGuid: queryGuid }))).then(() => {
+        ).get(queryParams))).then(() => {
           new HttpRequestHelper(
             `/api/matchmaker/finalize_mme_search/${submissionGuid}`,
             (responseJson) => {
@@ -280,7 +280,7 @@ export const searchMmeMatches = submissionGuid => (dispatch) => {
             (e) => {
               dispatch({ type: RECEIVE_MME_MATCHES, error: e.message, updatesById: {} })
             },
-          ).get()
+          ).get(queryParams)
         })
       })
     },

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -266,7 +266,7 @@ export const searchMmeMatches = submissionGuid => (dispatch) => {
         e => errors.add(e.message),
       ).get())).then(() => {
         new HttpRequestHelper(
-          `/api/matchmaker/remove_stale_mme_matches/${submissionGuid}`,
+          `/api/matchmaker/finalize_mme_search/${submissionGuid}`,
           (responseJson) => {
             dispatch({ type: RECEIVE_DATA, updatesById: responseJson })
             dispatch({ type: RECEIVE_MME_MATCHES, error: [...errors].join(', '), updatesById: {} })

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -611,20 +611,17 @@ export const getDefaultMmeSubmission = createSelector(
 export const getMmeResultsBySubmission = createSelector(
   getMmeResultsByGuid,
   getMmeSubmissionsByGuid,
-  (mmeResultsByGuid, mmeSubmissionsByGuid) => Object.values(mmeSubmissionsByGuid).reduce((acc, submission) => {
-    const { submissionGuid, mmeResultGuids = [] } = submission
+  (mmeResultsByGuid, mmeSubmissionsByGuid) => Object.values(mmeResultsByGuid).reduce((acc, result) => {
+    const { submissionGuid } = result
     if (!acc[submissionGuid]) {
       acc[submissionGuid] = { active: [], removed: [] }
     }
-    mmeResultGuids.forEach((resultGuid) => {
-      const result = mmeResultsByGuid[resultGuid]
-      const parsedResult = { ...result.matchStatus, ...result }
-      if (parsedResult.matchRemoved || mmeSubmissionsByGuid[submissionGuid].deletedDate) {
-        acc[submissionGuid].removed.push(parsedResult)
-      } else {
-        acc[submissionGuid].active.push(parsedResult)
-      }
-    })
+    const parsedResult = { ...result.matchStatus, ...result }
+    if (parsedResult.matchRemoved || mmeSubmissionsByGuid[submissionGuid].deletedDate) {
+      acc[submissionGuid].removed.push(parsedResult)
+    } else {
+      acc[submissionGuid].active.push(parsedResult)
+    }
     return acc
   }, { }),
 )


### PR DESCRIPTION
Parallelizes matchmaker search behavior so each nodes is searched in their own API request instead of all being searched sequenctially. This should fix the timeout issues we have been getting since taking RD Connect live