### PR TITLE
Locus list queryset

### DIFF
--- a/seqr/views/apis/locus_list_api.py
+++ b/seqr/views/apis/locus_list_api.py
@@ -37,8 +37,8 @@ def locus_lists(request):
         gene_id: gene_symbol for gene_id, gene_symbol in
         GeneInfo.objects.filter(gene_id__in=all_gene_ids).values_list('gene_id', 'gene_symbol')
     }
-    for list in locus_lists_json:
-        list['geneNames'] = [gene_ids_to_symbols.get(gene_id, '') for gene_id in list.pop('gene_ids')]
+    for locus_list in locus_lists_json:
+        locus_list['geneNames'] = [gene_ids_to_symbols.get(gene_id, '') for gene_id in locus_list.pop('gene_ids')]
 
     return create_json_response({
         'locusListsByGuid': {locus_list['locusListGuid']: locus_list for locus_list in locus_lists_json},

--- a/seqr/views/apis/locus_list_api.py
+++ b/seqr/views/apis/locus_list_api.py
@@ -1,16 +1,17 @@
 import json
 
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Q, Count
 from django.db.utils import IntegrityError
 
-from reference_data.models import GENOME_VERSION_GRCh37
+from reference_data.models import GeneInfo, GENOME_VERSION_GRCh37
 from seqr.models import LocusList, LocusListGene, LocusListInterval
 from seqr.utils.gene_utils import get_genes, parse_locus_list_items
 from seqr.utils.logging_utils import log_model_update, SeqrLogger
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_create_model_from_json, \
     create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
-from seqr.views.utils.orm_to_json_utils import get_json_for_locus_lists, get_detailed_json_for_locus_lists, get_json_for_locus_list
+from seqr.views.utils.orm_to_json_utils import get_json_for_locus_lists, get_json_for_locus_list
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_multi_project_permissions, \
     check_user_created_object_permissions, login_and_policies_required, get_project_guids_user_can_view
 
@@ -23,13 +24,24 @@ INVALID_ITEMS_ERROR = 'This list contains invalid genes/ intervals. Update them,
 def locus_lists(request):
     locus_list_models = LocusList.objects.filter(
         _get_user_list_filter(request.user)
-    ).annotate(num_projects=Count('projects'))
+    )
 
-    locus_lists_json = get_detailed_json_for_locus_lists(locus_list_models, request.user)
+    gene_ids_agg = ArrayAgg('locuslistgene__gene_id', distinct=True)
+    locus_lists_json = get_json_for_locus_lists(locus_list_models, request.user, additional_values={
+        'numProjects': Count('projects'),
+        'gene_ids': gene_ids_agg,
+    })
+
+    all_gene_ids = locus_list_models.aggregate(gene_ids=gene_ids_agg)['gene_ids']
+    gene_ids_to_symbols = {
+        gene_id: gene_symbol for gene_id, gene_symbol in
+        GeneInfo.objects.filter(gene_id__in=all_gene_ids).values_list('gene_id', 'gene_symbol')
+    }
+    for list in locus_lists_json:
+        list['geneNames'] = [gene_ids_to_symbols.get(gene_id, '') for gene_id in list.pop('gene_ids')]
 
     return create_json_response({
         'locusListsByGuid': {locus_list['locusListGuid']: locus_list for locus_list in locus_lists_json},
-        'genesById': _get_locus_lists_genes(locus_lists_json),
     })
 
 

--- a/seqr/views/apis/locus_list_api.py
+++ b/seqr/views/apis/locus_list_api.py
@@ -10,7 +10,7 @@ from seqr.utils.logging_utils import log_model_update, SeqrLogger
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_create_model_from_json, \
     create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
-from seqr.views.utils.orm_to_json_utils import get_json_for_locus_lists, get_json_for_locus_list
+from seqr.views.utils.orm_to_json_utils import get_json_for_locus_lists, get_detailed_json_for_locus_lists, get_json_for_locus_list
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_multi_project_permissions, \
     check_user_created_object_permissions, login_and_policies_required, get_project_guids_user_can_view
 
@@ -25,8 +25,7 @@ def locus_lists(request):
         _get_user_list_filter(request.user)
     ).annotate(num_projects=Count('projects'))
 
