### PR TITLE
filter to single page of airtable records

### DIFF
--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -287,6 +287,7 @@ class ReportAPITest(object):
     def _assert_expected_airtable_call(self, call_index, filter_formula, fields, additional_params=None):
         expected_params = {
             'fields[]': mock.ANY,
+            'pageSize': '100',
             'filterByFormula': filter_formula,
         }
         if additional_params:

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -8,7 +8,8 @@ from settings import AIRTABLE_API_KEY, AIRTABLE_URL
 
 logger = SeqrLogger(__name__)
 
-MAX_OR_FILTERS = 270
+PAGE_SIZE = 100
+MAX_OR_FILTERS = PAGE_SIZE - 5
 
 
 class AirtableSession(object):
@@ -43,7 +44,7 @@ class AirtableSession(object):
             logger.error(f'Airtable create "{record_type}" error: {e}', self._user)
 
     def fetch_records(self, record_type, fields, or_filters):
-        self._session.params.update({'fields[]': fields})
+        self._session.params.update({'fields[]': fields, 'pageSize': PAGE_SIZE})
         filter_formulas = []
         for key, values in or_filters.items():
             filter_formulas += [f"{key}='{value}'" for value in sorted(values)]
@@ -51,7 +52,7 @@ class AirtableSession(object):
         for i in range(0, len(filter_formulas), MAX_OR_FILTERS):
             filter_formula_group = filter_formulas[i:i + MAX_OR_FILTERS]
             self._session.params.update({'filterByFormula': f'OR({",".join(filter_formula_group)})'})
-            logger.info(f'Fetching {record_type} records {i}-{i + MAX_OR_FILTERS} from airtable', self._user)
+            logger.info(f'Fetching {record_type} records {i}-{i + len(filter_formula_group)} from airtable', self._user)
             self._populate_records(record_type, records)
         logger.info('Fetched {} {} records from airtable'.format(len(records), record_type), self._user)
         return records


### PR DESCRIPTION
This improved the performance of fetching records from airtable by reducing the overall number and duration of requests. Airtable has a maximum page size of 100, and if your filter returns more than that many records it return a response with an offset param so you can page through the results. This means that when we were passing 270 filters per request, this was actually executing up to 3 requests to page through all the data. Switching to setting the number of filters to just below the max results per page means we almost never need to make an offset request. Consider the case where we are filtering to 375 records.
Before:
1.  Query for records 0-270
2. Query for second page  of records 0-270
3. Query for third page of records 0-270
4. Query for records 270-375
5. Query for second page of records 270-375

Now:
1.  Query for records 0-95
2. Query for records 95-190
3. Query for records 190-285
4. Query for records 285-375

The reason for doing 95 instead of 100 is that there can infrequently be duplicate records for a given filter so requesting exactly 100 records can often lead to needing an offset page for a couple record, while only requesting 95 makes that case incredibly rare.

Also, searches with stricter filters run faster than those with broader filters, and the offset pagination requests are just as slow as the request for the first page, so even in cases where the total number of requests stays the same, the total time for requests drops