### PR TITLE
move selector to correct file

### DIFF
--- a/ui/pages/Project/components/PhenotypePrioritizedGenes.jsx
+++ b/ui/pages/Project/components/PhenotypePrioritizedGenes.jsx
@@ -6,10 +6,9 @@ import DataLoader from 'shared/components/DataLoader'
 import { RareGeneSearchLink } from 'shared/components/buttons/SearchResultsLink'
 import DataTable from 'shared/components/table/DataTable'
 import { BaseVariantGene } from 'shared/components/panel/variants/VariantGene'
-import { getIndividualPhenotypeGeneScores } from 'shared/components/panel/variants/selectors'
 import { camelcaseToTitlecase } from 'shared/utils/stringUtils'
 import { loadPhenotypeGeneScores } from '../reducers'
-import { getPhenotypeDataLoading } from '../selectors'
+import { getPhenotypeDataLoading, getIndividualPhenotypeGeneScores } from '../selectors'
 
 const PHENOTYPE_GENE_INFO_COLUMNS = [
   {

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -1014,6 +1014,33 @@ export const STATE_WITH_2_FAMILIES = {
       username: 'test_user2',
     },
   },
+    rnaSeqDataByIndividual: {
+    I021476_na19678_1: {
+      outliers: {
+        ENSG00000228198: { isSignificant: true, pValue: 0.0004 },
+        ENSG00000164458: { isSignificant: true, pValue: 0.0073 },
+      },
+    },
+    I021474_na19679_1: {
+      outliers: {
+        ENSG00000228198: { isSignificant: true, pValue: 0.01 },
+        ENSG00000164458: { isSignificant: false, pValue: 0.73 },
+      },
+    },
+    I021476_na19678_2: { outliers: { ENSG00000228198: { isSignificant: true, pValue: 0.0214 } } },
+  },
+  phenotypeGeneScoresByIndividual: {
+    I021476_na19678_1: {
+      ENSG00000228198: {
+        lirical: [{
+          diseaseId: 'OMIM:618460',
+          diseaseName: 'Khan-Khan-Katsanis syndrome',
+          rank: 1,
+          scores: { compositeLR: 0.066, post_test_probability: 0 },
+        }],
+      },
+    },
+  },
 }
 
 export const DATA_MANAGER_USER = {

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -1014,7 +1014,7 @@ export const STATE_WITH_2_FAMILIES = {
       username: 'test_user2',
     },
   },
-    rnaSeqDataByIndividual: {
+  rnaSeqDataByIndividual: {
     I021476_na19678_1: {
       outliers: {
         ENSG00000228198: { isSignificant: true, pValue: 0.0004 },

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -20,7 +20,7 @@ import {
   getAnalysisGroupsGroupedByProjectGuid, getSavedVariantsByGuid, getSortedIndividualsByFamily,
   getMmeResultsByGuid, getMmeSubmissionsByGuid, getHasActiveSearchableSampleByFamily, getSelectableTagTypesByProject,
   getVariantTagsByGuid, getUserOptionsByUsername, getSamplesByFamily, getNotesByFamilyType,
-  getSamplesGroupedByProjectGuid, getVariantTagNotesByFamilyVariants,
+  getSamplesGroupedByProjectGuid, getVariantTagNotesByFamilyVariants, getPhenotypeGeneScoresByIndividual,
 } from 'redux/selectors'
 
 import {
@@ -854,4 +854,21 @@ export const getPageHeaderEntityLinks = createSelector(
     }
     return entityLinks
   },
+)
+
+export const getIndividualPhenotypeGeneScores = createSelector(
+  getGenesById,
+  getPhenotypeGeneScoresByIndividual,
+  (genesById, phenotypeGeneScoresByIndividual) => (
+    Object.entries(phenotypeGeneScoresByIndividual || {}).reduce((acc, [individualGuid, dataByGene]) => ({
+      ...acc,
+      [individualGuid]: Object.entries(dataByGene).reduce((acc2, [geneId, dataByTool]) => ([
+        ...acc2,
+        ...Object.entries(dataByTool).reduce((acc3, [tool, data]) => ([
+          ...acc3,
+          ...data.map(d => ({ ...d, tool, gene: genesById[geneId], rowId: `${geneId}-${tool}-${d.diseaseId}` })),
+        ]), []),
+      ]), []),
+    }), {})
+  ),
 )

--- a/ui/pages/Project/selectors.test.js
+++ b/ui/pages/Project/selectors.test.js
@@ -3,7 +3,7 @@
 import orderBy from 'lodash/orderBy'
 import { getVisibleFamilies, getVisibleFamiliesInSortedOrder, getProjectExportUrls,
   getCaseReviewStatusCounts, getProjectAnalysisGroupFamiliesByGuid, getIndividualTaggedVariants,
-  getDefaultMmeSubmission, getMmeResultsBySubmission, getMmeDefaultContactEmail, getAnalystOptions
+  getDefaultMmeSubmission, getMmeResultsBySubmission, getMmeDefaultContactEmail, getIndividualPhenotypeGeneScores,
 } from './selectors'
 
 import { STATE_WITH_2_FAMILIES } from './fixtures'
@@ -131,5 +131,24 @@ test('getMmeDefaultContactEmail', () => {
     to: 'crowley@unc.edu,test@test.com,test@broadinstitute.org',
     subject: 'OR2M3 Matchmaker Exchange connection (NA19675_1)',
     body: 'Dear James Crowley,\n\nWe recently matched with one of your patients in Matchmaker Exchange harboring variants in OR2M3. Our patient has a homozygous frameshift variant 22:45919065 TTTC>T (hg19) (c.862delC/p.Leu288SerfsTer10), a copy number deletion 1:248367227-248369100 (hg19) (CN=0) and presents with childhood onset short-limb short stature and flexion contracture. Would you be willing to share whether your patient\'s phenotype and genotype match with ours? We are very grateful for your help and look forward to hearing more.\n\nBest wishes,\nTest User',
+  })
+})
+
+test('getIndividualPhenotypeGeneScores', () => {
+  expect(getIndividualPhenotypeGeneScores(STATE_WITH_2_FAMILIES)).toEqual({
+    I021476_na19678_1: [
+      {
+        tool: 'lirical',
+        diseaseId: 'OMIM:618460',
+        diseaseName: 'Khan-Khan-Katsanis syndrome',
+        gene: {
+          geneId: 'ENSG00000228198',
+          geneSymbol: 'OR2M3',
+        },
+        rowId: 'ENSG00000228198-lirical-OMIM:618460',
+        rank: 1,
+        scores: { compositeLR: 0.066, post_test_probability: 0 },
+      },
+    ],
   })
 })

--- a/ui/shared/components/panel/variants/selectors.js
+++ b/ui/shared/components/panel/variants/selectors.js
@@ -55,23 +55,6 @@ export const getIndividualGeneDataByFamilyGene = createSelector(
   ),
 )
 
