### PR TITLE
allow skip airtable for sample metadata

### DIFF
--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -183,8 +183,9 @@ def anvil_export(request, project_guid):
 
 @analyst_required
 def sample_metadata_export(request, project_guid):
-    omit_airtable = project_guid == 'all'
-    if omit_airtable:
+    is_all_projects = project_guid == 'all'
+    omit_airtable = is_all_projects or 'true' in request.GET.get('omitAirtable', '')
+    if is_all_projects:
         projects = get_internal_projects()
     else:
         projects = [get_project_and_check_permissions(project_guid, request.user)]

--- a/ui/pages/Report/components/SampleMetadata.jsx
+++ b/ui/pages/Report/components/SampleMetadata.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 import FormWrapper from 'shared/components/form/FormWrapper'
-import { BaseSemanticInput } from 'shared/components/form/Inputs'
+import { BaseSemanticInput, BooleanCheckbox } from 'shared/components/form/Inputs'
 import { ALL_PROJECTS_PATH, GREGOR_PROJECT_PATH } from '../constants'
 import { loadSampleMetadata } from '../reducers'
 import { getSampleMetadataLoading, getSampleMetadataLoadingError, getSampleMetadataRows, getSampleMetadataColumns } from '../selectors'
@@ -27,6 +27,12 @@ const FIELDS = [
     component: BaseSemanticInput,
     inputType: 'Input',
     type: 'date',
+  },
+  {
+    name: 'omitAirtable',
+    label: 'Skip Airtable Columns',
+    inline: true,
+    component: BooleanCheckbox,
   },
 ]
 


### PR DESCRIPTION
Allows users to opt to skip the airtable metadata in a single-project sample metadata table