### PR TITLE
Overview  UI performance

### DIFF
--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -195,7 +195,6 @@ def project_families(request, project_guid):
             'caseReviewStatusLastModified': family.case_review_status_last_modified,
             'hasFeatures': family.guid in has_features_families,
         })
-    response['projectsByGuid'] = {project_guid: {'familiesLoaded': True}}
     return create_json_response(response)
 
 
@@ -217,7 +216,6 @@ def project_overview(request, project_guid):
 
     project_json = response['projectsByGuid'][project_guid]
     project_json.update({
-        'overviewLoaded': True,
         'mmeSubmissionCount': project_mme_submissions.filter(deleted_date__isnull=True).count(),
         'mmeDeletedSubmissionCount': project_mme_submissions.filter(deleted_date__isnull=False).count(),
     })
@@ -233,7 +231,6 @@ def project_collaborators(request, project_guid):
 
     return create_json_response({
         'projectsByGuid': {project_guid: {
-            'collaboratorsLoaded': True,
             'collaborators': get_json_for_project_collaborator_list(request.user, project),
             'collaboratorGroups': get_json_for_project_collaborator_groups(project),
         }}
@@ -247,7 +244,6 @@ def project_individuals(request, project_guid):
         Individual.objects.filter(family__project=project), user=request.user, project_guid=project_guid, add_hpo_details=True)
 
     return create_json_response({
-        'projectsByGuid': {project_guid: {'individualsLoaded': True}},
         'individualsByGuid': {i['individualGuid']: i for i in individuals},
     })
 
@@ -256,7 +252,6 @@ def project_analysis_groups(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)
 
     return create_json_response({
-        'projectsByGuid': {project_guid: {'analysisGroupsLoaded': True}},
         'analysisGroupsByGuid': get_project_analysis_groups([project], project_guid)
     })
 
@@ -267,7 +262,7 @@ def project_locus_lists(request, project_guid):
     locus_list_json, _ = get_project_locus_lists([project], request.user, include_metadata=True)
 
     return create_json_response({
-        'projectsByGuid': {project_guid: {'locusListsLoaded': True, 'locusListGuids': list(locus_list_json.keys())}},
+        'projectsByGuid': {project_guid: {'locusListGuids': list(locus_list_json.keys())}},
         'locusListsByGuid': locus_list_json,
     })
 
@@ -278,7 +273,6 @@ def project_family_notes(request, project_guid):
     family_notes = get_json_for_family_notes(FamilyNote.objects.filter(family__project=project), is_analyst=False)
 
     return create_json_response({
-        'projectsByGuid': {project_guid: {'familyNotesLoaded': True}},
         'familyNotesByGuid': {n['noteGuid']: n for n in family_notes},
     })
 
@@ -297,7 +291,6 @@ def project_mme_submisssions(request, project_guid):
     family_notes = get_json_for_family_notes(FamilyNote.objects.filter(family__project=project))
 
     return create_json_response({
-        'projectsByGuid': {project_guid: {'mmeSubmissionsLoaded': True}},
         'mmeSubmissionsByGuid': submissions_by_guid,
         'familyNotesByGuid': {n['noteGuid']: n for n in family_notes},
     })

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -212,16 +212,13 @@ class ProjectAPITest(object):
         self.assertListEqual(list(response_json['projectsByGuid'].keys()), [DEMO_PROJECT_GUID])
         self.assertFalse(response_json['projectsByGuid'][DEMO_PROJECT_GUID]['canEdit'])
 
-    def _check_empty_project(self, empty_url, response_keys, project_loaded_key=None):
+    def _check_empty_project(self, empty_url, response_keys):
         response = self.client.get(empty_url)
         if self.HAS_EMPTY_PROJECT:
             self.assertEqual(response.status_code, 200)
             response_json = response.json()
             self.assertSetEqual(set(response_json.keys()), response_keys)
-            expected_response = {k: {} for k in response_keys}
-            expected_response['projectsByGuid'] = {
-                EMPTY_PROJECT_GUID: {project_loaded_key: True}
-            } if project_loaded_key else mock.ANY
+            expected_response = {k: {EMPTY_PROJECT_GUID: mock.ANY} if k == 'projectsByGuid' else {} for k in response_keys}
             self.assertDictEqual(response_json, expected_response)
         else:
             self.assertEqual(response.status_code, 403)
@@ -240,7 +237,7 @@ class ProjectAPITest(object):
         self.assertSetEqual(set(response_json.keys()), response_keys)
 
         project_fields = {
-            'variantTagTypes', 'variantFunctionalTagTypes', 'overviewLoaded',
+            'variantTagTypes', 'variantFunctionalTagTypes',
             'projectGuid', 'mmeDeletedSubmissionCount', 'mmeSubmissionCount',
         }
         project_response = response_json['projectsByGuid'][PROJECT_GUID]
@@ -288,7 +285,6 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
 
         self.assertDictEqual(response.json(), {'projectsByGuid': {PROJECT_GUID: {
-            'collaboratorsLoaded': True,
             'collaborators': self.PROJECT_COLLABORATORS,
             'collaboratorGroups': self.PROJECT_COLLABORATOR_GROUPS,
         }}})
@@ -316,7 +312,7 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
-        response_keys = {'projectsByGuid', 'familiesByGuid', 'genesById'}
+        response_keys = {'familiesByGuid', 'genesById'}
         self.assertSetEqual(set(response_json.keys()), response_keys)
 
         family_1 = response_json['familiesByGuid']['F000001_1']
@@ -339,12 +335,11 @@ class ProjectAPITest(object):
             len(response_json['familiesByGuid'][family_guid]['discoveryTags']) for family_guid in no_discovery_families
         }, {0})
 
-        self.assertDictEqual(response_json['projectsByGuid'], {PROJECT_GUID: {'familiesLoaded': True}})
         self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953'})
 
         # Test empty project
         empty_url = reverse(project_families, args=[EMPTY_PROJECT_GUID])
-        self._check_empty_project(empty_url, response_keys, 'familiesLoaded')
+        self._check_empty_project(empty_url, response_keys)
 
         # Test analyst users have internal fields returned
         self.login_analyst_user()
@@ -370,9 +365,8 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
-        response_keys = {'projectsByGuid',  'individualsByGuid'}
+        response_keys = {'individualsByGuid'}
         self.assertSetEqual(set(response_json.keys()), response_keys)
