### PR TITLE
Gregor report category

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -450,7 +450,7 @@
         "absent_nonstandard_features": null,
         "disorders": ["615593"],
         "candidate_genes": [{"gene": "EHBP1L1", "comments": "comments EHBP1L1"}, {"gene": "ACY3", "comments": "comments ACY3"}],
-        "rejected_genes": [{"gene": "IKBKAP", "comments": "comments IKBKAP"}, {"gene": "CCDC102B", "comments": "comments for CCDC102B"}],
+        "rejected_genes": [{"gene": "IKBKAP", "comments": "comments IKBKAP"}, {"gene": "CCDC102B", "comments": "comments for CCDC102B"}, {"comments":  "CMA - normal"}],
         "population": "MDE",
         "ar_fertility_meds": null,
         "ar_iui": null,

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -102,7 +102,7 @@
         "created_date": "2017-03-12T23:52:55.846Z",
         "created_by": null,
         "last_modified_date": "2017-03-12T23:52:55.846Z",
-        "name": "CMG",
+        "name": "GREGoR",
         "projects": [
             1, 3
         ]

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -839,11 +839,12 @@ def _get_gregor_family_row(family):
 
 
 def _get_participant_row(individual, airtable_sample):
+    import json
     participant = {
         'gregor_center': 'Broad',
         'paternal_id': f'Broad_{individual.father.individual_id}' if individual.father else '0',
         'maternal_id': f'Broad_{individual.mother.individual_id}' if individual.mother else '0',
-        'prior_testing': '|'.join([gene.get('gene', '') for gene in individual.rejected_genes or []]),
+        'prior_testing': '|'.join([gene.get('gene', gene['comments']) for gene in individual.rejected_genes or []]),
         'proband_relationship': individual.get_proband_relationship_display(),
         'sex': individual.get_sex_display(),
         'affected_status': individual.get_affected_display(),

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -746,6 +746,7 @@ def gregor_export(request, consent_code):
     individuals = Individual.objects.filter(
         family__project__consent_code=consent_code[0],
         family__project__in=projects,
+        family__project__projectcategory__name='GREGoR',
         sample__elasticsearch_index__isnull=False,
     ).distinct().prefetch_related('family__project', 'mother', 'father')
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -839,7 +839,6 @@ def _get_gregor_family_row(family):
 
 
 def _get_participant_row(individual, airtable_sample):
-    import json
     participant = {
         'gregor_center': 'Broad',
         'paternal_id': f'Broad_{individual.father.individual_id}' if individual.father else '0',

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -197,6 +197,12 @@ AIRTABLE_GREGOR_RECORDS = {
         'variant_types': 'SNV',
       },
     },
+    {
+      "id": "rec2B6OGmCVzkQW3s",
+      "fields": {
+        'SMID': 'SM-AGHT',
+      },
+    },
 ]}
 
 EXPECTED_NO_AIRTABLE_SAMPLE_METADATA_ROW = {
@@ -643,24 +649,24 @@ class ReportAPITest(object):
             ['Broad_SM-AGHT', 'Broad_NA19675_1', 'DNA', '', 'UBERON:0003714', '', '', 'No', '', '', '', '', '', '', ''],
             analyte_file)
 
-        self.assertEqual(len(experiment_file), 2)
+        self.assertEqual(len(experiment_file), 3)
         self.assertEqual(experiment_file[0], [
             'experiment_dna_short_read_id', 'analyte_id', 'experiment_sample_id', 'seq_library_prep_kit_method',
             'read_length', 'experiment_type', 'targeted_regions_method', 'targeted_region_bed_file',
             'date_data_generation', 'target_insert_size', 'sequencing_platform',
         ])
