### PR TITLE
Sample metadata 414

### DIFF
--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -441,9 +441,11 @@ class ReportAPITest(object):
             response.json()['error'],
             'Found multiple airtable records for sample NA19675 with mismatched values in field dbgap_study_id')
         self.assertEqual(len(responses.calls), 3)
+        first_formula = "OR({CollaboratorSampleID}='NA20885',{CollaboratorSampleID}='NA20888',{CollaboratorSampleID}='NA20889'," \
+                        "{SeqrCollaboratorSampleID}='NA20885')"
         expected_params = {
             'fields[]': mock.ANY,
-            'filterByFormula':  "OR({CollaboratorSampleID}='NA20885',{CollaboratorSampleID}='NA20888',{CollaboratorSampleID}='NA20889',{SeqrCollaboratorSampleID}='NA20885')",
+            'filterByFormula': first_formula,
         }
         expected_fields = [
             'SeqrCollaboratorSampleID', 'CollaboratorSampleID', 'Collaborator', 'dbgap_study_id', 'dbgap_subject_id',

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -460,14 +460,13 @@ class ReportAPITest(object):
         self.assertListEqual(_get_list_param(responses.calls[2].request, 'fields%5B%5D'), expected_fields)
 
         # Test success
-        responses.calls.reset()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertListEqual(list(response_json.keys()), ['rows'])
         self.assertIn(EXPECTED_SAMPLE_METADATA_ROW, response_json['rows'])
-        self.assertEqual(len(responses.calls), 3)
-        self.assertDictEqual(responses.calls[2].request.params, {
+        self.assertEqual(len(responses.calls), 6)
+        self.assertDictEqual(responses.calls[-1].request.params, {
             'fields[]': 'CollaboratorID',
             'filterByFormula': "OR(RECORD_ID()='recW24C2CJW5lT64K',RECORD_ID()='reca4hcBnbA2cnZf9')",
         })

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -8,6 +8,9 @@ from settings import AIRTABLE_API_KEY, AIRTABLE_URL
 
 logger = SeqrLogger(__name__)
 
+MAX_OR_FILTERS = 200
+
+
 class AirtableSession(object):
 
     RDG_BASE = 'RDG'
@@ -40,12 +43,15 @@ class AirtableSession(object):
             logger.error(f'Airtable create "{record_type}" error: {e}', self._user)
 
     def fetch_records(self, record_type, fields, or_filters):
+        self._session.params.update({'fields[]': fields})
         filter_formulas = []
         for key, values in or_filters.items():
             filter_formulas += [f"{key}='{value}'" for value in sorted(values)]
-        self._session.params.update({'fields[]': fields, 'filterByFormula': f'OR({",".join(filter_formulas)})'})
         records = {}
-        self._populate_records(record_type, records)
+        for i in range(0, len(filter_formulas), MAX_OR_FILTERS):
+            filter_formula_group = filter_formulas[i:i + MAX_OR_FILTERS]
+            self._session.params.update({'filterByFormula': f'OR({",".join(filter_formula_group)})'})
+            self._populate_records(record_type, records)
         logger.info('Fetched {} {} records from airtable'.format(len(records), record_type), self._user)
         return records
 


### PR DESCRIPTION
Split airtable requests with many OR filters into multiple requests in order to prevent the query URL from being too long