-    locus_lists_json = get_json_for_locus_lists(locus_list_models, request.user, include_project_count=True,
-                                                include_genes=True, include_pagenes=False)
+    locus_lists_json = get_detailed_json_for_locus_lists(locus_list_models, request.user)
 
     return create_json_response({
         'locusListsByGuid': {locus_list['locusListGuid']: locus_list for locus_list in locus_lists_json},

--- a/seqr/views/apis/locus_list_api_tests.py
+++ b/seqr/views/apis/locus_list_api_tests.py
@@ -34,9 +34,10 @@ class LocusListAPITest(AuthenticationTestCase):
         self.assertSetEqual(set(locus_lists_dict.keys()), {LOCUS_LIST_GUID})
 
         locus_list = locus_lists_dict[LOCUS_LIST_GUID]
-        fields = {'numProjects'}
-        fields.update(PUBLIC_LOCUS_LIST_FIELDS)
+        fields = {'numProjects', 'geneNames'}
+        fields.update(OPTION_LOCUS_LIST_FIELDS)
         self.assertSetEqual(set(locus_list.keys()), fields)
+        self.assertSetEqual(set(locus_list['geneNames']), {'WASH7P', 'DDX11L1', 'MIR1302-2HG'})
 
         self.login_analyst_user()
         response = self.client.get(url)

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -10,7 +10,7 @@ from django.db.models.functions import Concat, Coalesce, NullIf, Lower, Trim
 from django.contrib.auth.models import User
 from guardian.shortcuts import get_users_with_perms, get_groups_with_perms
 
-from panelapp.models import PaLocusList, PaLocusListGene
+from panelapp.models import PaLocusList
 from reference_data.models import HumanPhenotypeOntology
 from seqr.models import GeneNote, VariantNote, VariantTag, VariantFunctionalData, SavedVariant, CAN_VIEW, CAN_EDIT, \
     get_audit_field_names

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -646,15 +646,17 @@ def _add_pa_locus_lists(locus_lists_json, user):
             ll['paLocusList'] = pa_locus_list_json
 
 
-def get_json_for_locus_lists(locus_lists, user, include_metadata=True):
-    additional_values = {}
+def get_json_for_locus_lists(locus_lists, user, include_metadata=True, additional_values=None):
+    ll_additional_values = {}
+    if additional_values:
+        ll_additional_values.update(additional_values)
     if include_metadata:
-        additional_values.update({
+        ll_additional_values.update({
             'numEntries': Count('locuslistgene') + Count('locuslistinterval'),
             'canEdit': Case(When(created_by=user, then=Value(True)), default=Value(False)),
         })
 
-    results = _get_json_for_queryset(locus_lists, user=user, additional_values=additional_values)
+    results = _get_json_for_queryset(locus_lists, user=user, additional_values=ll_additional_values)
     _add_pa_locus_lists(results, user)
     return results
 

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -716,6 +716,7 @@ def get_json_for_locus_list(locus_list, user):
         gene_id = item.get('geneId')
         if gene_id:
             item['pagene'] = pg_genes_by_id.get(gene_id)
+    _add_pa_locus_lists([result], user)
 
     return result
 

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -677,7 +677,7 @@ def get_detailed_json_for_locus_lists(locus_lists, user, include_project_count=T
 
         result.update({
             'items': [{'geneId': gene.gene_id} for gene in gene_set.all()] + intervals,
-            'intervalGenomeVersion': genome_versions.pop() if len(genome_versions) == 1 else None,
+            'intervalGenomeVersion': genome_versions.pop() if len(genome_versions) == 1 else None,  # TODO not used in lists, only for single list
             # metadata
             'numEntries': gene_set.count() + interval_set.count(),
             'canEdit': user == locus_list.created_by,

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -106,13 +106,13 @@ def _saved_variant_genes_transcripts(variants):
     return genes, transcripts
 
 
-def _add_locus_lists(projects, genes, add_list_detail=False, user=None, is_analyst=None):
+def _add_locus_lists(projects, genes, add_list_detail=False, user=None):
     locus_lists = LocusList.objects.filter(projects__in=projects)
 
     if add_list_detail:
         locus_lists_by_guid = {
             ll['locusListGuid']: dict(intervals=[], **ll)
-            for ll in get_json_for_locus_lists(locus_lists, user, is_analyst=is_analyst)
+            for ll in get_json_for_locus_lists(locus_lists, user)
         }
     else:
         locus_lists_by_guid = defaultdict(lambda: {'intervals': []})
@@ -211,7 +211,7 @@ def get_variants_response(request, saved_variants, response_variants=None, add_a
     genes, transcripts = _saved_variant_genes_transcripts(variants)
     response['transcriptsById'] = transcripts
     response['locusListsByGuid'] = _add_locus_lists(
-        projects, genes, add_list_detail=add_locus_list_detail, user=request.user, is_analyst=is_analyst)
+        projects, genes, add_list_detail=add_locus_list_detail, user=request.user)
 
     if discovery_tags:
         _add_discovery_tags(variants, discovery_tags)

--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -392,6 +392,10 @@ export const getLocusListTableData = createSelector(
       data = data.filter(locusList => !locusListGuids.includes(locusList.locusListGuid))
     }
 
+    data = data.map(({ items, ...locusList }) => (items ?
+      { geneNames: items.map(({ gene }) => (gene || {}).geneSymbol), ...locusList } :
+      locusList))
+
     return data.reduce((acc, locusList) => {
       if (locusList.canEdit) {
         acc.My.push(locusList)

--- a/ui/shared/components/table/LocusListTables.jsx
+++ b/ui/shared/components/table/LocusListTables.jsx
@@ -74,9 +74,8 @@ const PUBLIC_TABLE = {
 const TABLES = [MY_TABLE, PUBLIC_TABLE]
 
 const getLocusListFilterVal = list => [
-  list[LOCUS_LIST_NAME_FIELD], list[LOCUS_LIST_DESCRIPTION_FIELD] || '', ...(list.items || []).map(
-    ({ gene }) => (gene || {}).geneSymbol,
-  )].join()
+  list[LOCUS_LIST_NAME_FIELD], list[LOCUS_LIST_DESCRIPTION_FIELD] || '', ...(list.geneNames || []),
+].join()
 
 const LocusListTables = React.memo(
   ({ tableData, basicFields, tableButtons, dispatch, ...tableProps }) => TABLES.map(


### PR DESCRIPTION
Changes the locus list json function to use the faster queryset logic. As part of this, there was conditional logic in the endpoint for fetching the full list of items associated with every list, which was really overkill as the only place that was used was for being able to filter a table of locus lists by gene name. To improve performance, I therefore changed that endpoint to only return the gene names, and moved the logic for fetching all the items into the single `get_json_for_locus_list` function