-export const getIndividualPhenotypeGeneScores = createSelector(
-  getGenesById,
-  getPhenotypeGeneScoresByIndividual,
-  (genesById, phenotypeGeneScoresByIndividual) => (
-    Object.entries(phenotypeGeneScoresByIndividual || {}).reduce((acc, [individualGuid, dataByGene]) => ({
-      ...acc,
-      [individualGuid]: Object.entries(dataByGene).reduce((acc2, [geneId, dataByTool]) => ([
-        ...acc2,
-        ...Object.entries(dataByTool).reduce((acc3, [tool, data]) => ([
-          ...acc3,
-          ...data.map(d => ({ ...d, tool, gene: genesById[geneId], rowId: `${geneId}-${tool}-${d.diseaseId}` })),
-        ]), []),
-      ]), []),
-    }), {})
-  ),
-)
-
 // Saved variant selectors
 export const getSavedVariantTableState = state => (
   state.currentProjectGuid ? state.savedVariantTableState : state.allProjectSavedVariantTableState

--- a/ui/shared/components/panel/variants/selectors.test.js
+++ b/ui/shared/components/panel/variants/selectors.test.js
@@ -6,7 +6,6 @@ import {
   getVisibleSortedSavedVariants,
   getPairedFilteredSavedVariants,
   getIndividualGeneDataByFamilyGene,
-  getIndividualPhenotypeGeneScores,
 } from './selectors'
 
 test('getPairedSelectedSavedVariants', () => {
@@ -74,39 +73,8 @@ test('getVisibleSortedSavedVariants', () => {
   expect(savedVariants[0].variantGuid).toEqual('SV0000002_1248367227_r0390_100')
 })
 
-const RNA_SEQ_PHENOTYPE_PRIORITIZATION_STATE = {
-  rnaSeqDataByIndividual: {
-    I021476_na19678_1: {
-      outliers: {
-        ENSG00000228198: { isSignificant: true, pValue: 0.0004 },
-        ENSG00000164458: { isSignificant: true, pValue: 0.0073 },
-      },
-    },
-    I021474_na19679_1: {
-      outliers: {
-        ENSG00000228198: { isSignificant: true, pValue: 0.01 },
-        ENSG00000164458: { isSignificant: false, pValue: 0.73 },
-      },
-    },
-    I021476_na19678_2: { outliers: { ENSG00000228198: { isSignificant: true, pValue: 0.0214 } } },
-  },
-  phenotypeGeneScoresByIndividual: {
-    I021476_na19678_1: {
-      ENSG00000228198: {
-        lirical: [{
-          diseaseId: 'OMIM:618460',
-          diseaseName: 'Khan-Khan-Katsanis syndrome',
-          rank: 1,
-          scores: { compositeLR: 0.066, post_test_probability: 0 },
-        }],
-      },
-    },
-  },
-  ...STATE_WITH_2_FAMILIES,
-}
-
 test('getIndividualGeneDataByFamilyGene', () => {
-  expect(getIndividualGeneDataByFamilyGene(RNA_SEQ_PHENOTYPE_PRIORITIZATION_STATE)).toEqual({
+  expect(getIndividualGeneDataByFamilyGene(STATE_WITH_2_FAMILIES)).toEqual({
     F011652_1: {
       rnaSeqData: {
         ENSG00000228198: [
@@ -135,24 +103,5 @@ test('getIndividualGeneDataByFamilyGene', () => {
         ENSG00000228198: [{ individualName: 'NA19678_2', isSignificant: true, pValue: 0.0214 }],
       },
     },
-  })
-})
-
-test('getIndividualPhenotypeGeneScores', () => {
-  expect(getIndividualPhenotypeGeneScores(RNA_SEQ_PHENOTYPE_PRIORITIZATION_STATE)).toEqual({
-    I021476_na19678_1: [
-      {
-        tool: 'lirical',
-        diseaseId: 'OMIM:618460',
-        diseaseName: 'Khan-Khan-Katsanis syndrome',
-        gene: {
-          geneId: 'ENSG00000228198',
-          geneSymbol: 'OR2M3',
-        },
-        rowId: 'ENSG00000228198-lirical-OMIM:618460',
-        rank: 1,
-        scores: { compositeLR: 0.066, post_test_probability: 0 },
-      },
-    ],
   })
 })


### PR DESCRIPTION
Not  crucial, but one of the phenotype priority selectors is only used on a project page but is defined in the variant selectors, which makes it hard to track down and hard to understand where it is used and how it is safe to change it.  This moves it to the project specific selector file to make that more clear