### PR TITLE
Sample metadata performance

### DIFF
--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -558,7 +558,6 @@ def _get_discovery_rows(sample, parsed_variants, male_individual_guids):
     return discovery_rows
 
 
-SAMPLE_ID_FIELDS = ['CollaboratorSampleID', 'SeqrCollaboratorSampleID']
 SINGLE_SAMPLE_FIELDS = ['Collaborator', 'dbgap_study_id', 'dbgap_subject_id', 'dbgap_sample_id']
 LIST_SAMPLE_FIELDS = ['SequencingProduct', 'dbgap_submission']
 
@@ -566,7 +565,7 @@ LIST_SAMPLE_FIELDS = ['SequencingProduct', 'dbgap_submission']
 def _get_airtable_samples_for_id_field(sample_ids, id_field, fields, session):
     raw_records = session.fetch_records(
         'Samples', fields=[id_field] + fields,
-        or_filters={f'{id_field}': sample_ids},
+        or_filters={f'{{{id_field}}}': sample_ids},
     )
 
     records_by_id = defaultdict(list)
@@ -798,7 +797,7 @@ def _get_gregor_airtable_data(individuals, user):
     airtable_metadata = session.fetch_records(
         'GREGoR Data Model',
         fields=[SMID_FIELD] + fields,
-        or_filters={f'{SMID_FIELD}': [r[SMID_FIELD] for r in sample_records.values()]},
+        or_filters={f'{SMID_FIELD}': {r[SMID_FIELD] for r in sample_records.values()}},
     )
     airtable_metadata_by_smid = {r[SMID_FIELD]: r for r in airtable_metadata.values()}
 

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -8,7 +8,7 @@ from settings import AIRTABLE_API_KEY, AIRTABLE_URL
 
 logger = SeqrLogger(__name__)
 
-MAX_OR_FILTERS = 200
+MAX_OR_FILTERS = 270
 
 
 class AirtableSession(object):

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -51,6 +51,7 @@ class AirtableSession(object):
         for i in range(0, len(filter_formulas), MAX_OR_FILTERS):
             filter_formula_group = filter_formulas[i:i + MAX_OR_FILTERS]
             self._session.params.update({'filterByFormula': f'OR({",".join(filter_formula_group)})'})
+            logger.info(f'Fetching {record_type} records {i}-{i + MAX_OR_FILTERS} from airtable', self._user)
             self._populate_records(record_type, records)
         logger.info('Fetched {} {} records from airtable'.format(len(records), record_type), self._user)
         return records


### PR DESCRIPTION
This improves performance for single-project sample metadata pages by reducing the total number of airtable calls. Most airtable records have a `CollaboratorSampleID` that maps to the seqr ID, but a relatively small subset have a different value for this, and the actual seqr ID is stored in `SeqrCollaboratorSampleID`. Since there is a URL query limit, we are limited in the number of or filters we can send per request, so in the previous approach of filtering for either one of those fields we essentially double the number of airtable requests we make (i.e if there are 400 samples at 200 filters per request we need to make 4 requests instead of only making 2 requests if we could only filter on one field). This change first runs the query for all the records that match the `CollaboratorSampleID`, and then makes a follow up query for any records that were not returned. In the worst-case scenario the number of requests stays the same, but in the best case scenario (which is true for several of our largest projects) the number of requests is halved