### PR TITLE
Refactor check for updating non-feature columns

### DIFF
--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -697,7 +697,6 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
                                                                    record.get(ABSENT_FEATURES_COL))
     update_record = {}
     for k, v in record.items():
-        # allow setting fields to False
         if not v:
             continue
         try:

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -697,7 +697,8 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
                                                                    record.get(ABSENT_FEATURES_COL))
     update_record = {}
     for k, v in record.items():
-        if not v:
+        # allow setting fields to False
+        if not isinstance(v, bool) and not v:
             continue
         try:
             if k == ASSIGNED_ANALYST_COL:
@@ -711,7 +712,7 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
                     or parsed_val == getattr(individual, k)
                 ):
                     parsed_val = None
-            if parsed_val:
+            if isinstance(parsed_val, bool) or parsed_val:
                 update_record[k] = parsed_val
         except (KeyError, ValueError):
             invalid_values[k][v].append(individual.individual_id)

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -707,9 +707,12 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
                     update_record[k] = v
             else:
                 _parsed_val = INDIVIDUAL_METADATA_FIELDS[k](v)
-                if k in {FEATURES_COL, ABSENT_FEATURES_COL} and not has_same_features:
-                    update_record[k] = _parsed_val
-                elif _parsed_val != getattr(individual, k):
+                if (
+                    # different features
+                    (k in {FEATURES_COL, ABSENT_FEATURES_COL} and not has_same_features)
+                    # different value (for non-feature col)
+                    or _parsed_val != getattr(individual, k)
+                ):
                     update_record[k] = _parsed_val
 
         except (KeyError, ValueError):

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -703,16 +703,15 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
             if k == ASSIGNED_ANALYST_COL:
                 if v not in allowed_assigned_analysts:
                     raise ValueError
-                parsed_val = v
+                if v:
+                    update_record[k] = v
             else:
-                parsed_val = INDIVIDUAL_METADATA_FIELDS[k](v)
-                if (
-                    (has_same_features and k in {FEATURES_COL, ABSENT_FEATURES_COL})
-                    or parsed_val == getattr(individual, k)
-                ):
-                    parsed_val = None
-            if parsed_val or parsed_val is False:
-                update_record[k] = parsed_val
+                _parsed_val = INDIVIDUAL_METADATA_FIELDS[k](v)
+                if k in {FEATURES_COL, ABSENT_FEATURES_COL} and not has_same_features:
+                    update_record[k] = _parsed_val
+                elif _parsed_val != getattr(individual, k):
+                    update_record[k] = _parsed_val
+
         except (KeyError, ValueError):
             invalid_values[k][v].append(individual.individual_id)
     return update_record

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -698,7 +698,7 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
     update_record = {}
     for k, v in record.items():
         # allow setting fields to False
-        if not isinstance(v, bool) and not v:
+        if not v:
             continue
         try:
             if k == ASSIGNED_ANALYST_COL:
@@ -712,7 +712,7 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
                     or parsed_val == getattr(individual, k)
                 ):
                     parsed_val = None
-            if isinstance(parsed_val, bool) or parsed_val:
+            if parsed_val or parsed_val is False:
                 update_record[k] = parsed_val
         except (KeyError, ValueError):
             invalid_values[k][v].append(individual.individual_id)

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -706,7 +706,10 @@ def _get_record_updates(record, individual, invalid_values, allowed_assigned_ana
                 parsed_val = v
             else:
                 parsed_val = INDIVIDUAL_METADATA_FIELDS[k](v)
-                if (k not in {FEATURES_COL, ABSENT_FEATURES_COL} and parsed_val == getattr(individual, k)) or has_same_features:
+                if (
+                    (has_same_features and k in {FEATURES_COL, ABSENT_FEATURES_COL})
+                    or parsed_val == getattr(individual, k)
+                ):
                     parsed_val = None
             if parsed_val:
                 update_record[k] = parsed_val

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -640,16 +640,6 @@ class IndividualAPITest(object):
         })
         self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953', 'ENSG00000268903'})
 
