### PR TITLE
Shared phi component

### DIFF
--- a/ui/shared/components/form/PhiWarningUploadField.jsx
+++ b/ui/shared/components/form/PhiWarningUploadField.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Segment } from 'semantic-ui-react'
+
+class PhiWarningUploadField extends React.PureComponent {
+
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  state = { confirmedNoPhi: false }
+
+  confirmNoPhi = () => {
+    this.setState({ confirmedNoPhi: true })
+  }
+
+  render() {
+    const { confirmedNoPhi } = this.state
+    const { children } = this.props
+    return confirmedNoPhi ? children : (
+      <Segment basic compact textAlign="center" size="large">
+        <i>seqr </i>
+        is not a HIPAA-compliant platform. By proceeding, I affirm that this image does not contain any
+        protected health information (PHI), either in the image itself or in the image metadata.
+        <br />
+        <br />
+        <Button primary floated="right" content="Continue" onClick={this.confirmNoPhi} />
+      </Segment>
+    )
+  }
+
+}
+
+export default PhiWarningUploadField

--- a/ui/shared/components/form/PhiWarningUploadField.jsx
+++ b/ui/shared/components/form/PhiWarningUploadField.jsx
@@ -28,7 +28,7 @@ class PhiWarningUploadField extends React.PureComponent {
         {disclaimerDetail}
         <br />
         <br />
-        <Button primary floated="right" content="Continue" onClick={this.confirmNoPhi} />
+        <Button primary floated="right" content="I Agree" onClick={this.confirmNoPhi} />
       </Segment>
     )
   }