-        self.assertEqual(experiment_file[1], [
+        self.assertEqual(experiment_file[2], [
             'Broad_VCGS_FAM203_621_D2', 'Broad_SM-JDBTM', 'VCGS_FAM203_621_D2', 'Kapa HyperPrep', '151', 'exome',
             'Twist', 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/SR_experiment.bed', '2022-08-15', '385', 'NovaSeq',
         ])
 
-        self.assertEqual(len(read_file), 2)
+        self.assertEqual(len(read_file), 3)
         self.assertEqual(read_file[0], [
             'aligned_dna_short_read_id', 'experiment_dna_short_read_id', 'aligned_dna_short_read_file',
             'aligned_dna_short_read_index_file', 'md5sum', 'reference_assembly', 'alignment_software', 'mean_coverage',
             'analysis_details',
         ])
-        self.assertEqual(read_file[1], [
+        self.assertEqual(read_file[2], [
             'BCM_H7YG5DSX2-3-IDUDI0014-1', 'Broad_VCGS_FAM203_621_D2',
             'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/Broad_COL_FAM1_1_D1.cram',
             'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/Broad_COL_FAM1_1_D1.crai', '129c28163df082', 'GRCh38',

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -309,7 +309,7 @@ class ReportAPITest(object):
         self.check_no_analyst_no_access(url)
 
     def test_get_category_projects(self):
-        url = reverse(get_category_projects, args=['CMG'])
+        url = reverse(get_category_projects, args=['GREGoR'])
         self.check_analyst_login(url)
 
         response = self.client.get(url)

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -614,7 +614,7 @@ class ReportAPITest(object):
             'age_at_last_observation', 'affected_status', 'phenotype_description', 'age_at_enrollment',
         ])
         self.assertIn([
-            'Broad_NA19675_1', 'Broad_1kg project nme with unide', 'Broad', 'HMB', 'Yes', 'IKBKAP|CCDC102B',
+            'Broad_NA19675_1', 'Broad_1kg project nme with unide', 'Broad', 'HMB', 'Yes', 'IKBKAP|CCDC102B|CMA - normal',
             '34415322|33665635', 'Broad_1', 'Broad_NA19678', 'Broad_NA19679', '', 'Self', '', 'Male', '',
             'Middle Eastern or North African', 'Unknown', '', '21', 'Affected', 'myopathy', '18',
         ], participant_file)

--- a/seqr/views/utils/export_utils.py
+++ b/seqr/views/utils/export_utils.py
@@ -75,8 +75,10 @@ def export_multiple_files(files, zip_filename, file_format='csv', add_header_pre
                     header_display = ['{}-{}'.format(str(header_tuple[0]).zfill(2), header_tuple[1]) for header_tuple in enumerate(header)]
                     header_display[0] = header[0]
                 content = DELIMITERS[file_format].join(header_display) + '\n'
+                content_rows = [[row.get(key) or blank_value for key in header] for row in rows]
                 content += '\n'.join([
-                    DELIMITERS[file_format].join([row.get(key) or blank_value for key in header]) for row in rows
+                    DELIMITERS[file_format].join(row) for row in content_rows
+                    if any(val for val in row if val != blank_value)
                 ])
                 content = str(content.encode('utf-8'), 'ascii', errors='ignore') # Strip unicode chars in the content
                 zip_file.writestr('{}.{}'.format(filename, file_format), content)

--- a/seqr/views/utils/export_utils.py
+++ b/seqr/views/utils/export_utils.py
@@ -78,7 +78,7 @@ def export_multiple_files(files, zip_filename, file_format='csv', add_header_pre
                 content_rows = [[row.get(key) or blank_value for key in header] for row in rows]
                 content += '\n'.join([
                     DELIMITERS[file_format].join(row) for row in content_rows
-                    if any(val for val in row if val != blank_value)
+                    if any(val != blank_value for val in row)
                 ])
                 content = str(content.encode('utf-8'), 'ascii', errors='ignore') # Strip unicode chars in the content
                 zip_file.writestr('{}.{}'.format(filename, file_format), content)


### PR DESCRIPTION
FIxes a few outstinding issues with the gregor report:

- Filters projects to the Gregor category
- Fixes the prior_testing field
- Filters out rows where all values are blank, which occurs now due to sparse real-world metadata