### PR TITLE
Fix hardcoded postgres username in entrypoint

### DIFF
--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -44,7 +44,7 @@ cat ~/.pgpass
 pg_retries=0
 until [ "$pg_retries" -ge 10 ]
 do
-    pg_isready -d postgres -h "$POSTGRES_SERVICE_HOSTNAME" -U postgres && break
+    pg_isready -d postgres -h "$POSTGRES_SERVICE_HOSTNAME" -U "$POSTGRES_USERNAME" && break
     pg_retries=$((pg_retries+1))
     if [ "$pg_retries" -eq 10 ]; then
         echo "Postgres database wasn't available after 10 connection attempts"
@@ -56,9 +56,9 @@ do
 done
 
 # init and populate seqrdb unless it already exists
-if ! psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -l | grep seqrdb; then
-    psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE reference_data_db';
-    psql --host "$POSTGRES_SERVICE_HOSTNAME" -U postgres -c 'CREATE DATABASE seqrdb';
+if ! psql --host "$POSTGRES_SERVICE_HOSTNAME" -U "$POSTGRES_USERNAME" -l | grep seqrdb; then
+    psql --host "$POSTGRES_SERVICE_HOSTNAME" -U "$POSTGRES_USERNAME" -c 'CREATE DATABASE reference_data_db';
+    psql --host "$POSTGRES_SERVICE_HOSTNAME" -U "$POSTGRES_USERNAME" -c 'CREATE DATABASE seqrdb';
     python -u manage.py migrate
     python -u manage.py migrate --database=reference_data
     python -u manage.py loaddata variant_tag_types


### PR DESCRIPTION
Seqr itself (in settings.py) pulls the postgres username from the environment variable that we set in the deployment. But, our entrypoint script was passing "postgres" as the username to the psql actions.

I think it's probably best to let this roll through dev first, and then it can just go out in the next prod deploy if it looks good there.