--- a/ui/shared/components/form/PhiWarningUploadField.jsx
+++ b/ui/shared/components/form/PhiWarningUploadField.jsx
@@ -6,6 +6,8 @@ class PhiWarningUploadField extends React.PureComponent {
 
   static propTypes = {
     children: PropTypes.node,
+    fileDescriptor: PropTypes.string,
+    disclaimerDetail: PropTypes.string,
   }
 
   state = { confirmedNoPhi: false }
@@ -16,12 +18,14 @@ class PhiWarningUploadField extends React.PureComponent {
 
   render() {
     const { confirmedNoPhi } = this.state
-    const { children } = this.props
+    const { children, fileDescriptor, disclaimerDetail } = this.props
     return confirmedNoPhi ? children : (
       <Segment basic compact textAlign="center" size="large">
         <i>seqr </i>
-        is not a HIPAA-compliant platform. By proceeding, I affirm that this image does not contain any
-        protected health information (PHI), either in the image itself or in the image metadata.
+        is not a HIPAA-compliant platform. By proceeding, I affirm that this &nbsp;
+        {fileDescriptor}
+        &nbsp; does not contain any protected health information (PHI), &nbsp;
+        {disclaimerDetail}
         <br />
         <br />
         <Button primary floated="right" content="Continue" onClick={this.confirmNoPhi} />

--- a/ui/shared/components/form/XHRUploaderField.jsx
+++ b/ui/shared/components/form/XHRUploaderField.jsx
@@ -17,9 +17,9 @@ class UploaderFieldComponent extends React.PureComponent {
     uploaderProps: PropTypes.object,
   }
 
-  onFinished = (xhr, uploaderState) => {
+  onFinished = (xhrResponse, uploaderState) => {
     const { input } = this.props
-    input.onChange({ uploaderState, ...JSON.parse(xhr.response) })
+    input.onChange({ uploaderState, ...xhrResponse })
   }
 
   render() {

--- a/ui/shared/components/form/XHRUploaderWithEvents.jsx
+++ b/ui/shared/components/form/XHRUploaderWithEvents.jsx
@@ -4,6 +4,7 @@
 import React from 'react'
 import Cookies from 'js-cookie'
 import PropTypes from 'prop-types'
+import { Message } from 'semantic-ui-react'
 
 // XHRUploader widget: https://github.com/rma-consulting/react-xhr-uploader/blob/master/src/index.js
 import XHRUploader from 'react-xhr-uploader'
@@ -23,6 +24,7 @@ class XHRUploaderWithEvents extends XHRUploader {
     onUploadStarted: PropTypes.func,
     onUploadFinished: PropTypes.func,
     initialState: PropTypes.object,
+    showError: PropTypes.bool,
   }
 
   constructor(props) {
@@ -46,6 +48,10 @@ class XHRUploaderWithEvents extends XHRUploader {
     )
   }
 
+  renderButton() {
+    return this.state.error && <Message error content={this.state.error} />
+  }
+
   /**
    * Override the default implementation to call the onUpload callback with the server's response and add CSRF header
    * Taken from https://github.com/harunhasdal/react-xhr-uploader/blob/master/src/index.js
@@ -67,7 +73,11 @@ class XHRUploaderWithEvents extends XHRUploader {
       xhr.onload = () => {
         progressCallback(100)
         if (this.props.onUploadFinished) {
-          this.props.onUploadFinished(xhr, this.state)
+          if (this.props.showError && xhr.status !== 200) {
+            this.setState({ error: `Error: ${xhr.statusText} (${xhr.status})` })
+          } else {
+            this.props.onUploadFinished(JSON.parse(xhr.response), this.state)
+          }
         }
       }
       xhr.upload.onprogress = (e) => {

--- a/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
+++ b/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Loader, Button, Segment } from 'semantic-ui-react'
+import { Loader } from 'semantic-ui-react'
 
 import { updateFamily } from 'redux/rootReducer'
 import { RECEIVE_DATA } from 'redux/utils/reducerUtils'
 import { closeModal } from 'redux/utils/modalReducer'
 import DeleteButton from '../../buttons/DeleteButton'
 import DispatchRequestButton from '../../buttons/DispatchRequestButton'
+import PhiWarningUploadField from '../../form/PhiWarningUploadField'
 import Modal from '../../modal/Modal'
 import { ButtonLink } from '../../StyledComponents'
 
@@ -20,8 +21,6 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
     onSuccess: PropTypes.func,
   }
 
-  state = { confirmedNoPhi: false }
-
   constructor(props) {
     super(props)
     this.modalId = `uploadPedigree-${props.family.familyGuid}`
@@ -32,20 +31,15 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
     return onSuccess(xhrResponse, this.modalId)
   }
 
-  confirmNoPhi = () => {
-    this.setState({ confirmedNoPhi: true })
-  }
-
   render() {
     const { family } = this.props
-    const { confirmedNoPhi } = this.state
     return (
       <Modal
         title={`Upload Pedigree for Family ${family.familyId}`}
         modalName={this.modalId}
         trigger={<ButtonLink content="Upload New Image" icon="upload" labelPosition="right" />}
       >
-        {confirmedNoPhi ? (
+        <PhiWarningUploadField>
           <React.Suspense fallback={<Loader />}>
             <XHRUploaderWithEvents
               onUploadFinished={this.onFinished}
@@ -57,16 +51,7 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
               showError
             />
           </React.Suspense>
-        ) : (
-          <Segment basic compact textAlign="center" size="large">
-            <i>seqr </i>
-            is not a HIPAA-compliant platform. By proceeding, I affirm that this image does not contain any
-            protected health information (PHI), either in the image itself or in the image metadata.
-            <br />
-            <br />
-            <Button primary floated="right" content="Continue" onClick={this.confirmNoPhi} />
-          </Segment>
-        )}
+        </PhiWarningUploadField>
       </Modal>
     )
   }

--- a/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
+++ b/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
@@ -8,60 +8,45 @@ import { RECEIVE_DATA } from 'redux/utils/reducerUtils'
 import { closeModal } from 'redux/utils/modalReducer'
 import DeleteButton from '../../buttons/DeleteButton'
 import DispatchRequestButton from '../../buttons/DispatchRequestButton'
-import PhiWarningUploadField from '../../form/PhiWarningUploadField'
 import Modal from '../../modal/Modal'
 import { ButtonLink } from '../../StyledComponents'
 
 const XHRUploaderWithEvents = React.lazy(() => import('../../form/XHRUploaderWithEvents'))
+const PhiWarningUploadField = React.lazy(() => import('../../form/PhiWarningUploadField'))
 
-class BaseEditPedigreeImageButton extends React.PureComponent {
+const getModalId = family => `uploadPedigree-${family.familyGuid}`
 
-  static propTypes = {
-    family: PropTypes.object,
-    onSuccess: PropTypes.func,
-  }
+const BaseEditPedigreeImageButton = ({ family, onSuccess }) => (
+  <Modal
+    title={`Upload Pedigree for Family ${family.familyId}`}
+    modalName={getModalId(family)}
+    trigger={<ButtonLink content="Upload New Image" icon="upload" labelPosition="right" />}
+  >
+    <React.Suspense fallback={<Loader />}>
+      <PhiWarningUploadField>
+        <XHRUploaderWithEvents
+          onUploadFinished={onSuccess}
+          url={`/api/family/${family.familyGuid}/update_pedigree_image`}
+          clearTimeOut={0}
+          auto
+          maxFiles={1}
+          dropzoneLabel="Drag and drop or click to upload pedigree image"
+          showError
+        />
+      </PhiWarningUploadField>
+    </React.Suspense>
+  </Modal>
+)
 
-  constructor(props) {
-    super(props)
-    this.modalId = `uploadPedigree-${props.family.familyGuid}`
-  }
-
-  onFinished = (xhrResponse) => {
-    const { onSuccess } = this.props
-    return onSuccess(xhrResponse, this.modalId)
-  }
-
-  render() {
-    const { family } = this.props
-    return (
-      <Modal
-        title={`Upload Pedigree for Family ${family.familyId}`}
-        modalName={this.modalId}
-        trigger={<ButtonLink content="Upload New Image" icon="upload" labelPosition="right" />}
-      >
-        <PhiWarningUploadField>
-          <React.Suspense fallback={<Loader />}>
-            <XHRUploaderWithEvents
-              onUploadFinished={this.onFinished}
-              url={`/api/family/${family.familyGuid}/update_pedigree_image`}
-              clearTimeOut={0}
-              auto
-              maxFiles={1}
-              dropzoneLabel="Drag and drop or click to upload pedigree image"
-              showError
-            />
-          </React.Suspense>
-        </PhiWarningUploadField>
-      </Modal>
-    )
-  }
-
+BaseEditPedigreeImageButton.propTypes = {
+  family: PropTypes.object,
+  onSuccess: PropTypes.func,
 }
 
-const mapDispatchToProps = dispatch => ({
-  onSuccess: (responseJson, modalId) => {
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  onSuccess: (responseJson) => {
     dispatch({ type: RECEIVE_DATA, updatesById: { familiesByGuid: responseJson } })
-    dispatch(closeModal(modalId))
+    dispatch(closeModal(getModalId(ownProps.family)))
   },
 })
 

--- a/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
+++ b/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Message, Loader, Button, Segment } from 'semantic-ui-react'
+import { Loader, Button, Segment } from 'semantic-ui-react'
 
 import { updateFamily } from 'redux/rootReducer'
 import { RECEIVE_DATA } from 'redux/utils/reducerUtils'
@@ -20,17 +20,16 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
     onSuccess: PropTypes.func,
   }
 
-  state = { error: null, confirmedNoPhi: false }
+  state = { confirmedNoPhi: false }
 
   constructor(props) {
     super(props)
     this.modalId = `uploadPedigree-${props.family.familyGuid}`
   }
 
-  onFinished = (xhr) => {
+  onFinished = (xhrResponse) => {
     const { onSuccess } = this.props
-    return xhr.status === 200 ? onSuccess(JSON.parse(xhr.response), this.modalId) :
-      this.setState({ error: `Error: ${xhr.statusText} (${xhr.status})` })
+    return onSuccess(xhrResponse, this.modalId)
   }
 
   confirmNoPhi = () => {
@@ -39,7 +38,7 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
 
   render() {
     const { family } = this.props
-    const { error, confirmedNoPhi } = this.state
+    const { confirmedNoPhi } = this.state
     return (
       <Modal
         title={`Upload Pedigree for Family ${family.familyId}`}
@@ -55,6 +54,7 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
               auto
               maxFiles={1}
               dropzoneLabel="Drag and drop or click to upload pedigree image"
+              showError
             />
           </React.Suspense>
         ) : (
@@ -67,7 +67,6 @@ class BaseEditPedigreeImageButton extends React.PureComponent {
             <Button primary floated="right" content="Continue" onClick={this.confirmNoPhi} />
           </Segment>
         )}
-        {error && <Message error content={error} />}
       </Modal>
     )
   }

--- a/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
+++ b/ui/shared/components/panel/view-pedigree-image/PedigreeImageButtons.jsx
@@ -8,11 +8,11 @@ import { RECEIVE_DATA } from 'redux/utils/reducerUtils'
 import { closeModal } from 'redux/utils/modalReducer'
 import DeleteButton from '../../buttons/DeleteButton'
 import DispatchRequestButton from '../../buttons/DispatchRequestButton'
+import PhiWarningUploadField from '../../form/PhiWarningUploadField'
 import Modal from '../../modal/Modal'
 import { ButtonLink } from '../../StyledComponents'
 
 const XHRUploaderWithEvents = React.lazy(() => import('../../form/XHRUploaderWithEvents'))
-const PhiWarningUploadField = React.lazy(() => import('../../form/PhiWarningUploadField'))
 
 const getModalId = family => `uploadPedigree-${family.familyGuid}`
 
@@ -22,8 +22,8 @@ const BaseEditPedigreeImageButton = ({ family, onSuccess }) => (
     modalName={getModalId(family)}
     trigger={<ButtonLink content="Upload New Image" icon="upload" labelPosition="right" />}
   >
-    <React.Suspense fallback={<Loader />}>
-      <PhiWarningUploadField>
+    <PhiWarningUploadField fileDescriptor="image" disclaimerDetail="either in the image itself or in the image metadata">
+      <React.Suspense fallback={<Loader />}>
         <XHRUploaderWithEvents
           onUploadFinished={onSuccess}
           url={`/api/family/${family.familyGuid}/update_pedigree_image`}
@@ -33,8 +33,8 @@ const BaseEditPedigreeImageButton = ({ family, onSuccess }) => (
           dropzoneLabel="Drag and drop or click to upload pedigree image"
           showError
         />
-      </PhiWarningUploadField>
-    </React.Suspense>
+      </React.Suspense>
+    </PhiWarningUploadField>
   </Modal>
 )
 


### PR DESCRIPTION
Makes no real functionality changes, but breaks out the PHI confirmation logic from the pedigree image component into a sharable base component that will be used in https://github.com/broadinstitute/seqr/issues/3123

This also cleans up how error handling is managed in the base file uploader field to allow the pedigree image component to be greatly simplified