### PR TITLE
fix phenotype gene search and tweak display

### DIFF
--- a/ui/pages/Project/components/FamilyTable/IndividualRow.jsx
+++ b/ui/pages/Project/components/FamilyTable/IndividualRow.jsx
@@ -130,6 +130,7 @@ const SHOW_DATA_MODAL_CONFIG = [
     component: PhenotypePrioritizedGenes,
     modalName: ({ individualId }) => `PHENOTYPE-PRIORITIZATION-${individualId}`,
     title: ({ individualId }) => `Phenotype Prioritized Genes: ${individualId}`,
+    modalSize: 'large',
     linkText: 'Show Phenotype Prioritized Genes',
   },
 ]
@@ -173,7 +174,7 @@ const DataDetails = React.memo(({ loadedSamples, individual, mmeSubmission }) =>
       ) : <MmeStatusLabel title="Submitted to MME" dateField="lastModifiedDate" color="violet" individual={individual} mmeSubmission={mmeSubmission} />
     )}
     {SHOW_DATA_MODAL_CONFIG.filter(({ shouldShowField }) => individual[shouldShowField]).map(
-      ({ modalName, title, linkText, component }) => {
+      ({ modalName, title, modalSize, linkText, component }) => {
         const sample = loadedSamples.find(({ sampleType, isActive }) => isActive && sampleType === SAMPLE_TYPE_RNA)
         const titleIds = { sampleId: sample?.sampleId, individualId: individual.individualId }
         return (
@@ -181,6 +182,7 @@ const DataDetails = React.memo(({ loadedSamples, individual, mmeSubmission }) =>
             key={modalName(titleIds)}
             modalName={modalName(titleIds)}
             title={title(titleIds)}
+            size={modalSize}
             trigger={<ButtonLink padding="1em 0 0 0" content={linkText} />}
           >
             <React.Suspense fallback={<Loader />}>

--- a/ui/pages/Project/components/PhenotypePrioritizedGenes.jsx
+++ b/ui/pages/Project/components/PhenotypePrioritizedGenes.jsx
@@ -14,7 +14,7 @@ import { getPhenotypeDataLoading } from '../selectors'
 const PHENOTYPE_GENE_INFO_COLUMNS = [
   {
     name: 'geneId',
-    width: 6,
+    width: 5,
     content: 'Gene',
     format: ({ gene, rowId }) => (
       <BaseVariantGene
@@ -30,7 +30,7 @@ const PHENOTYPE_GENE_INFO_COLUMNS = [
   { name: 'tool', width: 1, content: 'Tool' },
   {
     name: 'diseaseName',
-    width: 3,
+    width: 5,
     content: 'Disease',
     format: ({ diseaseName, diseaseId }) => (
       <div>
@@ -43,7 +43,7 @@ const PHENOTYPE_GENE_INFO_COLUMNS = [
   { name: 'rank', width: 1, content: 'Rank' },
   {
     name: 'scores',
-    width: 5,
+    width: 4,
     content: 'Scores',
     format: ({ scores }) => Object.keys(scores).sort().map(scoreName => (
       <div key={scoreName}>
@@ -62,9 +62,10 @@ const BasePhenotypePriGenes = React.memo((
     <RareGeneSearchLink
       buttonText="Search for variants in high-ranked genes"
       icon="search"
-      location={(phenotypeGeneScores[individualGuid] || []).map(({ geneId }) => geneId).join(',')}
+      location={[...(new Set((phenotypeGeneScores[individualGuid] || []).map(({ gene }) => gene.geneId)))].join(',')}
       familyGuid={familyGuid}
       floated="right"
+      padding="0 1em 1em 0"
     />
     <DataTable
       data={phenotypeGeneScores[individualGuid]}


### PR DESCRIPTION
The gene search link generated for phenotpye prioritization was not working because it was using the wrong field to pull the gene Ids. This fixes that, and also tweaks the display a bit to use a larger modal 

<img width="1116" alt="Screen Shot 2023-02-09 at 3 46 39 PM" src="https://user-images.githubusercontent.com/24598672/217935496-e2335a85-a910-4886-9208-8ff7af1453ff.png">
