### PR TITLE
Family saved variant fix

### DIFF
--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -137,6 +137,7 @@ class SavedVariantAPITest(object):
         fields = {'mainTranscriptId', 'mmeSubmissions'}
         fields.update(SAVED_VARIANT_DETAIL_FIELDS)
         self.assertSetEqual(set(variant.keys()), fields)
+        self.assertListEqual(variant['familyGuids'], ['F000001_1'])
         self.assertSetEqual(set(variant['genotypes'].keys()), {'I000003_na19679', 'I000001_na19675', 'I000002_na19678'})
         self.assertSetEqual(
             set(variant['tagGuids']), {'VT1708633_2103343353_r0390_100', 'VT1726961_2103343353_r0390_100'},
@@ -280,6 +281,7 @@ class SavedVariantAPITest(object):
             'createdBy': None,
         }]
         self.assertListEqual(variants['SV0000002_1248367227_r0390_100']['discoveryTags'], discovery_tags)
+        self.assertListEqual(variants['SV0000002_1248367227_r0390_100']['familyGuids'], ['F000002_2'])
         self.assertSetEqual(set(response_json['familiesByGuid'].keys()), {'F000012_12'})
 
         # Test discovery tags with family context
@@ -292,6 +294,7 @@ class SavedVariantAPITest(object):
             {'SV0000002_1248367227_r0390_100', 'SV0000001_2103343353_r0390_100'}
         )
         self.assertListEqual(variants['SV0000002_1248367227_r0390_100']['discoveryTags'], discovery_tags)
+        self.assertListEqual(variants['SV0000002_1248367227_r0390_100']['familyGuids'], ['F000002_2'])
         self.assertEqual(set(response_json['familiesByGuid'].keys()), {'F000001_1', 'F000002_2', 'F000012_12'})
 
     def test_create_saved_variant(self):

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -453,8 +453,9 @@ def get_json_for_analysis_group(analysis_group, **kwargs):
 
 def get_json_for_saved_variants(saved_variants, add_details=False, additional_model_fields=None):
     additional_values = {
-        'familyGuids': ArrayAgg('family__guid'),
+        'familyGuids': ArrayAgg('family__guid', distinct=True),
     }
+
     additional_fields = []
     additional_fields += additional_model_fields or []
     if add_details:

--- a/ui/pages/Project/components/SavedVariants.jsx
+++ b/ui/pages/Project/components/SavedVariants.jsx
@@ -222,6 +222,7 @@ class BaseProjectSavedVariants extends React.PureComponent {
           <VariantTagTypeBar
             height={30}
             projectGuid={project.projectGuid}
+            familyGuid={match.params.familyGuid}
             analysisGroupGuid={match.params.analysisGroupGuid}
             tagTypeCounts={tagTypeCounts}
             tagTypes={project.variantTagTypes}


### PR DESCRIPTION
Fixes the reported bug and a new bug from my lasrt PR that returns duplicate family guids for saved variants