-
-class LocalIndividualAPITest(AuthenticationTestCase, IndividualAPITest):
-    fixtures = ['users', '1kg_project', 'reference_data']
-    HAS_EXTERNAL_PROJECT_ACCESS = False
-
-
-class AnvilIndividualAPITest(AnvilAuthenticationTestCase, IndividualAPITest):
-    fixtures = ['users', 'social_auth', '1kg_project', 'reference_data']
-    HAS_EXTERNAL_PROJECT_ACCESS = True
-
     def test_get_record_update(self):
         """
         Test updating the consanguinity field of a mocked individual.
@@ -670,3 +660,12 @@ class AnvilIndividualAPITest(AnvilAuthenticationTestCase, IndividualAPITest):
         )
 
         self.assertEqual(False, updates['consanguinity'])
+
+class LocalIndividualAPITest(AuthenticationTestCase, IndividualAPITest):
+    fixtures = ['users', '1kg_project', 'reference_data']
+    HAS_EXTERNAL_PROJECT_ACCESS = False
+
+
+class AnvilIndividualAPITest(AnvilAuthenticationTestCase, IndividualAPITest):
+    fixtures = ['users', 'social_auth', '1kg_project', 'reference_data']
+    HAS_EXTERNAL_PROJECT_ACCESS = True

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -649,3 +649,24 @@ class LocalIndividualAPITest(AuthenticationTestCase, IndividualAPITest):
 class AnvilIndividualAPITest(AnvilAuthenticationTestCase, IndividualAPITest):
     fixtures = ['users', 'social_auth', '1kg_project', 'reference_data']
     HAS_EXTERNAL_PROJECT_ACCESS = True
+
+    def test_get_record_update(self):
+        """
+        Test updating the consanguinity field of a mocked individual.
+        Specifically test the False case to avoid incidental false-y checks.
+        """
+        individual = mock.Mock()
+        individual.features = []
+        individual.absent_features = []
+        individual.consanguinity = None
+
+        invalid_values = {}
+
+        updates = _get_record_updates(
+            {'consanguinity': False},
+            individual,
+            invalid_values=invalid_values,
+            allowed_assigned_analysts={},
+        )
+
+        self.assertEqual(False, updates['consanguinity'])

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -659,7 +659,8 @@ class IndividualAPITest(object):
             allowed_assigned_analysts={},
         )
 
-        self.assertEqual(False, updates['consanguinity'])
+        # assert that the consanguinity field will be updated
+        self.assertEqual(False, updates.get('consanguinity'))
 
 class LocalIndividualAPITest(AuthenticationTestCase, IndividualAPITest):
     fixtures = ['users', '1kg_project', 'reference_data']

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -514,7 +514,7 @@ class IndividualAPITest(object):
             [{'gene': 'IKBKAP', 'comments': 'multiple panels, no confirm'}, {'gene': 'EHBP1L1'}])
 
         if has_non_hpo_update:
-            self.assertListEqual(response_json['individualsByGuid']['I000002_na19678']['features'], [])
+            self.assertIsNone(response_json['individualsByGuid']['I000002_na19678']['features'])
             self.assertFalse(response_json['individualsByGuid']['I000002_na19678']['affectedRelatives'])
 
         if expected_families:

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -459,7 +459,10 @@ class IndividualAPITest(object):
         self.assertEqual(response.status_code, 200)
 
 
-    def _is_expected_individuals_metadata_upload(self, response, expected_families=False):
+    def _is_expected_individuals_metadata_upload(self, response, expected_families=False, has_non_hpo_update=False):
+        unchanged_individuals = ['NA19679']
+        if not has_non_hpo_update:
+            unchanged_individuals.insert(0, 'NA19678')
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         expected_response = {
@@ -468,9 +471,9 @@ class IndividualAPITest(object):
             'warnings': [
                 "The following HPO terms were not found in seqr's HPO data and will not be added: HP:0004322 (NA19675_1); HP:0100258 (NA19679)",
                 'Unable to find matching ids for 1 individuals. The following entries will not be updated: HG00731',
-                'No changes detected for 2 individuals. The following entries will not be updated: NA19678, NA19679',
+                f'No changes detected for {len(unchanged_individuals)} individuals. The following entries will not be updated: {", ".join(unchanged_individuals)}',
             ],
-            'info': ['1 individuals will be updated'],
+            'info': [f'{2 if has_non_hpo_update else 1} individuals will be updated'],
         }
         if expected_families:
             expected_response['warnings'].insert(1, 'The following invalid values for "assigned_analyst" will not be added: test_user_no_access@test.com (NA19679)')
@@ -486,7 +489,10 @@ class IndividualAPITest(object):
         if expected_families:
             expected_keys.add('familiesByGuid')
         self.assertSetEqual(set(response_json.keys()), expected_keys)
-        self.assertListEqual(list(response_json['individualsByGuid'].keys()), ['I000001_na19675'])
+        updated_individuals = {'I000001_na19675'}
+        if has_non_hpo_update:
+            updated_individuals.add('I000002_na19678')
+        self.assertSetEqual(set(response_json['individualsByGuid'].keys()), updated_individuals)
         self.assertSetEqual(set(response_json['individualsByGuid']['I000001_na19675'].keys()), INDIVIDUAL_FIELDS)
         self.assertListEqual(
             response_json['individualsByGuid']['I000001_na19675']['features'],
@@ -506,6 +512,10 @@ class IndividualAPITest(object):
         self.assertListEqual(
             response_json['individualsByGuid']['I000001_na19675']['candidateGenes'],
             [{'gene': 'IKBKAP', 'comments': 'multiple panels, no confirm'}, {'gene': 'EHBP1L1'}])
+
+        if has_non_hpo_update:
+            self.assertListEqual(response_json['individualsByGuid']['I000002_na19678']['features'], [])
+            self.assertFalse(response_json['individualsByGuid']['I000002_na19678']['affectedRelatives'])
 
         if expected_families:
             self.assertListEqual(list(response_json['familiesByGuid'].keys()), ['F000001_1'])
@@ -549,11 +559,11 @@ class IndividualAPITest(object):
             ]})
 
         # send valid request
-        rows[0] = '1,NA19678,,,,,,,,,,'
+        rows[0] = '1,NA19678,,,,,false,,,,,'
         rows.append('1,NA19675_1,HP:0002017,"HP:0012469 (Infantile spasms);HP:0004322 (Short stature, severe)",F,2000,True,Juvenile onset,"Autosomal dominant inheritance, Sporadic","Finnish, Irish","IKBKAP -- (multiple panels, no confirm), EHBP1L1",test_user_collaborator@test.com')
         f = SimpleUploadedFile('updates.csv', "{}\n{}".format(header, '\n'.join(rows)).encode('utf-8'))
         response = self.client.post(url, data={'f': f})
-        self._is_expected_individuals_metadata_upload(response, expected_families=True)
+        self._is_expected_individuals_metadata_upload(response, expected_families=True, has_non_hpo_update=True)
 
     def test_individuals_metadata_json_table_handler(self):
         url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -10,7 +10,7 @@ from seqr.models import Individual
 from seqr.views.apis.individual_api import edit_individuals_handler, update_individual_handler, \
     delete_individuals_handler, receive_individuals_table_handler, save_individuals_table_handler, \
     receive_individuals_metadata_handler, save_individuals_metadata_table_handler, update_individual_hpo_terms, \
-    get_hpo_terms, get_individual_rna_seq_data
+    get_hpo_terms, get_individual_rna_seq_data, _get_record_updates
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, INDIVIDUAL_FIELDS, \
     INDIVIDUAL_CORE_FIELDS, CORE_INTERNAL_INDIVIDUAL_FIELDS
 

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -10,7 +10,7 @@ from seqr.models import Individual
 from seqr.views.apis.individual_api import edit_individuals_handler, update_individual_handler, \
     delete_individuals_handler, receive_individuals_table_handler, save_individuals_table_handler, \
     receive_individuals_metadata_handler, save_individuals_metadata_table_handler, update_individual_hpo_terms, \
-    get_hpo_terms, get_individual_rna_seq_data, _get_record_updates
+    get_hpo_terms, get_individual_rna_seq_data
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, INDIVIDUAL_FIELDS, \
     INDIVIDUAL_CORE_FIELDS, CORE_INTERNAL_INDIVIDUAL_FIELDS
 
@@ -640,27 +640,6 @@ class IndividualAPITest(object):
         })
         self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953', 'ENSG00000268903'})
 
-    def test_get_record_update(self):
-        """
-        Test updating the consanguinity field of a mocked individual.
-        Specifically test the False case to avoid incidental false-y checks.
-        """
-        individual = mock.Mock()
-        individual.features = []
-        individual.absent_features = []
-        individual.consanguinity = None
-
-        invalid_values = {}
-
-        updates = _get_record_updates(
-            {'consanguinity': False},
-            individual,
-            invalid_values=invalid_values,
-            allowed_assigned_analysts={},
-        )
-
-        # assert that the consanguinity field will be updated
-        self.assertEqual(False, updates.get('consanguinity'))
 
 class LocalIndividualAPITest(AuthenticationTestCase, IndividualAPITest):
     fixtures = ['users', '1kg_project', 'reference_data']


### PR DESCRIPTION
Hi, we had some trouble updating metadata for non-feature columns - and I think a small refactor to this conditional would allow updating non-feature columns. My test was simply trying to update a single individual with a changed notes column.

Keen to understand more about this conditional to see if I'm misunderstanding the requirements for updating :)