### PR TITLE
Individual row collapsed in case review

### DIFF
--- a/ui/pages/Project/components/CaseReview.jsx
+++ b/ui/pages/Project/components/CaseReview.jsx
@@ -26,7 +26,6 @@ const FIELDS = [
 const CaseReviewTable = React.memo(({ headerStatus }) => (
   <div>
     <FamilyTable
-      showDetails
       tableName={CASE_REVIEW_TABLE_NAME}
       headerStatus={headerStatus}
       detailFields={FIELDS}

--- a/ui/pages/Project/components/FamilyPage.jsx
+++ b/ui/pages/Project/components/FamilyPage.jsx
@@ -175,7 +175,7 @@ const BaseFamilyDetail = React.memo(({ familyGuid, family, compact, tableName, s
     <Family
       family={family}
       compact={compact}
-      rightContent={showVariantDetails ? <VariantDetail family={family} compact={compact} /> : null}
+      rightContent={showVariantDetails ? <VariantDetail family={family} compact={compact} /> : <div />}
       {...props}
     />
   )

--- a/ui/pages/Project/components/FamilyTable/CollapsableLayout.jsx
+++ b/ui/pages/Project/components/FamilyTable/CollapsableLayout.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+class CollapsableLayout extends React.PureComponent {
+
+  static propTypes = {
+    children: PropTypes.node,
+  }
+
+  state = { showDetails: false }
+
+  toggle = () => {
+    this.setState(prevState => ({ showDetails: !prevState.showDetails }))
+  }
+
+  render() {
+    const { children } = this.props
+    const { showDetails } = this.state
+    return React.cloneElement(children, { showDetails, toggleDetails: this.toggle })
+  }
+
+}
+
+export default CollapsableLayout

--- a/ui/pages/Project/components/FamilyTable/CollapsableLayout.jsx
+++ b/ui/pages/Project/components/FamilyTable/CollapsableLayout.jsx
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types'
 class CollapsableLayout extends React.PureComponent {
 
   static propTypes = {
-    children: PropTypes.node,
+    layoutComponent: PropTypes.elementType.isRequired,
+    detailFields: PropTypes.arrayOf(PropTypes.object).isRequired,
+    noDetailFields: PropTypes.arrayOf(PropTypes.object),
   }
 
   state = { showDetails: false }
@@ -14,9 +16,18 @@ class CollapsableLayout extends React.PureComponent {
   }
 
   render() {
-    const { children } = this.props
+    const { layoutComponent, detailFields, noDetailFields, ...props } = this.props
     const { showDetails } = this.state
-    return React.cloneElement(children, { showDetails, toggleDetails: this.toggle })
+    const allowToggle = !!noDetailFields
+    const compact = allowToggle && !showDetails
+
+    return React.createElement(layoutComponent, {
+      fields: compact ? noDetailFields : detailFields,
+      compact,
+      disableEdit: compact,
+      toggleDetails: allowToggle ? this.toggle : null,
+      ...props,
+    })
   }
 
 }

--- a/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
+++ b/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { Table, Icon, Popup, Visibility } from 'semantic-ui-react'
+import { Table, Popup, Visibility } from 'semantic-ui-react'
 import { connect } from 'react-redux'
 
 import DataLoader from 'shared/components/DataLoader'
@@ -16,16 +16,12 @@ import {
 } from '../../selectors'
 import { loadFamilies, loadProjectExportData } from '../../reducers'
 import { FamilyDetail } from '../FamilyPage'
+import CollapsableLayout from './CollapsableLayout'
 import TableHeaderRow from './header/TableHeaderRow'
 
 const ExportContainer = styled.span`
   float: right;
   padding-bottom: 15px;
-`
-
-const ToggleIcon = styled(Icon).attrs({ size: 'large', link: true, name: 'dropdown' })`
-  position: relative;
-  z-index: 1;
 `
 
 const EmptyCell = styled(Table.Cell)`
@@ -43,6 +39,22 @@ const OverflowCell = styled(Table.Cell)`
   }
 `
 
+const FamilyRowDetail = ({ showDetails, detailFields, noDetailFields, ...props }) => (
+  <FamilyDetail
+    {...props}
+    showFamilyPageLink
+    fields={showDetails ? detailFields : noDetailFields}
+    compact={!showDetails}
+    disableEdit={!showDetails}
+  />
+)
+
+FamilyRowDetail.propTypes = {
+  showDetails: PropTypes.bool,
+  detailFields: PropTypes.arrayOf(PropTypes.object),
+  noDetailFields: PropTypes.arrayOf(PropTypes.object),
+}
+
 class FamilyTableRow extends React.PureComponent {
 
   static propTypes = {
@@ -54,45 +66,24 @@ class FamilyTableRow extends React.PureComponent {
     showDetails: PropTypes.bool,
   }
 
-  state = { showDetails: null, isVisible: false }
-
-  toggle = () => {
-    const { showDetails } = this.props
-    this.setState(prevState => (
-      { showDetails: !(prevState.showDetails === null ? showDetails : prevState.showDetails) }
-    ))
-  }
+  state = { isVisible: false }
 
   handleOnScreen = () => {
     this.setState({ isVisible: true })
   }
 
   render() {
-    const {
-      familyGuid, showVariantDetails, detailFields, noDetailFields, tableName, showDetails: initialShowDetails,
-    } = this.props
-    const { showDetails, isVisible } = this.state
-    const showFamilyDetails = showDetails === null ? initialShowDetails : showDetails
+    const { noDetailFields } = this.props
+    const { isVisible } = this.state
+
+    const rowDetail = <FamilyRowDetail {...this.props} />
+    const rowContent = noDetailFields ? <CollapsableLayout>{rowDetail}</CollapsableLayout> : rowDetail
+
     return (
       <Table.Row>
-        <Table.Cell collapsing verticalAlign="top">
-          {detailFields && noDetailFields &&
-            <ToggleIcon rotated={showFamilyDetails ? undefined : 'counterclockwise'} onClick={this.toggle} />}
-        </Table.Cell>
-        <OverflowCell>
+        <OverflowCell width={16}>
           <Visibility fireOnMount onOnScreen={this.handleOnScreen}>
-            {isVisible && (
-              <FamilyDetail
-                key={familyGuid}
-                familyGuid={familyGuid}
-                showFamilyPageLink
-                showVariantDetails={showVariantDetails}
-                tableName={tableName}
-                fields={showFamilyDetails ? detailFields : noDetailFields}
-                compact={!showFamilyDetails}
-                disableEdit={!showFamilyDetails}
-              />
-            )}
+            {isVisible && rowContent}
           </Visibility>
         </OverflowCell>
       </Table.Row>
@@ -163,7 +154,7 @@ const FamilyTable = React.memo(({
         analysisGroupGuid={props.analysisGroupGuid}
       />
     </Table>
-    <Table striped compact attached="bottom">
+    <Table striped compact fixed attached="bottom">
       <Table.Body>
         {loading && <TableLoading />}
         {!loading && (

--- a/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
+++ b/ui/pages/Project/components/FamilyTable/FamilyTable.jsx
@@ -39,22 +39,6 @@ const OverflowCell = styled(Table.Cell)`
   }
 `
 
-const FamilyRowDetail = ({ showDetails, detailFields, noDetailFields, ...props }) => (
-  <FamilyDetail
-    {...props}
-    showFamilyPageLink
-    fields={showDetails ? detailFields : noDetailFields}
-    compact={!showDetails}
-    disableEdit={!showDetails}
-  />
-)
-
-FamilyRowDetail.propTypes = {
-  showDetails: PropTypes.bool,
-  detailFields: PropTypes.arrayOf(PropTypes.object),
-  noDetailFields: PropTypes.arrayOf(PropTypes.object),
-}
-
 class FamilyTableRow extends React.PureComponent {
 
   static propTypes = {
@@ -63,7 +47,6 @@ class FamilyTableRow extends React.PureComponent {
     detailFields: PropTypes.arrayOf(PropTypes.object),
     noDetailFields: PropTypes.arrayOf(PropTypes.object),
     showVariantDetails: PropTypes.bool,
-    showDetails: PropTypes.bool,
   }
 
   state = { isVisible: false }
@@ -73,17 +56,13 @@ class FamilyTableRow extends React.PureComponent {
   }
 
   render() {
-    const { noDetailFields } = this.props
     const { isVisible } = this.state
-
-    const rowDetail = <FamilyRowDetail {...this.props} />
-    const rowContent = noDetailFields ? <CollapsableLayout>{rowDetail}</CollapsableLayout> : rowDetail
 
     return (
       <Table.Row>
         <OverflowCell width={16}>
           <Visibility fireOnMount onOnScreen={this.handleOnScreen}>
-            {isVisible && rowContent}
+            {isVisible && <CollapsableLayout layoutComponent={FamilyDetail} showFamilyPageLink {...this.props} />}
           </Visibility>
         </OverflowCell>
       </Table.Row>

--- a/ui/pages/Project/components/FamilyTable/IndividualRow.jsx
+++ b/ui/pages/Project/components/FamilyTable/IndividualRow.jsx
@@ -34,6 +34,7 @@ import {
 import { getCurrentProject } from '../../selectors'
 
 import CaseReviewStatusDropdown from './CaseReviewStatusDropdown'
+import CollapsableLayout from './CollapsableLayout'
 
 const RnaSeqOutliers = React.lazy(() => import('../RnaSeqOutliers'))
 const PhenotypePrioritizedGenes = React.lazy(() => import('../PhenotypePrioritizedGenes'))
@@ -49,6 +50,10 @@ const Detail = styled.div`
 const CaseReviewDropdownContainer = styled.div`
   float: right;
   width: 100%;
+`
+
+const IndividualContainer = styled.div`
+ display: inline-block;
 `
 
 const FLAG_TITLE = {
@@ -499,6 +504,7 @@ const NON_CASE_REVIEW_FIELDS = [
   },
   ...INDIVIDUAL_FIELDS,
 ]
+const EMPTY_FIELDS = [{ id: 'blank', colWidth: 10, component: () => null }]
 
 class IndividualRow extends React.PureComponent {
 
@@ -539,7 +545,7 @@ class IndividualRow extends React.PureComponent {
     loadedSamples = loadedSamples.filter((sample, i) => sample.isActive || i === 0 || i === loadedSamples.length - 1)
 
     const leftContent = (
-      <div>
+      <IndividualContainer>
         <div>
           <PedigreeIcon sex={sex} affected={affected} />
           {displayName}
@@ -549,7 +555,7 @@ class IndividualRow extends React.PureComponent {
             {`ADDED ${new Date(createdDate).toLocaleDateString().toUpperCase()}`}
           </Detail>
         </div>
-      </div>
+      </IndividualContainer>
     )
 
     const editCaseReview = tableName === CASE_REVIEW_TABLE_NAME
@@ -557,11 +563,11 @@ class IndividualRow extends React.PureComponent {
       <CaseReviewStatus individual={individual} /> :
       <DataDetails loadedSamples={loadedSamples} individual={individual} mmeSubmission={mmeSubmission} />
 
-    const fields = editCaseReview ? CASE_REVIEW_FIELDS : NON_CASE_REVIEW_FIELDS
-
     return (
-      <FamilyLayout
-        fields={fields}
+      <CollapsableLayout
+        layoutComponent={FamilyLayout}
+        detailFields={editCaseReview ? CASE_REVIEW_FIELDS : NON_CASE_REVIEW_FIELDS}
+        noDetailFields={editCaseReview ? EMPTY_FIELDS : null}
         fieldDisplay={this.individualFieldDisplay}
         leftContent={leftContent}
         rightContent={rightContent}

--- a/ui/pages/Project/components/FamilyTable/header/TableHeaderRow.jsx
+++ b/ui/pages/Project/components/FamilyTable/header/TableHeaderRow.jsx
@@ -191,7 +191,6 @@ const TableHeaderRow = React.memo(({
         <OverflowHeaderCell colSpan={2} textAlign="left">
           <FamilyLayout
             compact
-            offset
             fields={fields}
             fieldDisplay={familyFieldDisplay}
             rightContent={showVariantDetails ? <FamilyTableFilter category={FAMILY_FIELD_SAVED_VARIANTS} /> : null}

--- a/ui/pages/Project/components/ProjectPageUI.jsx
+++ b/ui/pages/Project/components/ProjectPageUI.jsx
@@ -69,7 +69,7 @@ const NO_DETAIL_FIELDS = [
   { id: FAMILY_FIELD_ANALYSIS_STATUS, colWidth: 2 },
   { id: FAMILY_FIELD_ANALYSED_BY, colWidth: 2 },
   { id: FAMILY_FIELD_FIRST_SAMPLE, colWidth: 2 },
-  { id: FAMILY_FIELD_DESCRIPTION, colWidth: 5 },
+  { id: FAMILY_FIELD_DESCRIPTION, colWidth: 4 },
 ]
 
 const ProjectPageUI = React.memo(({ analysisGroupGuid, load, loading, familiesLoading }) => (

--- a/ui/shared/components/panel/family/Family.jsx
+++ b/ui/shared/components/panel/family/Family.jsx
@@ -136,6 +136,7 @@ class Family extends React.PureComponent {
     annotation: PropTypes.node,
     disableEdit: PropTypes.bool,
     disableInternalEdit: PropTypes.bool,
+    toggleDetails: PropTypes.func,
   }
 
   familyField = (field) => {
@@ -163,7 +164,7 @@ class Family extends React.PureComponent {
   render() {
     const {
       project, family, fields, rightContent, compact, useFullWidth, disablePedigreeZoom, disableEdit,
-      showFamilyPageLink, annotation, hidePedigree,
+      showFamilyPageLink, annotation, hidePedigree, toggleDetails,
     } = this.props
 
     if (!family) {
@@ -189,7 +190,7 @@ class Family extends React.PureComponent {
               {`(${family.individualGuids.length})`}
             </span>
           ) : (
-            <div key="header">
+            <span key="header">
               {familyHeader}
               <PedigreeImagePanel
                 key="pedigree"
@@ -197,7 +198,7 @@ class Family extends React.PureComponent {
                 disablePedigreeZoom={disablePedigreeZoom}
                 isEditable={!disableEdit && project.canEdit}
               />
-            </div>
+            </span>
           )}
         </span>
       )
@@ -212,6 +213,7 @@ class Family extends React.PureComponent {
         fieldDisplay={this.familyField}
         leftContent={leftContent}
         rightContent={rightContent}
+        toggleDetails={toggleDetails}
       />
     )
   }

--- a/ui/shared/components/panel/family/FamilyLayout.jsx
+++ b/ui/shared/components/panel/family/FamilyLayout.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table } from 'semantic-ui-react'
+import { Icon, Table } from 'semantic-ui-react'
 import styled from 'styled-components'
 
 const FamilyGrid = styled(({ annotation, offset, ...props }) => <Table {...props} />)`
@@ -8,6 +8,11 @@ const FamilyGrid = styled(({ annotation, offset, ...props }) => <Table {...props
   margin-top: ${props => (props.annotation ? '-33px !important' : 'inherit')};
   background: inherit !important;
   border: none !important;
+`
+
+const ToggleIconContainer = styled.span`
+  z-index: 1;
+  margin-right: 5px;
 `
 
 const getContentWidth = (useFullWidth, leftContent, rightContent) => {
@@ -21,14 +26,19 @@ const getContentWidth = (useFullWidth, leftContent, rightContent) => {
 }
 
 const FamilyLayout = React.memo((
-  { leftContent, rightContent, annotation, offset, fields, fieldDisplay, useFullWidth, compact },
+  { leftContent, toggleDetails, rightContent, annotation, offset, fields, fieldDisplay, useFullWidth, compact },
 ) => (
   <div>
     {annotation}
     <FamilyGrid annotation={annotation} offset={offset} compact fixed={!useFullWidth}>
       <Table.Body>
         <Table.Row verticalAlign="top">
-          {(leftContent || !useFullWidth) && <Table.Cell width={3}>{leftContent}</Table.Cell>}
+          {(leftContent || !useFullWidth) && (
+            <Table.Cell width={3}>
+              {toggleDetails && <ToggleIconContainer><Icon size="large" name="dropdown" link rotated={compact ? 'counterclockwise' : undefined} onClick={toggleDetails} /></ToggleIconContainer>}
+              {leftContent}
+            </Table.Cell>
+          )}
           {compact ? (fields || []).map(
             field => <Table.Cell width={field.colWidth || 1} key={field.id}>{fieldDisplay(field)}</Table.Cell>,
           ) : (
@@ -52,6 +62,7 @@ FamilyLayout.propTypes = {
   annotation: PropTypes.node,
   leftContent: PropTypes.node,
   rightContent: PropTypes.node,
+  toggleDetails: PropTypes.func,
 }
 
 export default FamilyLayout

--- a/ui/shared/components/panel/family/FamilyLayout.jsx
+++ b/ui/shared/components/panel/family/FamilyLayout.jsx
@@ -13,6 +13,7 @@ const FamilyGrid = styled(({ annotation, offset, ...props }) => <Table {...props
 const ToggleIconContainer = styled.span`
   z-index: 1;
   margin-right: 5px;
+  vertical-align: top;
 `
 
 const getContentWidth = (useFullWidth, leftContent, rightContent) => {


### PR DESCRIPTION
Moves the behavior for toggling whether a FamilyLayout` component is collapsed or not into a helper component instead of implementing directly for Family table rows, so behavior can be easily shared for individual rows. This does require some tweaking for the display, but overall everything (except case review) looks the same