### PR TITLE
Correct a miss-leading error message when the permission is insufficient.

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -397,6 +397,8 @@ def load_phenotype_prioritization_data(request):
     request_json = json.loads(request.body)
 
     file_path = request_json['file']
+    if not does_file_exist(file_path, user=request.user):
+        return create_json_response({'error': 'File not found: {}'.format(file_path)}, status=400)
 
     try:
         tool, data_by_project_indiv_id = load_phenotype_prioritization_data_file(file_path)

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -814,30 +814,38 @@ class DataManagerAPITest(AuthenticationTestCase):
     def _join_data(cls, data):
         return iter(['\t'.join(line) for line in data])
 
+    @mock.patch('seqr.utils.file_utils.subprocess.Popen')
     @mock.patch('seqr.views.utils.dataset_utils.file_iter')
     @mock.patch('seqr.models.logger')
-    def test_load_phenotype_prioritization_data(self, mock_logger, mock_file_iter):
+    def test_load_phenotype_prioritization_data(self, mock_logger, mock_file_iter, mock_subprocess):
         url = reverse(load_phenotype_prioritization_data)
         self.check_data_manager_login(url)
 
+        request_body = {'file': 'gs://seqr_data/lirical_data.tsv.gz'}
+        mock_subprocess.return_value.wait.return_value = 1
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['error'], 'File not found: gs://seqr_data/lirical_data.tsv.gz')
+
+        mock_subprocess.return_value.wait.return_value = 0
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_MISS_HEADER)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['error'], 'Invalid file: missing column(s) project, diseaseId')
-        mock_file_iter.assert_called_with('lirical_data.tsv.gz')
+        mock_file_iter.assert_called_with('gs://seqr_data/lirical_data.tsv.gz')
 
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_NO_PROJECT_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['error'], 'Both sample ID and project fields are required.')
 
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_DATA + EXOMISER_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['error'], 'Multiple tools found lirical and exomiser. Only one in a file is supported.')
 
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_PROJECT_NOT_EXIST_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['error'], 'Project CMG_Beggs_WGS not found. ')
 
@@ -845,22 +853,22 @@ class DataManagerAPITest(AuthenticationTestCase):
                                          name='1kg project nåme with uniçøde', workspace_namespace='my-seqr-billing')
         mock_file_iter.return_value = self._join_data(
             PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_DATA + LIRICAL_PROJECT_NOT_EXIST_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['error'], 'Project CMG_Beggs_WGS not found. Projects with conflict name(s) 1kg project nåme with uniçøde.')
         project.delete()
 
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_NO_EXIST_INDV_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['error'], "Can't find individuals NA19678x, NA19679x")
 
         # Test a successful operation
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 200)
         info = [
-            'Loaded Lirical data from lirical_data.tsv.gz',
+            'Loaded Lirical data from gs://seqr_data/lirical_data.tsv.gz',
             'Project 1kg project nåme with uniçøde: loaded 1 record(s)',
             'Project Test Reprocessed Project: loaded 1 record(s)'
         ]
@@ -875,10 +883,10 @@ class DataManagerAPITest(AuthenticationTestCase):
         # Test uploading new data
         mock_logger.reset_mock()
         mock_file_iter.return_value = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + UPDATE_LIRICAL_DATA)
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'file': 'lirical_data.tsv.gz'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 200)
         info = [
-            'Loaded Lirical data from lirical_data.tsv.gz',
+            'Loaded Lirical data from gs://seqr_data/lirical_data.tsv.gz',
             'Project 1kg project nåme with uniçøde: deleted 1 record(s), loaded 2 record(s)'
         ]
         self.assertEqual(response.json()['info'], info)


### PR DESCRIPTION
See this [ticket.](https://github.com/broadinstitute/seqr-private/issues/1202)