-        self.assertDictEqual(response_json['projectsByGuid'], {PROJECT_GUID: {'individualsLoaded': True}})
 
         self.assertSetEqual(set(next(iter(response_json['individualsByGuid'].values())).keys()), INDIVIDUAL_FIELDS)
         self.assertSetEqual(
@@ -386,7 +380,7 @@ class ProjectAPITest(object):
 
         # Test empty project
         empty_url = reverse(project_individuals, args=[EMPTY_PROJECT_GUID])
-        self._check_empty_project(empty_url, response_keys, 'individualsLoaded')
+        self._check_empty_project(empty_url, response_keys)
 
         # Test analyst users have internal fields returned
         self.login_analyst_user()
@@ -413,9 +407,8 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
-        response_keys = {'projectsByGuid', 'analysisGroupsByGuid'}
+        response_keys = {'analysisGroupsByGuid'}
         self.assertSetEqual(set(response_json.keys()), response_keys)
-        self.assertDictEqual(response_json['projectsByGuid'], {PROJECT_GUID: {'analysisGroupsLoaded': True}})
         self.assertEqual(len(response_json['analysisGroupsByGuid']), 2)
         self.assertSetEqual(
             set(next(iter(response_json['analysisGroupsByGuid'].values())).keys()), ANALYSIS_GROUP_FIELDS
@@ -432,7 +425,7 @@ class ProjectAPITest(object):
         response_keys = {'projectsByGuid', 'locusListsByGuid'}
         self.assertSetEqual(set(response_json.keys()), response_keys)
         self.assertDictEqual(response_json['projectsByGuid'], {PROJECT_GUID: {
-            'locusListsLoaded': True, 'locusListGuids': ['LL00049_pid_genes_autosomal_do', 'LL00005_retina_proteome'],
+            'locusListGuids': ['LL00049_pid_genes_autosomal_do', 'LL00005_retina_proteome'],
         }})
         self.assertEqual(len(response_json['locusListsByGuid']), 2)
         self.assertSetEqual(set(response_json['locusListsByGuid']['LL00005_retina_proteome'].keys()), LOCUS_LIST_FIELDS)
@@ -448,9 +441,8 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
-        response_keys = {'projectsByGuid', 'familyNotesByGuid'}
+        response_keys = {'familyNotesByGuid'}
         self.assertSetEqual(set(response_json.keys()), response_keys)
-        self.assertDictEqual(response_json['projectsByGuid'], {PROJECT_GUID: {'familyNotesLoaded': True}})
         self.assertEqual(len(response_json['familyNotesByGuid']), 3)
         self.assertSetEqual(
             set(next(iter(response_json['familyNotesByGuid'].values())).keys()), FAMILY_NOTE_FIELDS
@@ -458,7 +450,7 @@ class ProjectAPITest(object):
 
         # Test empty project
         empty_url = reverse(project_family_notes, args=[EMPTY_PROJECT_GUID])
-        self._check_empty_project(empty_url, response_keys, 'familyNotesLoaded')
+        self._check_empty_project(empty_url, response_keys)
 
     def test_project_mme_submisssions(self):
         url = reverse(project_mme_submisssions, args=[PROJECT_GUID])
@@ -468,9 +460,8 @@ class ProjectAPITest(object):
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
-        response_keys = {'projectsByGuid', 'mmeSubmissionsByGuid', 'familyNotesByGuid'}
+        response_keys = {'mmeSubmissionsByGuid', 'familyNotesByGuid'}
         self.assertSetEqual(set(response_json.keys()), response_keys)
-        self.assertDictEqual(response_json['projectsByGuid'], {PROJECT_GUID: {'mmeSubmissionsLoaded': True}})
         self.assertSetEqual(set(response_json['mmeSubmissionsByGuid'].keys()), {'MS000001_na19675'})
         submission_fields = {'geneIds'}
         submission_fields.update(MATCHMAKER_SUBMISSION_FIELDS)
@@ -480,7 +471,7 @@ class ProjectAPITest(object):
 
         # Test empty project
         empty_url = reverse(project_mme_submisssions, args=[EMPTY_PROJECT_GUID])
-        self._check_empty_project(empty_url, response_keys, 'mmeSubmissionsLoaded')
+        self._check_empty_project(empty_url, response_keys)
 
 
 BASE_COLLABORATORS = [

--- a/ui/pages/Project/components/AnalysisGroups.jsx
+++ b/ui/pages/Project/components/AnalysisGroups.jsx
@@ -9,14 +9,14 @@ import DataLoader from 'shared/components/DataLoader'
 import { HelpIcon } from 'shared/components/StyledComponents'
 import { compareObjects } from 'shared/utils/sortUtils'
 import { loadCurrentProjectAnalysisGroups } from '../reducers'
-import { getProjectAnalysisGroupsByGuid, getCurrentProject } from '../selectors'
+import { getProjectAnalysisGroupsByGuid, getProjectGuid } from '../selectors'
 import { UpdateAnalysisGroupButton, DeleteAnalysisGroupButton } from './AnalysisGroupButtons'
 
-const AnalysisGroups = React.memo(({ project, load, loading, analysisGroupsByGuid }) => (
+const AnalysisGroups = React.memo(({ projectGuid, load, loading, analysisGroupsByGuid }) => (
   <DataLoader load={load} loading={loading} content={analysisGroupsByGuid}>
     {Object.values(analysisGroupsByGuid).sort(compareObjects('name')).map(ag => (
       <div key={ag.name}>
-        <Link to={`/project/${project.projectGuid}/analysis_group/${ag.analysisGroupGuid}`}>{ag.name}</Link>
+        <Link to={`/project/${projectGuid}/analysis_group/${ag.analysisGroupGuid}`}>{ag.name}</Link>
         <Popup
           position="right center"
           trigger={<HelpIcon />}
@@ -37,14 +37,14 @@ const AnalysisGroups = React.memo(({ project, load, loading, analysisGroupsByGui
 ))
 
 AnalysisGroups.propTypes = {
-  project: PropTypes.object,
+  projectGuid: PropTypes.string,
   analysisGroupsByGuid: PropTypes.object.isRequired,
   loading: PropTypes.bool,
   load: PropTypes.func,
 }
 
 const mapStateToProps = state => ({
-  project: getCurrentProject(state),
+  projectGuid: getProjectGuid(state),
   analysisGroupsByGuid: getProjectAnalysisGroupsByGuid(state),
   loading: getAnalysisGroupIsLoading(state),
 })

--- a/ui/pages/Project/components/EditDatasetsButton.jsx
+++ b/ui/pages/Project/components/EditDatasetsButton.jsx
@@ -12,7 +12,7 @@ import AddWorkspaceDataForm from 'shared/components/panel/LoadWorkspaceDataForm'
 import { DATASET_TYPE_VARIANT_CALLS, DATASET_TYPE_SV_CALLS, DATASET_TYPE_MITO_CALLS } from 'shared/utils/constants'
 
 import { addVariantsDataset, addIGVDataset } from '../reducers'
-import { getProjectGuid } from '../selectors'
+import { getCurrentProject, getProjectGuid } from '../selectors'
 
 const UPLOADER_STYLES = { placeHolderStyle: { paddingLeft: '5%', paddingRight: '5%' } }
 
@@ -171,8 +171,13 @@ const PANES = [
 
 const IGV_ONLY_PANES = [PANES[1]]
 
-const EditDatasetsButton = React.memo(({ project, user }) => {
-  const showLoadWorkspaceData = project.workspaceName && !project.isAnalystProject && project.canEdit
+const mapAddDataStateToProps = state => ({
+  params: getCurrentProject(state),
+})
+
+const AddProjectWorkspaceDataForm = connect(mapAddDataStateToProps)(AddWorkspaceDataForm)
+
+const EditDatasetsButton = React.memo(({ showLoadWorkspaceData, user }) => {
   const showEditDatasets = user.isDataManager || user.isPm
   return (
     (showEditDatasets || showLoadWorkspaceData) ? (
@@ -183,8 +188,7 @@ const EditDatasetsButton = React.memo(({ project, user }) => {
         trigger={<ButtonLink>{showEditDatasets ? 'Edit Datasets' : 'Load Additional Data'}</ButtonLink>}
       >
         {showEditDatasets ? <Tab panes={user.isDataManager ? PANES : IGV_ONLY_PANES} /> : (
-          <AddWorkspaceDataForm
-            params={project}
+          <AddProjectWorkspaceDataForm
             successMessage="Your request to load data has been submitted. Loading data from AnVIL to seqr is a slow process, and generally takes a week. You will receive an email letting you know once your new data is available."
           />
         )}
@@ -194,7 +198,7 @@ const EditDatasetsButton = React.memo(({ project, user }) => {
 })
 
 EditDatasetsButton.propTypes = {
-  project: PropTypes.object.isRequired,
+  showLoadWorkspaceData: PropTypes.bool,
   user: PropTypes.object,
 }
 

--- a/ui/pages/Project/components/FamilyPage.jsx
+++ b/ui/pages/Project/components/FamilyPage.jsx
@@ -63,7 +63,7 @@ const BaseVariantDetail = (
     <VariantTagTypeBar
       height={15}
       width="calc(100% - 2.5em)"
-      project={project}
+      projectGuid={project.projectGuid}
       familyGuid={family.familyGuid}
       tagTypeCounts={tagTypeCounts}
       sectionLinks={false}

--- a/ui/pages/Project/components/FamilyPage.jsx
+++ b/ui/pages/Project/components/FamilyPage.jsx
@@ -66,6 +66,7 @@ const BaseVariantDetail = (
       projectGuid={project.projectGuid}
       familyGuid={family.familyGuid}
       tagTypeCounts={tagTypeCounts}
+      tagTypes={project.variantTagTypes}
       sectionLinks={false}
     />
     <HorizontalSpacer width={10} />

--- a/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
+++ b/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { Table, Icon, Popup, Visibility } from 'semantic-ui-react'
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router'
 
 import DataLoader from 'shared/components/DataLoader'
 import { ExportTableButtonContent, DownloadButton } from 'shared/components/buttons/ExportTableButton'
@@ -161,7 +160,7 @@ const FamilyTable = React.memo(({
         fields={noDetailFields}
         tableName={tableName}
         showVariantDetails={showVariantDetails}
-        analysisGroupGuid={props.match.params.analysisGroupGuid}
+        analysisGroupGuid={props.analysisGroupGuid}
       />
     </Table>
     <Table striped compact attached="bottom">
@@ -198,7 +197,7 @@ FamilyTable.propTypes = {
   showVariantDetails: PropTypes.bool,
   noDetailFields: PropTypes.arrayOf(PropTypes.object),
   tableName: PropTypes.string,
-  match: PropTypes.object,
+  analysisGroupGuid: PropTypes.string,
 }
 
 const mapStateToProps = (state, ownProps) => ({
@@ -212,4 +211,4 @@ const mapDispatchToProps = {
   loadExportData: loadProjectExportData,
 }
 
-export default withRouter(connect(mapStateToProps, mapDispatchToProps)(FamilyTable))
+export default connect(mapStateToProps, mapDispatchToProps)(FamilyTable)

--- a/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
+++ b/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
@@ -102,8 +102,32 @@ class FamilyTableRow extends React.PureComponent {
 
 }
 
+const BaseFamilyTableRows = ({ visibleFamilies, ...props }) => (
+  visibleFamilies.length > 0 ? visibleFamilies.map(family => (
+    <FamilyTableRow
+      key={family.familyGuid}
+      familyGuid={family.familyGuid}
+      {...props}
+    />
+  )) : (
+    <Table.Row>
+      <EmptyCell content="0 families found" />
+    </Table.Row>
+  )
+)
+
+const mapFamilyRowsStateToProps = (state, ownProps) => ({
+  visibleFamilies: getVisibleFamiliesInSortedOrder(state, ownProps),
+})
+
+BaseFamilyTableRows.propTypes = {
+  visibleFamilies: PropTypes.arrayOf(PropTypes.object).isRequired,
+}
+
+const FamilyTableRows = connect(mapFamilyRowsStateToProps)(BaseFamilyTableRows)
+
 const FamilyTable = React.memo(({
-  visibleFamilies, load, loading, headerStatus, exportUrls, noDetailFields, tableName, showVariantDetails,
+  load, loading, headerStatus, exportUrls, noDetailFields, tableName, showVariantDetails,
   loadExportData, exportDataLoading, ...props
 }) => (
   <DataLoader load={load} loading={false} content>
@@ -143,20 +167,14 @@ const FamilyTable = React.memo(({
     <Table striped compact attached="bottom">
       <Table.Body>
         {loading && <TableLoading />}
-        {!loading && (visibleFamilies.length > 0 ? visibleFamilies.map(family => (
-          <FamilyTableRow
-            key={family.familyGuid}
-            familyGuid={family.familyGuid}
+        {!loading && (
+          <FamilyTableRows
             noDetailFields={noDetailFields}
             showVariantDetails={showVariantDetails}
             tableName={tableName}
             {...props}
           />
-        )) : (
-          <Table.Row>
-            <EmptyCell content="0 families found" />
-          </Table.Row>
-        ))}
+        )}
       </Table.Body>
       <Table.Footer>
         <Table.Row>
@@ -171,7 +189,6 @@ const FamilyTable = React.memo(({
 export { FamilyTable as FamilyTableComponent }
 
 FamilyTable.propTypes = {
-  visibleFamilies: PropTypes.arrayOf(PropTypes.object).isRequired,
   loading: PropTypes.bool,
   load: PropTypes.func,
   exportDataLoading: PropTypes.bool,
@@ -185,7 +202,6 @@ FamilyTable.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  visibleFamilies: getVisibleFamiliesInSortedOrder(state, ownProps),
   loading: getFamiliesLoading(state) || getProjectOverviewIsLoading(state),
   exportDataLoading: getFamiliesLoading(state) || getIndivdualsLoading(state),
   exportUrls: getProjectExportUrls(state, ownProps),

--- a/ui/pages/Project/components/GeneLists.jsx
+++ b/ui/pages/Project/components/GeneLists.jsx
@@ -15,7 +15,7 @@ import { validators } from 'shared/components/form/FormHelpers'
 import Modal from 'shared/components/modal/Modal'
 import { HelpIcon, ButtonLink } from 'shared/components/StyledComponents'
 import { loadProjectLocusLists, updateLocusLists } from '../reducers'
-import { getProjectLocusListsIsLoading } from '../selectors'
+import { getCurrentProject, getProjectLocusListsIsLoading } from '../selectors'
 
 const ItemContainer = styled.div`
   padding: 2px 0px;
@@ -28,11 +28,11 @@ const ItemContainer = styled.div`
   }
 `
 
-const LocusListItem = React.memo(({ project, locusList, onSubmit }) => (
+const LocusListItem = React.memo(({ projectGuid, canEdit, locusList, onSubmit }) => (
   <ItemContainer key={locusList.locusListGuid}>
     <Modal
       title={`${locusList.name} Gene List`}
-      modalName={`${project.projectGuid}-${locusList.name}-genes`}
+      modalName={`${projectGuid}-${locusList.name}-genes`}
       trigger={<ButtonLink>{locusList.name}</ButtonLink>}
       size="large"
     >
@@ -50,7 +50,7 @@ const LocusListItem = React.memo(({ project, locusList, onSubmit }) => (
       }
       size="small"
     />
-    {project.canEdit && (
+    {canEdit && (
       <DeleteButton
         onSubmit={onSubmit}
         size="tiny"
@@ -67,8 +67,9 @@ const LocusListItem = React.memo(({ project, locusList, onSubmit }) => (
 ))
 
 LocusListItem.propTypes = {
-  project: PropTypes.object.isRequired,
+  projectGuid: PropTypes.string.isRequired,
   locusList: PropTypes.object.isRequired,
+  canEdit: PropTypes.bool,
   onSubmit: PropTypes.func.isRequired,
 }
 
@@ -85,7 +86,9 @@ const LocusList = connect(mapStateToProps, mapItemDispatchToProps)(LocusListItem
 class BaseGeneLists extends React.PureComponent {
 
   static propTypes = {
-    project: PropTypes.object.isRequired,
+    projectGuid: PropTypes.string.isRequired,
+    canEdit: PropTypes.bool,
+    locusListGuids: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
     load: PropTypes.func,
   }
@@ -102,20 +105,19 @@ class BaseGeneLists extends React.PureComponent {
   }
 
   render() {
-    const { project, loading } = this.props
+    const { projectGuid, canEdit, locusListGuids = [], loading } = this.props
     const { showAll } = this.state
 
     if (loading) {
       return <Dimmer inverted active><Loader content="Loading" /></Dimmer>
     }
 
-    const locusListGuids = project.locusListGuids || []
     const locusListsToShow = showAll ? locusListGuids : locusListGuids.slice(0, 20)
 
     return [
-      ...locusListsToShow.map(
-        locusListGuid => <LocusList key={locusListGuid} project={project} locusListGuid={locusListGuid} />,
-      ),
+      ...locusListsToShow.map(locusListGuid => (
+        <LocusList key={locusListGuid} projectGuid={projectGuid} canEdit={canEdit} locusListGuid={locusListGuid} />
+      )),
       locusListsToShow.length < locusListGuids.length ?
         <ButtonLink key="show" padding="15px 0 0 0" color="grey" onClick={this.show}>Show More...</ButtonLink> :
         null,
@@ -124,9 +126,10 @@ class BaseGeneLists extends React.PureComponent {
 
 }
 
-const mapGeneListsStateToProps = state => ({
-  loading: getProjectLocusListsIsLoading(state),
-})
+const mapGeneListsStateToProps = (state) => {
+  const { projectGuid, canEdit, locusListGuids } = getCurrentProject(state)
+  return { projectGuid, canEdit, locusListGuids, loading: getProjectLocusListsIsLoading(state) }
+}
 
 const mapGeneListsDispatchToProps = {
   load: loadProjectLocusLists,
@@ -144,28 +147,28 @@ const LOCUS_LIST_FIELDS = [{
   format: value => (value || []).reduce((acc, locusListGuid) => ({ ...acc, [locusListGuid]: true }), {}),
 }]
 
-const LocustListsContainer = ({ project, children }) => (
+const LocustListsContainer = ({ projectName, children }) => (
   <LocusListsLoader>
-    {`Add an existing Gene List to ${project.name} or `}
+    {`Add an existing Gene List to ${projectName} or `}
     <CreateLocusListButton />
     {children}
   </LocusListsLoader>
 )
 
 LocustListsContainer.propTypes = {
-  project: PropTypes.object,
+  projectName: PropTypes.string,
   children: PropTypes.node,
 }
 
-const AddGeneLists = React.memo(({ project, onSubmit }) => (
+const AddGeneLists = React.memo(({ projectGuid, name, onSubmit }) => (
   <UpdateButton
     modalTitle="Add Gene Lists"
-    modalId={`add-gene-list-${project.projectGuid}`}
-    formMetaId={project.projectGuid}
+    modalId={`add-gene-list-${projectGuid}`}
+    formMetaId={projectGuid}
     modalSize="large"
     buttonText="Add Gene List"
     editIconName="plus"
-    formContainer={<LocustListsContainer project={project} />}
+    formContainer={<LocustListsContainer projectName={name} />}
     onSubmit={onSubmit}
     formFields={LOCUS_LIST_FIELDS}
     showErrorPanel
@@ -173,10 +176,16 @@ const AddGeneLists = React.memo(({ project, onSubmit }) => (
 ))
 
 AddGeneLists.propTypes = {
-  project: PropTypes.object,
+  projectGuid: PropTypes.string,
+  name: PropTypes.string,
   onSubmit: PropTypes.func,
+}
+
+const mapButtonStateToProps = (state) => {
+  const { projectGuid, name } = getCurrentProject(state)
+  return { projectGuid, name }
 }
 
 const mapDispatchToProps = { onSubmit: updateLocusLists }
 
-export const AddGeneListsButton = connect(null, mapDispatchToProps)(AddGeneLists)
+export const AddGeneListsButton = connect(mapButtonStateToProps, mapDispatchToProps)(AddGeneLists)

--- a/ui/pages/Project/components/GeneLists.jsx
+++ b/ui/pages/Project/components/GeneLists.jsx
@@ -160,7 +160,7 @@ LocustListsContainer.propTypes = {
   children: PropTypes.node,
 }
 
-const AddGeneLists = React.memo(({ projectGuid, name, onSubmit }) => (
+const AddGeneLists = React.memo(({ projectGuid, projectName, onSubmit }) => (
   <UpdateButton
     modalTitle="Add Gene Lists"
     modalId={`add-gene-list-${projectGuid}`}
@@ -168,7 +168,7 @@ const AddGeneLists = React.memo(({ projectGuid, name, onSubmit }) => (
     modalSize="large"
     buttonText="Add Gene List"
     editIconName="plus"
-    formContainer={<LocustListsContainer projectName={name} />}
+    formContainer={<LocustListsContainer projectName={projectName} />}
     onSubmit={onSubmit}
     formFields={LOCUS_LIST_FIELDS}
     showErrorPanel
@@ -177,13 +177,13 @@ const AddGeneLists = React.memo(({ projectGuid, name, onSubmit }) => (
 
 AddGeneLists.propTypes = {
   projectGuid: PropTypes.string,
-  name: PropTypes.string,
+  projectName: PropTypes.string,
   onSubmit: PropTypes.func,
 }
 
 const mapButtonStateToProps = (state) => {
   const { projectGuid, name } = getCurrentProject(state)
-  return { projectGuid, name }
+  return { projectGuid, projectName: name }
 }
 
 const mapDispatchToProps = { onSubmit: updateLocusLists }

--- a/ui/pages/Project/components/ProjectCollaborators.jsx
+++ b/ui/pages/Project/components/ProjectCollaborators.jsx
@@ -162,39 +162,40 @@ const collaboratorDisplay = ({ displayName, email }) => (
 
 const groupNameDisplay = ({ name }) => name
 
-const ProjectCollaborators = React.memo((
-  { project, user, loading, load, onSubmit, onGroupSubmit, addCollaborator },
-) => {
-  const canEdit = project.canEdit && !user.isAnvil
+const ProjectCollaborators = React.memo(({
+  canEdit, workspaceName, collaborators, collaboratorGroups, user, loading, load, onSubmit, onGroupSubmit,
+  addCollaborator,
+}) => {
+  const canEditCollaboratots = canEdit && !user.isAnvil
   return (
-    <DataLoader load={load} loading={loading} content={project.collaborators}>
+    <DataLoader load={load} loading={loading} content={collaborators}>
       <ProjectAccessSection
         title="Collaborator"
         idField="email"
         displayField="displayName"
         deleteMessage=" They will still have their user account and be able to log in, but will not be able to access this project anymore."
-        entities={project.collaborators}
-        canEdit={canEdit}
+        entities={collaborators}
+        canEdit={canEditCollaboratots}
         onSubmit={onSubmit}
         onAdd={addCollaborator}
         addEntityFields={CREATE_FIELDS}
         rowDisplay={collaboratorDisplay}
       />
-      {project.collaboratorGroups?.length > 0 && <Header subheader="Groups" size="small" />}
+      {collaboratorGroups?.length > 0 && <Header subheader="Groups" size="small" />}
       <ProjectAccessSection
         title="Collaborator Group"
         idField="name"
-        entities={project.collaboratorGroups}
-        canEdit={canEdit}
+        entities={collaboratorGroups}
+        canEdit={canEditCollaboratots}
         onSubmit={onGroupSubmit}
         onAdd={onGroupSubmit}
         addEntityFields={CREATE_GROUP_FIELDS}
         rowDisplay={groupNameDisplay}
       />
-      {user.isAnvil && project.workspaceName && (
+      {user.isAnvil && workspaceName && (
         <Segment basic size="small" textAlign="right">
           <i>Collaborators fetched from AnVIL</i>
-          {project.canEdit && (
+          {canEdit && (
             <Popup
               trigger={<HelpIcon color="black" />}
               content={`Project collaborators are managed in AnVIL. Users with access to the associated workspace have
@@ -209,8 +210,11 @@ const ProjectCollaborators = React.memo((
 })
 
 ProjectCollaborators.propTypes = {
-  project: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
+  canEdit: PropTypes.bool,
+  workspaceName: PropTypes.string,
+  collaborators: PropTypes.arrayOf(PropTypes.object),
+  collaboratorGroups: PropTypes.arrayOf(PropTypes.object),
   loading: PropTypes.bool,
   load: PropTypes.func,
   onSubmit: PropTypes.func,
@@ -218,11 +222,17 @@ ProjectCollaborators.propTypes = {
   addCollaborator: PropTypes.func,
 }
 
-const mapStateToProps = state => ({
-  project: getCurrentProject(state),
-  user: getUser(state),
-  loading: getProjectCollaboratorsIsLoading(state),
-})
+const mapStateToProps = (state) => {
+  const { canEdit, workspaceName, collaborators, collaboratorGroups } = getCurrentProject(state)
+  return {
+    canEdit,
+    workspaceName,
+    collaborators,
+    collaboratorGroups,
+    user: getUser(state),
+    loading: getProjectCollaboratorsIsLoading(state),
+  }
+}
 
 const mapDispatchToProps = {
   load: loadProjectCollaborators,

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -421,7 +421,7 @@ const ProjectOverview = React.memo(({
       <DetailSection title="Genome Version" content={GENOME_VERSION_LOOKUP[genomeVersion]} />
       <LoadingSection loading={overviewLoading}>
         <DatasetOverview
-          showLoadWorkspaceData={workspaceName && !isAnalystProject && canEdit}
+          showLoadWorkspaceData={!!workspaceName && !isAnalystProject && canEdit}
           hasAnvil={!!workspaceName}
           analysisGroupGuid={analysisGroupGuid}
         />

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -315,20 +315,25 @@ const mapDatasetStateToProps = (state, ownProps) => ({
 
 const DatasetOverview = connect(mapDatasetStateToProps)(Dataset)
 
-const Anvil = React.memo(({ project, user, onSubmit }) => (
-  (project.workspaceName || user.isPm) && user.isAnvil && (
+const mapAnvilButtonStateToProps = state => ({
+  initialValues: getCurrentProject(state),
+})
+
+const UpdateAnvilButton = connect(mapAnvilButtonStateToProps)(UpdateButton)
+
+const Anvil = React.memo(({ workspaceName, workspaceNamespace, user, onSubmit }) => (
+  (workspaceName || user.isPm) && user.isAnvil && (
     <DetailSection
       title="AnVIL Workspace"
-      content={project.workspaceName ? (
-        <a href={`${ANVIL_URL}/#workspaces/${project.workspaceNamespace}/${project.workspaceName}`} target="_blank" rel="noreferrer">
-          {project.workspaceName}
+      content={workspaceName ? (
+        <a href={`${ANVIL_URL}/#workspaces/${workspaceNamespace}/${workspaceName}`} target="_blank" rel="noreferrer">
+          {workspaceName}
         </a>
       ) : 'None'}
       button={user.isPm && (
-        <UpdateButton
+        <UpdateAnvilButton
           onSubmit={onSubmit}
           formFields={ANVIL_FIELDS}
-          initialValues={project}
           modalTitle="Edit AnVIL Workspace"
           modalId="editAnvilWorkspace"
           buttonText="Edit Workspace"
@@ -339,8 +344,9 @@ const Anvil = React.memo(({ project, user, onSubmit }) => (
 ))
 
 Anvil.propTypes = {
-  project: PropTypes.object.isRequired,
   user: PropTypes.object.isRequired,
+  workspaceName: PropTypes.string,
+  workspaceNamespace: PropTypes.string,
   onSubmit: PropTypes.func,
 }
 
@@ -380,40 +386,43 @@ LoadingSection.propTypes = {
   children: PropTypes.node,
 }
 
-const ProjectOverview = React.memo(({ familiesLoading, overviewLoading, project, analysisGroupGuid }) => (
+const ProjectOverview = React.memo(({
+  familiesLoading, overviewLoading, analysisGroupGuid, name, genomeVersion, workspaceName, workspaceNamespace,
+  canEdit, hasCaseReview, isAnalystProject, mmeSubmissionCount, mmeDeletedSubmissionCount,
+}) => (
   <Grid>
     <Grid.Column width={5}>
       <LoadingSection loading={familiesLoading}>
         <FamiliesIndividualsOverview
-          canEdit={project.canEdit}
-          hasCaseReview={project.hasCaseReview}
+          canEdit={canEdit}
+          hasCaseReview={hasCaseReview}
           analysisGroupGuid={analysisGroupGuid}
         />
       </LoadingSection>
       <VerticalSpacer height={10} />
       <LoadingSection loading={familiesLoading || overviewLoading}>
         <DataLoadedFamiliesIndividualsOverview
-          canEdit={project.canEdit}
-          hasCaseReview={project.hasCaseReview}
+          canEdit={canEdit}
+          hasCaseReview={hasCaseReview}
           analysisGroupGuid={analysisGroupGuid}
         />
       </LoadingSection>
       <VerticalSpacer height={10} />
       <LoadingSection loading={overviewLoading}>
         <MatchmakerOverview
-          name={project.name}
-          mmeSubmissionCount={project.mmeSubmissionCount}
-          mmeDeletedSubmissionCount={project.mmeDeletedSubmissionCount}
-          canEdit={project.canEdit}
+          name={name}
+          mmeSubmissionCount={mmeSubmissionCount}
+          mmeDeletedSubmissionCount={mmeDeletedSubmissionCount}
+          canEdit={canEdit}
         />
       </LoadingSection>
     </Grid.Column>
     <Grid.Column width={5}>
-      <DetailSection title="Genome Version" content={GENOME_VERSION_LOOKUP[project.genomeVersion]} />
+      <DetailSection title="Genome Version" content={GENOME_VERSION_LOOKUP[genomeVersion]} />
       <LoadingSection loading={overviewLoading}>
         <DatasetOverview
-          showLoadWorkspaceData={project.workspaceName && !project.isAnalystProject && project.canEdit}
-          hasAnvil={!!project.workspaceName}
+          showLoadWorkspaceData={workspaceName && !isAnalystProject && canEdit}
+          hasAnvil={!!workspaceName}
           analysisGroupGuid={analysisGroupGuid}
         />
       </LoadingSection>
@@ -423,20 +432,49 @@ const ProjectOverview = React.memo(({ familiesLoading, overviewLoading, project,
         <AnalysisStatusOverview analysisGroupGuid={analysisGroupGuid} />
       </LoadingSection>
       <VerticalSpacer height={10} />
-      <AnvilOverview project={project} />
+      <AnvilOverview workspaceName={workspaceName} workspaceNamespace={workspaceNamespace} />
     </Grid.Column>
   </Grid>
 ))
 
 ProjectOverview.propTypes = {
-  project: PropTypes.object.isRequired,
+  name: PropTypes.string,
+  genomeVersion: PropTypes.string,
+  workspaceName: PropTypes.string,
+  workspaceNamespace: PropTypes.string,
+  canEdit: PropTypes.bool,
+  hasCaseReview: PropTypes.bool,
+  isAnalystProject: PropTypes.bool,
+  mmeSubmissionCount: PropTypes.number,
+  mmeDeletedSubmissionCount: PropTypes.number,
   analysisGroupGuid: PropTypes.string,
   familiesLoading: PropTypes.bool,
   overviewLoading: PropTypes.bool,
 }
 
-const mapStateToProps = state => ({
-  project: getCurrentProject(state),
-})
+const mapStateToProps = (state) => {
+  const {
+    name,
+    genomeVersion,
+    workspaceName,
+    workspaceNamespace,
+    canEdit,
+    hasCaseReview,
+    isAnalystProject,
+    mmeSubmissionCount,
+    mmeDeletedSubmissionCount,
+  } = getCurrentProject(state)
+  return {
+    name,
+    genomeVersion,
+    workspaceName,
+    workspaceNamespace,
+    canEdit,
+    hasCaseReview,
+    isAnalystProject,
+    mmeSubmissionCount,
+    mmeDeletedSubmissionCount,
+  }
+}
 
 export default connect(mapStateToProps)(ProjectOverview)

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -24,6 +24,7 @@ import {
 } from 'shared/utils/constants'
 import { updateProjectMmeContact, loadMmeSubmissions, updateAnvilWorkspace } from '../reducers'
 import {
+  getCurrentProject,
   getAnalysisStatusCounts,
   getProjectAnalysisGroupFamilyIndividualCounts,
   getProjectAnalysisGroupDataLoadedFamilyIndividualCounts,
@@ -434,4 +435,8 @@ ProjectOverview.propTypes = {
   overviewLoading: PropTypes.bool,
 }
 
-export default ProjectOverview
+const mapStateToProps = state => ({
+  project: getCurrentProject(state),
+})
+
+export default connect(mapStateToProps)(ProjectOverview)

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -191,7 +191,7 @@ const FamiliesIndividualsOverview = connect(mapFamiliesStateToProps)(FamiliesInd
 
 const DataLoadedFamiliesIndividualsOverview = connect(mapDataLoadedFamiliesStateToProps)(FamiliesIndividuals)
 
-const MatchmakerOverview = React.memo(({ name, mmeSubmissionCount, mmeDeletedSubmissionCount, canEdit }) => (
+const MatchmakerOverview = React.memo(({ projectName, mmeSubmissionCount, mmeDeletedSubmissionCount, canEdit }) => (
   <DetailSection
     title="Matchmaker Submissions"
     content={mmeSubmissionCount ? (
@@ -199,7 +199,7 @@ const MatchmakerOverview = React.memo(({ name, mmeSubmissionCount, mmeDeletedSub
         {`${mmeSubmissionCount} submissions `}
         <Modal
           trigger={<ButtonLink icon="external" size="tiny" />}
-          title={`Matchmaker Submissions for ${name}`}
+          title={`Matchmaker Submissions for ${projectName}`}
           modalName="mmeSubmissions"
           size="large"
         >
@@ -212,7 +212,7 @@ const MatchmakerOverview = React.memo(({ name, mmeSubmissionCount, mmeDeletedSub
 ))
 
 MatchmakerOverview.propTypes = {
-  name: PropTypes.string.isRequired,
+  projectName: PropTypes.string.isRequired,
   canEdit: PropTypes.bool,
   mmeSubmissionCount: PropTypes.number,
   mmeDeletedSubmissionCount: PropTypes.number,
@@ -387,7 +387,7 @@ LoadingSection.propTypes = {
 }
 
 const ProjectOverview = React.memo(({
-  familiesLoading, overviewLoading, analysisGroupGuid, name, genomeVersion, workspaceName, workspaceNamespace,
+  familiesLoading, overviewLoading, analysisGroupGuid, projectName, genomeVersion, workspaceName, workspaceNamespace,
   canEdit, hasCaseReview, isAnalystProject, mmeSubmissionCount, mmeDeletedSubmissionCount,
 }) => (
   <Grid>
@@ -410,7 +410,7 @@ const ProjectOverview = React.memo(({
       <VerticalSpacer height={10} />
       <LoadingSection loading={overviewLoading}>
         <MatchmakerOverview
-          name={name}
+          projectName={projectName}
           mmeSubmissionCount={mmeSubmissionCount}
           mmeDeletedSubmissionCount={mmeDeletedSubmissionCount}
           canEdit={canEdit}
@@ -438,7 +438,7 @@ const ProjectOverview = React.memo(({
 ))
 
 ProjectOverview.propTypes = {
-  name: PropTypes.string,
+  projectName: PropTypes.string,
   genomeVersion: PropTypes.string,
   workspaceName: PropTypes.string,
   workspaceNamespace: PropTypes.string,
@@ -465,7 +465,7 @@ const mapStateToProps = (state) => {
     mmeDeletedSubmissionCount,
   } = getCurrentProject(state)
   return {
-    name,
+    projectName: name,
     genomeVersion,
     workspaceName,
     workspaceNamespace,

--- a/ui/pages/Project/components/ProjectPageUI.jsx
+++ b/ui/pages/Project/components/ProjectPageUI.jsx
@@ -72,12 +72,12 @@ const NO_DETAIL_FIELDS = [
   { id: FAMILY_FIELD_DESCRIPTION, colWidth: 6 },
 ]
 
-const ProjectPageUI = React.memo(({ match, load, loading, familiesLoading }) => (
+const ProjectPageUI = React.memo(({ analysisGroupGuid, load, loading, familiesLoading }) => (
   <Grid stackable>
     <DataLoader load={load} loading={false} content>
       <Grid.Row>
         <Grid.Column width={4}>
-          {match.params.analysisGroupGuid ? null : (
+          {analysisGroupGuid ? null : (
             <ProjectSection label="Analysis Groups" editButton={<UpdateAnalysisGroupButton />}>
               <AnalysisGroups />
             </ProjectSection>
@@ -90,14 +90,14 @@ const ProjectPageUI = React.memo(({ match, load, loading, familiesLoading }) => 
         <Grid.Column width={8}>
           <ProjectSection label="Overview">
             <ProjectOverview
-              analysisGroupGuid={match.params.analysisGroupGuid}
+              analysisGroupGuid={analysisGroupGuid}
               familiesLoading={familiesLoading}
               overviewLoading={loading}
             />
           </ProjectSection>
           <VerticalSpacer height={10} />
           <ProjectSection label="Variant Tags" linkPath="saved_variants" linkText="View All" loading={loading}>
-            <VariantTags analysisGroupGuid={match.params.analysisGroupGuid} />
+            <VariantTags analysisGroupGuid={analysisGroupGuid} />
           </ProjectSection>
         </Grid.Column>
         <Grid.Column width={4}>
@@ -121,7 +121,7 @@ const ProjectPageUI = React.memo(({ match, load, loading, familiesLoading }) => 
 ))
 
 ProjectPageUI.propTypes = {
-  match: PropTypes.object,
+  analysisGroupGuid: PropTypes.string,
   load: PropTypes.func,
   loading: PropTypes.bool,
   familiesLoading: PropTypes.bool,
@@ -138,4 +138,6 @@ const mapDispatchToProps = {
 
 export { ProjectPageUI as ProjectPageUIComponent }
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectPageUI)
+export default connect(mapStateToProps, mapDispatchToProps)(
+  ({ match, ...props }) => <ProjectPageUI analysisGroupGuid={match.params.analysisGroupGuid} {...props} />,
+)

--- a/ui/pages/Project/components/ProjectPageUI.jsx
+++ b/ui/pages/Project/components/ProjectPageUI.jsx
@@ -15,14 +15,7 @@ import {
   FAMILY_FIELD_FIRST_SAMPLE,
   FAMILY_DETAIL_FIELDS,
 } from 'shared/utils/constants'
-import {
-  getCurrentProject,
-  getAnalysisStatusCounts,
-  getProjectOverviewIsLoading,
-  getFamiliesLoading,
-  getTagTypeCounts,
-  getAnalysisGroupTagTypeCounts,
-} from '../selectors'
+import { getCurrentProject, getProjectOverviewIsLoading, getFamiliesLoading } from '../selectors'
 import { loadProjectOverview } from '../reducers'
 import ProjectOverview from './ProjectOverview'
 import AnalysisGroups from './AnalysisGroups'
@@ -31,7 +24,6 @@ import ProjectCollaborators from './ProjectCollaborators'
 import { GeneLists, AddGeneListsButton } from './GeneLists'
 import FamilyTable from './FamilyTable/FamilyTable'
 import VariantTags from './VariantTags'
-import VariantTagTypeBar from './VariantTagTypeBar'
 
 const ProjectSectionComponent = React.memo((
   { loading, label, children, editButton, linkPath, linkText, project, collaboratorEdit },
@@ -80,44 +72,35 @@ const NO_DETAIL_FIELDS = [
   { id: FAMILY_FIELD_DESCRIPTION, colWidth: 6 },
 ]
 
-const ProjectPageUI = React.memo(props => (
+const ProjectPageUI = React.memo(({ match, load, project, loading, familiesLoading }) => (
   <Grid stackable>
-    <DataLoader load={props.load} loading={false} content>
+    <DataLoader load={load} loading={false} content>
       <Grid.Row>
         <Grid.Column width={4}>
-          {props.match.params.analysisGroupGuid ? null : (
+          {match.params.analysisGroupGuid ? null : (
             <ProjectSection label="Analysis Groups" editButton={<UpdateAnalysisGroupButton />}>
               <AnalysisGroups />
             </ProjectSection>
           )}
           <VerticalSpacer height={10} />
-          <ProjectSection label="Gene Lists" editButton={<AddGeneListsButton project={props.project} />} collaboratorEdit>
-            <GeneLists project={props.project} />
+          <ProjectSection label="Gene Lists" editButton={<AddGeneListsButton project={project} />} collaboratorEdit>
+            <GeneLists project={project} />
           </ProjectSection>
         </Grid.Column>
         <Grid.Column width={8}>
           <ProjectSection label="Overview">
             <ProjectOverview
-              project={props.project}
-              analysisGroupGuid={props.match.params.analysisGroupGuid}
-              familiesLoading={props.familiesLoading}
-              overviewLoading={props.loading}
+              project={project}
+              analysisGroupGuid={match.params.analysisGroupGuid}
+              familiesLoading={familiesLoading}
+              overviewLoading={loading}
             />
           </ProjectSection>
           <VerticalSpacer height={10} />
-          <ProjectSection label="Variant Tags" linkPath="saved_variants" linkText="View All" loading={props.loading}>
-            <VariantTagTypeBar
-              project={props.project}
-              analysisGroupGuid={props.match.params.analysisGroupGuid}
-              tagTypeCounts={props.tagTypeCounts}
-              height={20}
-              showAllPopupCategories
-            />
-            <VerticalSpacer height={10} />
+          <ProjectSection label="Variant Tags" linkPath="saved_variants" linkText="View All" loading={loading}>
             <VariantTags
-              project={props.project}
-              analysisGroupGuid={props.match.params.analysisGroupGuid}
-              tagTypeCounts={props.tagTypeCounts}
+              project={project}
+              analysisGroupGuid={match.params.analysisGroupGuid}
             />
           </ProjectSection>
         </Grid.Column>
@@ -147,16 +130,12 @@ ProjectPageUI.propTypes = {
   load: PropTypes.func,
   loading: PropTypes.bool,
   familiesLoading: PropTypes.bool,
-  tagTypeCounts: PropTypes.object,
 }
 
-const mapStateToProps = (state, ownProps) => ({
+const mapStateToProps = state => ({
   project: getCurrentProject(state),
-  analysisStatusCounts: getAnalysisStatusCounts(state, ownProps),
   loading: getProjectOverviewIsLoading(state),
   familiesLoading: getFamiliesLoading(state),
-  tagTypeCounts: ownProps.match.params.analysisGroupGuid ?
-    getAnalysisGroupTagTypeCounts(state, ownProps) : getTagTypeCounts(state),
 })
 
 const mapDispatchToProps = {

--- a/ui/pages/Project/components/ProjectPageUI.jsx
+++ b/ui/pages/Project/components/ProjectPageUI.jsx
@@ -72,7 +72,7 @@ const NO_DETAIL_FIELDS = [
   { id: FAMILY_FIELD_DESCRIPTION, colWidth: 6 },
 ]
 
-const ProjectPageUI = React.memo(({ match, load, project, loading, familiesLoading }) => (
+const ProjectPageUI = React.memo(({ match, load, loading, familiesLoading }) => (
   <Grid stackable>
     <DataLoader load={load} loading={false} content>
       <Grid.Row>
@@ -83,14 +83,13 @@ const ProjectPageUI = React.memo(({ match, load, project, loading, familiesLoadi
             </ProjectSection>
           )}
           <VerticalSpacer height={10} />
-          <ProjectSection label="Gene Lists" editButton={<AddGeneListsButton project={project} />} collaboratorEdit>
-            <GeneLists project={project} />
+          <ProjectSection label="Gene Lists" editButton={<AddGeneListsButton />} collaboratorEdit>
+            <GeneLists />
           </ProjectSection>
         </Grid.Column>
         <Grid.Column width={8}>
           <ProjectSection label="Overview">
             <ProjectOverview
-              project={project}
               analysisGroupGuid={match.params.analysisGroupGuid}
               familiesLoading={familiesLoading}
               overviewLoading={loading}
@@ -98,10 +97,7 @@ const ProjectPageUI = React.memo(({ match, load, project, loading, familiesLoadi
           </ProjectSection>
           <VerticalSpacer height={10} />
           <ProjectSection label="Variant Tags" linkPath="saved_variants" linkText="View All" loading={loading}>
-            <VariantTags
-              project={project}
-              analysisGroupGuid={match.params.analysisGroupGuid}
-            />
+            <VariantTags analysisGroupGuid={match.params.analysisGroupGuid} />
           </ProjectSection>
         </Grid.Column>
         <Grid.Column width={4}>
@@ -125,7 +121,6 @@ const ProjectPageUI = React.memo(({ match, load, project, loading, familiesLoadi
 ))
 
 ProjectPageUI.propTypes = {
-  project: PropTypes.object.isRequired,
   match: PropTypes.object,
   load: PropTypes.func,
   loading: PropTypes.bool,
@@ -133,7 +128,6 @@ ProjectPageUI.propTypes = {
 }
 
 const mapStateToProps = state => ({
-  project: getCurrentProject(state),
   loading: getProjectOverviewIsLoading(state),
   familiesLoading: getFamiliesLoading(state),
 })

--- a/ui/pages/Project/components/ProjectPageUI.jsx
+++ b/ui/pages/Project/components/ProjectPageUI.jsx
@@ -111,6 +111,7 @@ const ProjectPageUI = React.memo(({ analysisGroupGuid, load, loading, familiesLo
       <Grid.Column width={16}>
         <SectionHeader>Families</SectionHeader>
         <FamilyTable
+          analysisGroupGuid={analysisGroupGuid}
           showVariantDetails
           detailFields={FAMILY_DETAIL_FIELDS}
           noDetailFields={NO_DETAIL_FIELDS}

--- a/ui/pages/Project/components/SavedVariants.jsx
+++ b/ui/pages/Project/components/SavedVariants.jsx
@@ -139,7 +139,7 @@ class BaseProjectSavedVariants extends React.PureComponent {
     const isCategory = categoryOptions.includes(newTag)
     updateTableField('categoryFilter')(isCategory ? newTag : null)
     return getSavedVariantsLinkPath({
-      project,
+      projectGuid: project.projectGuid,
       analysisGroupGuid: match.params.analysisGroupGuid,
       tag: !isCategory && newTag !== ALL_FILTER && newTag,
       familyGuid: match.params.familyGuid,
@@ -190,7 +190,9 @@ class BaseProjectSavedVariants extends React.PureComponent {
       content: (
         <LabelLink
           to={getSavedVariantsLinkPath({
-            project, analysisGroupGuid: match.params.analysisGroupGuid, familyGuid: match.params.familyGuid,
+            projectGuid: project.projectGuid,
+            analysisGroupGuid: match.params.analysisGroupGuid,
+            familyGuid: match.params.familyGuid,
           })}
         >
           All Saved
@@ -207,7 +209,7 @@ class BaseProjectSavedVariants extends React.PureComponent {
         <Grid.Column width={16}>
           <VariantTagTypeBar
             height={30}
-            project={project}
+            projectGuid={project.projectGuid}
             analysisGroupGuid={match.params.analysisGroupGuid}
             tagTypeCounts={tagTypeCounts}
             {...summaryProps}

--- a/ui/pages/Project/components/SavedVariants.jsx
+++ b/ui/pages/Project/components/SavedVariants.jsx
@@ -212,6 +212,7 @@ class BaseProjectSavedVariants extends React.PureComponent {
             projectGuid={project.projectGuid}
             analysisGroupGuid={match.params.analysisGroupGuid}
             tagTypeCounts={tagTypeCounts}
+            tagTypes={project.variantTagTypes}
             {...summaryProps}
           />
         </Grid.Column>

--- a/ui/pages/Project/components/SavedVariants.jsx
+++ b/ui/pages/Project/components/SavedVariants.jsx
@@ -13,6 +13,8 @@ import {
   VARIANT_HIDE_REVIEW_FIELD,
   VARIANT_HIDE_KNOWN_GENE_FOR_PHENOTYPE_FIELD,
   VARIANT_PER_PAGE_FIELD,
+  EXCLUDED_TAG_NAME,
+  REVIEW_TAG_NAME,
 } from 'shared/utils/constants'
 import UpdateButton from 'shared/components/buttons/UpdateButton'
 import { LargeMultiselect, Dropdown } from 'shared/components/form/Inputs'
@@ -58,6 +60,10 @@ const FILTER_FIELDS = [
   },
 ]
 const NON_DISCOVERY_FILTER_FIELDS = FILTER_FIELDS.filter(({ name }) => name !== 'hideKnownGeneForPhenotype')
+
+const EXCLUDED_TAGS = [EXCLUDED_TAG_NAME]
+const REVIEW_TAGS = [REVIEW_TAG_NAME]
+const EXCLUDED_AND_REVIEW_TAGS = [...EXCLUDED_TAGS, ...REVIEW_TAGS]
 
 const mapVariantLinkStateToProps = (state, ownProps) => {
   const familyGuid = ownProps.meta.data.formId
@@ -202,8 +208,14 @@ class BaseProjectSavedVariants extends React.PureComponent {
     }])
   }
 
-  tableSummary = (summaryProps) => {
+  tableSummary = ({ hideExcluded, hideReviewOnly }) => {
     const { project, tagTypeCounts, match } = this.props
+    let excludeItems
+    if (hideExcluded) {
+      excludeItems = hideReviewOnly ? EXCLUDED_AND_REVIEW_TAGS : EXCLUDED_TAGS
+    } else if (hideReviewOnly) {
+      excludeItems = REVIEW_TAGS
+    }
     return (
       <Grid.Row>
         <Grid.Column width={16}>
@@ -213,7 +225,7 @@ class BaseProjectSavedVariants extends React.PureComponent {
             analysisGroupGuid={match.params.analysisGroupGuid}
             tagTypeCounts={tagTypeCounts}
             tagTypes={project.variantTagTypes}
-            {...summaryProps}
+            excludeItems={excludeItems}
           />
         </Grid.Column>
       </Grid.Row>

--- a/ui/pages/Project/components/VariantTagTypeBar.jsx
+++ b/ui/pages/Project/components/VariantTagTypeBar.jsx
@@ -1,10 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 
 import HorizontalStackedBar from 'shared/components/graph/HorizontalStackedBar'
-import { EXCLUDED_TAG_NAME, REVIEW_TAG_NAME } from 'shared/utils/constants'
-import { getProjectTagTypes } from '../selectors'
 
 export const getSavedVariantsLinkPath = ({ projectGuid, analysisGroupGuid, familyGuid, tag }) => {
   let path = tag ? `/${tag}` : ''
@@ -18,8 +15,7 @@ export const getSavedVariantsLinkPath = ({ projectGuid, analysisGroupGuid, famil
 }
 
 const VariantTagTypeBar = React.memo(({
-  tagTypes, tagTypeCounts, projectGuid, familyGuid, analysisGroupGuid, hideExcluded, hideReviewOnly,
-  sectionLinks = true, ...props
+  tagTypes, tagTypeCounts, projectGuid, familyGuid, analysisGroupGuid, sectionLinks = true, ...props
 }) => (
   <HorizontalStackedBar
     {...props}
@@ -31,15 +27,13 @@ const VariantTagTypeBar = React.memo(({
     linkPath={getSavedVariantsLinkPath({ projectGuid, analysisGroupGuid, familyGuid })}
     sectionLinks={sectionLinks}
     dataCounts={tagTypeCounts}
-    data={(hideExcluded || hideReviewOnly) ? tagTypes.filter(
-      vtt => !(hideExcluded && vtt.name === EXCLUDED_TAG_NAME) && !(hideReviewOnly && vtt.name === REVIEW_TAG_NAME),
-    ) : tagTypes}
+    data={tagTypes}
   />
 ))
 
 VariantTagTypeBar.propTypes = {
   projectGuid: PropTypes.string.isRequired,
-  tagTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  tagTypes: PropTypes.arrayOf(PropTypes.object),
   tagTypeCounts: PropTypes.object,
   familyGuid: PropTypes.string,
   analysisGroupGuid: PropTypes.string,

--- a/ui/pages/Project/components/VariantTagTypeBar.jsx
+++ b/ui/pages/Project/components/VariantTagTypeBar.jsx
@@ -48,8 +48,4 @@ VariantTagTypeBar.propTypes = {
   hideReviewOnly: PropTypes.bool,
 }
 
-const mapStateToProps = state => ({
-  tagTypes: getProjectTagTypes(state),
-})
-
-export default connect(mapStateToProps)(VariantTagTypeBar)
+export default VariantTagTypeBar

--- a/ui/pages/Project/components/VariantTagTypeBar.jsx
+++ b/ui/pages/Project/components/VariantTagTypeBar.jsx
@@ -6,7 +6,7 @@ import HorizontalStackedBar from 'shared/components/graph/HorizontalStackedBar'
 import { EXCLUDED_TAG_NAME, REVIEW_TAG_NAME } from 'shared/utils/constants'
 import { getProjectTagTypes } from '../selectors'
 
-export const getSavedVariantsLinkPath = ({ project, analysisGroupGuid, familyGuid, tag }) => {
+export const getSavedVariantsLinkPath = ({ projectGuid, analysisGroupGuid, familyGuid, tag }) => {
   let path = tag ? `/${tag}` : ''
   if (familyGuid) {
     path = `/family/${familyGuid}${path}`
@@ -14,12 +14,12 @@ export const getSavedVariantsLinkPath = ({ project, analysisGroupGuid, familyGui
     path = `/analysis_group/${analysisGroupGuid}${path}`
   }
 
-  return `/project/${project.projectGuid}/saved_variants${path}`
+  return `/project/${projectGuid}/saved_variants${path}`
 }
 
 const VariantTagTypeBar = React.memo(({
-  tagTypes, tagTypeCounts, project, familyGuid, analysisGroupGuid, sectionLinks = true, hideExcluded, hideReviewOnly,
-  ...props
+  tagTypes, tagTypeCounts, projectGuid, familyGuid, analysisGroupGuid, hideExcluded, hideReviewOnly,
+  sectionLinks = true, ...props
 }) => (
   <HorizontalStackedBar
     {...props}
@@ -28,7 +28,7 @@ const VariantTagTypeBar = React.memo(({
     showTotal={false}
     title="Saved Variants"
     noDataMessage="No Saved Variants"
-    linkPath={getSavedVariantsLinkPath({ project, analysisGroupGuid, familyGuid })}
+    linkPath={getSavedVariantsLinkPath({ projectGuid, analysisGroupGuid, familyGuid })}
     sectionLinks={sectionLinks}
     dataCounts={tagTypeCounts}
     data={(hideExcluded || hideReviewOnly) ? tagTypes.filter(
@@ -38,7 +38,7 @@ const VariantTagTypeBar = React.memo(({
 ))
 
 VariantTagTypeBar.propTypes = {
-  project: PropTypes.object.isRequired,
+  projectGuid: PropTypes.string.isRequired,
   tagTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
   tagTypeCounts: PropTypes.object,
   familyGuid: PropTypes.string,

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -17,14 +17,14 @@ const TableRow = styled(Table.Row)`
 const TableCell = styled(Table.Cell)`
   padding: 0 0 0 10px !important;`
 
-const TagSummary = ({ variantTagType, count, project, analysisGroupGuid }) => (
+const TagSummary = ({ variantTagType, count, projectGuid, analysisGroupGuid }) => (
   <TableRow>
     <TableCell collapsing>
       <ColoredIcon name="square" size="small" color={variantTagType.color} />
       <b>{count}</b>
     </TableCell>
     <TableCell>
-      <Link to={getSavedVariantsLinkPath({ project, analysisGroupGuid, tag: variantTagType.name })}>
+      <Link to={getSavedVariantsLinkPath({ projectGuid, analysisGroupGuid, tag: variantTagType.name })}>
         {variantTagType.name}
       </Link>
       {variantTagType.description && (
@@ -42,7 +42,7 @@ const TagSummary = ({ variantTagType, count, project, analysisGroupGuid }) => (
 TagSummary.propTypes = {
   variantTagType: PropTypes.object.isRequired,
   count: PropTypes.number,
-  project: PropTypes.object,
+  projectGuid: PropTypes.string,
   analysisGroupGuid: PropTypes.string,
 }
 
@@ -52,7 +52,7 @@ const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeC
   return (
     <div>
       <VariantTagTypeBar
-        project={project}
+        projectGuid={project.projectGuid}
         analysisGroupGuid={analysisGroupGuid}
         tagTypeCounts={tagTypeCounts}
         height={20}
@@ -68,14 +68,14 @@ const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeC
                   key={variantTagType.variantTagTypeGuid}
                   variantTagType={variantTagType}
                   count={tagTypeCounts[variantTagType.name]}
-                  project={project}
+                  projectGuid={project.projectGuid}
                   analysisGroupGuid={analysisGroupGuid}
                 />
               ),
             )
           }
           {noteTagType && noteTagType.numTags > 0 && (
-            <TagSummary variantTagType={noteTagType} count={noteTagType.numTags} project={project} />
+            <TagSummary variantTagType={noteTagType} count={noteTagType.numTags} projectGuid={project.projectGuid} />
           )}
         </Table.Body>
       </NoBorderTable>

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -54,6 +54,7 @@ const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeC
       <VariantTagTypeBar
         projectGuid={project.projectGuid}
         analysisGroupGuid={analysisGroupGuid}
+        tagTypes={tagTypes}
         tagTypeCounts={tagTypeCounts}
         height={20}
         showAllPopupCategories

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -9,7 +9,9 @@ import { ColoredIcon, HelpIcon, NoBorderTable } from 'shared/components/StyledCo
 import { NOTE_TAG_NAME } from 'shared/utils/constants'
 import { VerticalSpacer } from 'shared/components/Spacers'
 import VariantTagTypeBar, { getSavedVariantsLinkPath } from './VariantTagTypeBar'
-import { getAnalysisGroupTagTypeCounts, getCurrentProject, getProjectTagTypes, getTagTypeCounts } from '../selectors'
+import { getAnalysisGroupTagTypeCounts, getCurrentProject, getTagTypeCounts } from '../selectors'
+
+const NOTE_TAGS = [NOTE_TAG_NAME]
 
 const TableRow = styled(Table.Row)`
   padding: 0px !important;`
@@ -46,43 +48,37 @@ TagSummary.propTypes = {
   analysisGroupGuid: PropTypes.string,
 }
 
-const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeCounts }) => {
-  const noteTagType = analysisGroupGuid ? null : (project.variantTagTypes || []).find(vtt => vtt.name === NOTE_TAG_NAME)
-  // TODO clean up project
-  return (
-    <div>
-      <VariantTagTypeBar
-        projectGuid={project.projectGuid}
-        analysisGroupGuid={analysisGroupGuid}
-        tagTypes={tagTypes}
-        tagTypeCounts={tagTypeCounts}
-        height={20}
-        showAllPopupCategories
-      />
-      <VerticalSpacer height={10} />
-      <NoBorderTable basic="very" compact="very">
-        <Table.Body>
-          {
-            tagTypes.filter(variantTagType => variantTagType && tagTypeCounts[variantTagType.name] > 0).map(
-              variantTagType => (
-                <TagSummary
-                  key={variantTagType.variantTagTypeGuid}
-                  variantTagType={variantTagType}
-                  count={tagTypeCounts[variantTagType.name]}
-                  projectGuid={project.projectGuid}
-                  analysisGroupGuid={analysisGroupGuid}
-                />
-              ),
-            )
-          }
-          {noteTagType && noteTagType.numTags > 0 && (
-            <TagSummary variantTagType={noteTagType} count={noteTagType.numTags} projectGuid={project.projectGuid} />
-          )}
-        </Table.Body>
-      </NoBorderTable>
-    </div>
-  )
-})
+const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeCounts }) => (
+  <div>
+    <VariantTagTypeBar
+      projectGuid={project.projectGuid}
+      analysisGroupGuid={analysisGroupGuid}
+      tagTypes={tagTypes}
+      tagTypeCounts={tagTypeCounts}
+      height={20}
+      excludeItems={NOTE_TAGS}
+      showAllPopupCategories
+    />
+    <VerticalSpacer height={10} />
+    <NoBorderTable basic="very" compact="very">
+      <Table.Body>
+        {
+          tagTypes?.filter(variantTagType => variantTagType && tagTypeCounts[variantTagType.name] > 0).map(
+            variantTagType => (
+              <TagSummary
+                key={variantTagType.variantTagTypeGuid}
+                variantTagType={variantTagType}
+                count={tagTypeCounts[variantTagType.name]}
+                projectGuid={project.projectGuid}
+                analysisGroupGuid={analysisGroupGuid}
+              />
+            ),
+          )
+        }
+      </Table.Body>
+    </NoBorderTable>
+  </div>
+))
 
 VariantTags.propTypes = {
   project: PropTypes.object.isRequired,
@@ -93,7 +89,7 @@ VariantTags.propTypes = {
 
 const mapStateToProps = (state, ownProps) => ({
   project: getCurrentProject(state),
-  tagTypes: getProjectTagTypes(state),
+  tagTypes: getCurrentProject(state).variantTagTypes,
   tagTypeCounts: ownProps.analysisGroupGuid ?
     getAnalysisGroupTagTypeCounts(state, ownProps) : getTagTypeCounts(state),
 })

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -7,8 +7,9 @@ import { Popup, Table } from 'semantic-ui-react'
 
 import { ColoredIcon, HelpIcon, NoBorderTable } from 'shared/components/StyledComponents'
 import { NOTE_TAG_NAME } from 'shared/utils/constants'
-import { getSavedVariantsLinkPath } from './VariantTagTypeBar'
-import { getProjectTagTypes } from '../selectors'
+import { VerticalSpacer } from 'shared/components/Spacers'
+import VariantTagTypeBar, { getSavedVariantsLinkPath } from './VariantTagTypeBar'
+import { getAnalysisGroupTagTypeCounts, getProjectTagTypes, getTagTypeCounts } from '../selectors'
 
 const TableRow = styled(Table.Row)`
   padding: 0px !important;`
@@ -48,26 +49,36 @@ TagSummary.propTypes = {
 const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeCounts }) => {
   const noteTagType = analysisGroupGuid ? null : (project.variantTagTypes || []).find(vtt => vtt.name === NOTE_TAG_NAME)
   return (
-    <NoBorderTable basic="very" compact="very">
-      <Table.Body>
-        {
-          tagTypes.filter(variantTagType => variantTagType && tagTypeCounts[variantTagType.name] > 0).map(
-            variantTagType => (
-              <TagSummary
-                key={variantTagType.variantTagTypeGuid}
-                variantTagType={variantTagType}
-                count={tagTypeCounts[variantTagType.name]}
-                project={project}
-                analysisGroupGuid={analysisGroupGuid}
-              />
-            ),
-          )
-        }
-        {noteTagType && noteTagType.numTags > 0 && (
-          <TagSummary variantTagType={noteTagType} count={noteTagType.numTags} project={project} />
-        )}
-      </Table.Body>
-    </NoBorderTable>
+    <div>
+      <VariantTagTypeBar
+        project={project}
+        analysisGroupGuid={analysisGroupGuid}
+        tagTypeCounts={tagTypeCounts}
+        height={20}
+        showAllPopupCategories
+      />
+      <VerticalSpacer height={10} />
+      <NoBorderTable basic="very" compact="very">
+        <Table.Body>
+          {
+            tagTypes.filter(variantTagType => variantTagType && tagTypeCounts[variantTagType.name] > 0).map(
+              variantTagType => (
+                <TagSummary
+                  key={variantTagType.variantTagTypeGuid}
+                  variantTagType={variantTagType}
+                  count={tagTypeCounts[variantTagType.name]}
+                  project={project}
+                  analysisGroupGuid={analysisGroupGuid}
+                />
+              ),
+            )
+          }
+          {noteTagType && noteTagType.numTags > 0 && (
+            <TagSummary variantTagType={noteTagType} count={noteTagType.numTags} project={project} />
+          )}
+        </Table.Body>
+      </NoBorderTable>
+    </div>
   )
 })
 
@@ -78,8 +89,10 @@ VariantTags.propTypes = {
   analysisGroupGuid: PropTypes.string,
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
   tagTypes: getProjectTagTypes(state),
+  tagTypeCounts: ownProps.analysisGroupGuid ?
+    getAnalysisGroupTagTypeCounts(state, ownProps) : getTagTypeCounts(state),
 })
 
 export default connect(mapStateToProps)(VariantTags)

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -48,10 +48,10 @@ TagSummary.propTypes = {
   analysisGroupGuid: PropTypes.string,
 }
 
-const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeCounts }) => (
+const VariantTags = React.memo(({ projectGuid, analysisGroupGuid, tagTypes, tagTypeCounts }) => (
   <div>
     <VariantTagTypeBar
-      projectGuid={project.projectGuid}
+      projectGuid={projectGuid}
       analysisGroupGuid={analysisGroupGuid}
       tagTypes={tagTypes}
       tagTypeCounts={tagTypeCounts}
@@ -69,7 +69,7 @@ const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeC
                 key={variantTagType.variantTagTypeGuid}
                 variantTagType={variantTagType}
                 count={tagTypeCounts[variantTagType.name]}
-                projectGuid={project.projectGuid}
+                projectGuid={projectGuid}
                 analysisGroupGuid={analysisGroupGuid}
               />
             ),
@@ -81,17 +81,20 @@ const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeC
 ))
 
 VariantTags.propTypes = {
-  project: PropTypes.object.isRequired,
-  tagTypes: PropTypes.arrayOf(PropTypes.object).isRequired,
+  projectGuid: PropTypes.string.isRequired,
+  tagTypes: PropTypes.arrayOf(PropTypes.object),
   tagTypeCounts: PropTypes.object,
   analysisGroupGuid: PropTypes.string,
 }
 
-const mapStateToProps = (state, ownProps) => ({
-  project: getCurrentProject(state),
-  tagTypes: getCurrentProject(state).variantTagTypes,
-  tagTypeCounts: ownProps.analysisGroupGuid ?
-    getAnalysisGroupTagTypeCounts(state, ownProps) : getTagTypeCounts(state),
-})
+const mapStateToProps = (state, ownProps) => {
+  const { projectGuid, variantTagTypes } = getCurrentProject(state)
+  return {
+    projectGuid,
+    tagTypes: variantTagTypes,
+    tagTypeCounts: ownProps.analysisGroupGuid ?
+      getAnalysisGroupTagTypeCounts(state, ownProps) : getTagTypeCounts(state),
+  }
+}
 
 export default connect(mapStateToProps)(VariantTags)

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -9,7 +9,7 @@ import { ColoredIcon, HelpIcon, NoBorderTable } from 'shared/components/StyledCo
 import { NOTE_TAG_NAME } from 'shared/utils/constants'
 import { VerticalSpacer } from 'shared/components/Spacers'
 import VariantTagTypeBar, { getSavedVariantsLinkPath } from './VariantTagTypeBar'
-import { getAnalysisGroupTagTypeCounts, getProjectTagTypes, getTagTypeCounts } from '../selectors'
+import { getAnalysisGroupTagTypeCounts, getCurrentProject, getProjectTagTypes, getTagTypeCounts } from '../selectors'
 
 const TableRow = styled(Table.Row)`
   padding: 0px !important;`
@@ -91,6 +91,7 @@ VariantTags.propTypes = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
+  project: getCurrentProject(state),
   tagTypes: getProjectTagTypes(state),
   tagTypeCounts: ownProps.analysisGroupGuid ?
     getAnalysisGroupTagTypeCounts(state, ownProps) : getTagTypeCounts(state),

--- a/ui/pages/Project/components/VariantTags.jsx
+++ b/ui/pages/Project/components/VariantTags.jsx
@@ -48,6 +48,7 @@ TagSummary.propTypes = {
 
 const VariantTags = React.memo(({ project, analysisGroupGuid, tagTypes, tagTypeCounts }) => {
   const noteTagType = analysisGroupGuid ? null : (project.variantTagTypes || []).find(vtt => vtt.name === NOTE_TAG_NAME)
+  // TODO clean up project
   return (
     <div>
       <VariantTagTypeBar

--- a/ui/pages/Project/components/edit-families-and-individuals/BulkEditForm.jsx
+++ b/ui/pages/Project/components/edit-families-and-individuals/BulkEditForm.jsx
@@ -39,11 +39,11 @@ const mapStateToProps = (state, ownProps) => {
       getRawData: state2 => Object.values(
         (ownProps.getRawData || getProjectAnalysisGroupIndividualsByGuid)(state2, ownProps),
       ),
-      ...getEntityExportConfig({ project, fileName: ownProps.name, fields }),
+      ...getEntityExportConfig({ projectName: project.name, fileName: ownProps.name, fields }),
     },
     blankExportConfig: {
       rawData: [],
-      ...getEntityExportConfig({ project, fileName: 'template', fields }),
+      ...getEntityExportConfig({ projectName: project.name, fileName: 'template', fields }),
     },
   }
 }

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -11,7 +11,6 @@ import {
   getVariantMainTranscript,
   INDIVIDUAL_EXPORT_DATA,
   INDIVIDUAL_HAS_DATA_FIELD,
-  NOTE_TAG_NAME,
   MME_TAG_NAME,
 } from 'shared/utils/constants'
 import { toCamelcase, toSnakecase, snakecaseToTitlecase } from 'shared/utils/stringUtils'
@@ -171,11 +170,6 @@ export const getProjectAnalysisGroupMmeSubmissionDetails = createSelector(
   },
 )
 
-export const getProjectTagTypes = createSelector(
-  getCurrentProject,
-  project => (project.variantTagTypes || []).filter(vtt => vtt.name !== NOTE_TAG_NAME),
-)
-
 export const getTaggedVariantsByFamily = createSelector(
   getSavedVariantsByGuid,
   getGenesById,
@@ -254,8 +248,8 @@ export const getAnalysisGroupTagTypeCounts = createSelector(
 )
 
 export const getTagTypeCounts = createSelector(
-  getProjectTagTypes,
-  tagTypes => tagTypes.reduce((acc, { name, numTags }) => ({ ...acc, [name]: numTags }), {}),
+  getCurrentProject,
+  project => project?.variantTagTypes?.reduce((acc, { name, numTags }) => ({ ...acc, [name]: numTags }), {}),
 )
 
 export const getVariantGeneId = ({ variantGuid, geneId }, variantGeneId) => `${variantGuid}-${variantGeneId || geneId}`

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -493,8 +493,8 @@ export const getVisibleFamiliesInSortedOrder = createSelector(
   },
 )
 
-export const getEntityExportConfig = ({ project, tableName, fileName, fields }) => ({
-  filename: `${project.name.replace(' ', '_').toLowerCase()}_${tableName ? `${toSnakecase(tableName)}_` : ''}${fileName}`,
+export const getEntityExportConfig = ({ projectName, tableName, fileName, fields }) => ({
+  filename: `${projectName.replace(' ', '_').toLowerCase()}_${tableName ? `${toSnakecase(tableName)}_` : ''}${fileName}`,
   headers: fields.map(config => config.header),
   processRow: family => fields.map((config) => {
     const val = family[config.field]
@@ -551,10 +551,10 @@ const getSamplesExportData = createSelector(
 )
 
 export const getProjectExportUrls = createSelector(
-  getCurrentProject,
+  state => getCurrentProject(state).name,
   (state, ownProps) => (ownProps || {}).tableName,
   getAnalysisGroupGuid,
-  (project, tableName, analysisGroupGuid) => {
+  (projectName, tableName, analysisGroupGuid) => {
     const ownProps = { tableName, analysisGroupGuid }
     const isCaseReview = tableName === CASE_REVIEW_TABLE_NAME
     return [
@@ -562,7 +562,7 @@ export const getProjectExportUrls = createSelector(
         name: 'Families',
         getRawData: state => getFamiliesExportData(state, ownProps),
         ...getEntityExportConfig({
-          project,
+          projectName,
           tableName,
           fileName: 'families',
           fields: isCaseReview ? CASE_REVIEW_FAMILY_EXPORT_DATA : FAMILY_EXPORT_DATA,
@@ -572,7 +572,7 @@ export const getProjectExportUrls = createSelector(
         name: 'Individuals',
         getRawData: state => getIndividualsExportData(state, ownProps),
         ...getEntityExportConfig({
-          project,
+          projectName,
           tableName,
           fileName: 'individuals',
           fields: isCaseReview ? CASE_REVIEW_INDIVIDUAL_EXPORT_DATA : INDIVIDUAL_EXPORT_DATA,
@@ -581,7 +581,7 @@ export const getProjectExportUrls = createSelector(
       {
         name: 'Samples',
         getRawData: state => getSamplesExportData(state, ownProps),
-        ...getEntityExportConfig({ project, tableName, fileName: 'samples', fields: SAMPLE_EXPORT_DATA }),
+        ...getEntityExportConfig({ projectName, tableName, fileName: 'samples', fields: SAMPLE_EXPORT_DATA }),
       },
     ]
   },

--- a/ui/redux/rootReducer.js
+++ b/ui/redux/rootReducer.js
@@ -15,6 +15,7 @@ import modalReducers from './utils/modalReducer'
 import {
   RECEIVE_DATA,
   REQUEST_PROJECTS,
+  RECEIVE_PROJECT_CHILD_ENTITES,
   RECEIVE_SAVED_SEARCHES,
   REQUEST_SAVED_SEARCHES,
   REQUEST_SAVED_VARIANTS,
@@ -315,6 +316,7 @@ const rootReducer = combineReducers({
   projectsByGuid: createObjectsByIdReducer(RECEIVE_DATA, 'projectsByGuid'),
   projectsLoading: loadingReducer(REQUEST_PROJECTS, RECEIVE_DATA),
   projectDetailsLoading: loadingReducer(REQUEST_PROJECT_DETAILS, RECEIVE_DATA),
+  loadedProjectChildEntities: createObjectsByIdReducer(RECEIVE_PROJECT_CHILD_ENTITES),
   familiesByGuid: createObjectsByIdReducer(RECEIVE_DATA, 'familiesByGuid'),
   familyNotesByGuid: createObjectsByIdReducer(RECEIVE_DATA, 'familyNotesByGuid'),
   familyDetailsLoading: createSingleObjectReducer(REQUEST_FAMILY_DETAILS),

--- a/ui/redux/utils/reducerUtils.js
+++ b/ui/redux/utils/reducerUtils.js
@@ -1,10 +1,11 @@
 import { HttpRequestHelper } from 'shared/utils/httpRequestHelper'
-import { toCamelcase, toSnakecase } from 'shared/utils/stringUtils'
+import { toSnakecase } from 'shared/utils/stringUtils'
 
 // actions
 export const RECEIVE_DATA = 'RECEIVE_DATA'
 export const REQUEST_PROJECTS = 'REQUEST_PROJECTS'
 export const REQUEST_PROJECT_DETAILS = 'REQUEST_PROJECT_DETAILS'
+export const RECEIVE_PROJECT_CHILD_ENTITES = 'RECEIVE_PROJECT_CHILD_ENTITES'
 export const RECEIVE_SAVED_SEARCHES = 'RECEIVE_SAVED_SEARCHES'
 export const REQUEST_SAVED_SEARCHES = 'REQUEST_SAVED_SEARCHES'
 export const REQUEST_SAVED_VARIANTS = 'REQUEST_SAVED_VARIANTS'
@@ -37,10 +38,9 @@ export const updateEntity = (
 export const loadProjectChildEntities = (
   projectGuid, entityType, dispatchType, receiveDispatchType,
 ) => (dispatch, getState) => {
-  const { projectsByGuid } = getState()
-  const project = projectsByGuid[projectGuid]
+  const { loadedProjectChildEntities } = getState()
 
-  if (!project[`${toCamelcase(entityType)}Loaded`]) {
+  if (!(loadedProjectChildEntities[projectGuid] || {})[entityType]) {
     dispatch({ type: dispatchType })
     new HttpRequestHelper(`/api/project/${projectGuid}/get_${toSnakecase(entityType)}`,
       (responseJson) => {
@@ -48,6 +48,7 @@ export const loadProjectChildEntities = (
         if (receiveDispatchType) {
           dispatch({ type: receiveDispatchType, updatesById: responseJson })
         }
+        dispatch({ type: RECEIVE_PROJECT_CHILD_ENTITES, updatesById: { [projectGuid]: { [entityType]: true } } })
       },
       (e) => {
         dispatch({ type: RECEIVE_DATA, error: e.message, updatesById: {} })

--- a/ui/shared/components/graph/HorizontalStackedBar.jsx
+++ b/ui/shared/components/graph/HorizontalStackedBar.jsx
@@ -50,25 +50,28 @@ class HorizontalStackedBar extends React.PureComponent {
     showPercent: PropTypes.bool,
     showTotal: PropTypes.bool,
     sectionLinks: PropTypes.bool,
+    excludeItems: PropTypes.arrayOf(PropTypes.string),
   }
 
   render() {
     const {
-      title, data, dataCounts, width, height, linkPath, sectionLinks, showAllPopupCategories, minPercent = 1,
-      noDataMessage = 'No Data', showPercent = true, showTotal = true,
+      title, width, height, linkPath, sectionLinks, showAllPopupCategories, dataCounts, excludeItems,
+      minPercent = 1, noDataMessage = 'No Data', showPercent = true, showTotal = true,
     } = this.props
-    const total = (dataCounts ? Object.values(dataCounts) : data.map(({ count }) => count)).reduce(
-      (acc, count) => acc + count, 0,
-    )
+    let { data = [] } = this.props
+
+    if (excludeItems) {
+      data = data.filter(t => !excludeItems.includes(t.name))
+    }
+    data = data.map(({ count, ...item }) => ({ ...item, count: (dataCounts ? dataCounts[item.name] : count) || 0 }))
+
+    const total = data.reduce((acc, { count }) => acc + count, 0)
 
     if (total === 0) {
       return <BarContainer width={width} height={height}>{noDataMessage}</BarContainer>
     }
 
-    const dataWithPercents = data.map((d) => {
-      const count = dataCounts ? dataCounts[d.name] : d.count
-      return { ...d, count: count || 0, percent: (100 * (count || 0)) / total }
-    })
+    const dataWithPercents = data.map(d => ({ ...d, percent: (100 * (d.count || 0)) / total }))
     let currCategory = null
     const popupData = dataWithPercents.reduce((acc, d) => {
       if (d.count <= 0 && !showAllPopupCategories) {


### PR DESCRIPTION
Data for the project page is loaded in several separate requests. This was badly impacting the preformanceof the project page, as when each request completed any component that had the current project as a prop re-rendered. There were 3 categories of changes I made to address this:
1) Change the response from the server to remove the `<families/overview/etc>Loaded` field from the project response, and instead keep track of which entities have been loaded directly in the state, removing unnecessary updates to the project object
2) Instead of connecting several props to a top level component to pass down to its children, connecting the children directly and removing props from the parent, so when a part of the data updates only the relevant child component updates (i.e. instead of connecting the tag type counts to the top level project page, connect them directly to the tag summary component)
3) Instead of using the full project as a prop, only pass through the fields actually used by the relevant component. 