### PR TITLE
Bulk create logging error and better logging tests

### DIFF
--- a/seqr/models.py
+++ b/seqr/models.py
@@ -1038,7 +1038,7 @@ class BulkOperationBase(models.Model):
         prefetch_related_objects(models, cls.PARENT_FIELD)
         parent_ids = {getattr(model, cls.PARENT_FIELD).guid for model in models}
         db_update = {
-            'dbEntity': db_entity, 'numEntities': len(models), 'parentEntityIds': parent_ids,
+            'dbEntity': db_entity, 'numEntities': len(models), 'parentEntityIds': sorted(parent_ids),
             'updateType': 'bulk_{}'.format(update_type),
         }
         logger.info(f'{update_type} {db_entity}s', user, db_update=db_update)

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -404,7 +404,7 @@ def load_phenotype_prioritization_data(request):
         return create_json_response({'error': 'File not found: {}'.format(file_path)}, status=400)
 
     try:
-        tool, data_by_project_indiv_id = load_phenotype_prioritization_data_file(file_path)
+        tool, data_by_project_indiv_id = load_phenotype_prioritization_data_file(file_path, request.user)
     except ValueError as e:
         return create_json_response({'error': str(e)}, status=400)
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -431,13 +431,10 @@ class DataManagerAPITest(AuthenticationTestCase):
         self.assertListEqual(
             response.json()['errors'],
             ['File not found: gs://seqr-datasets/v02/GRCh38/RDG_WES_Broad_Internal/v15/sample_qc/final_output/seqr_sample_qc.tsv'])
-        self.assert_json_logs([{
-            'message': '==> gsutil ls gs://seqr-datasets/v02/GRCh38/RDG_WES_Broad_Internal/v15/sample_qc/final_output/seqr_sample_qc.tsv',
-            'user': self.data_manager_user.email,
-        }, {
-            'message': 'BucketNotFoundException: 404 gs://seqr-datsets bucket does not exist.',
-            'user': self.data_manager_user.email,
-        }])
+        self.assert_json_logs(self.data_manager_user, [
+            ('==> gsutil ls gs://seqr-datasets/v02/GRCh38/RDG_WES_Broad_Internal/v15/sample_qc/final_output/seqr_sample_qc.tsv', None),
+            ('BucketNotFoundException: 404 gs://seqr-datsets bucket does not exist.', None),
+        ])
 
         # Test missing columns
         mock_does_file_exist.wait.return_value = 0
@@ -669,6 +666,22 @@ class DataManagerAPITest(AuthenticationTestCase):
         },
     }
 
+    def _has_expected_file_loading_logs(self, file, info=None, warnings=None, additional_logs=None, additional_logs_offset=None):
+        expected_logs = [
+            (f'==> gsutil ls {file}', None),
+            (f'==> gsutil cat {file} | gunzip -c -q - ', None),
+        ] + [(info_log, None) for info_log in info or []] + [
+            (warn_log, {'severity': 'WARNING'}) for warn_log in warnings or []
+        ]
+        if additional_logs:
+            if additional_logs_offset:
+                for log in reversed(additional_logs):
+                    expected_logs.insert(additional_logs_offset, log)
+            else:
+                expected_logs += additional_logs
+
+        self.assert_json_logs(self.data_manager_user, expected_logs)
+
     def _check_rna_sample_model(self, individual_id, data_source, tissue_type):
         rna_samples = Sample.objects.filter(individual_id=individual_id, sample_type='RNA')
         self.assertEqual(len(rna_samples), 1)
@@ -688,9 +701,7 @@ class DataManagerAPITest(AuthenticationTestCase):
     @mock.patch('seqr.views.apis.data_manager_api.load_uploaded_file')
     @mock.patch('seqr.utils.file_utils.subprocess.Popen')
     @mock.patch('seqr.views.apis.data_manager_api.gzip.open')
-    @mock.patch('seqr.views.utils.dataset_utils.logger')
-    @mock.patch('seqr.models.logger')
-    def test_update_rna_seq(self, mock_model_logger, mock_logger, mock_open, mock_subprocess, mock_load_uploaded_file,
+    def test_update_rna_seq(self, mock_open, mock_subprocess, mock_load_uploaded_file,
                             mock_os, mock_datetime, mock_send_slack):
         url = reverse(update_rna_seq)
         self.check_data_manager_login(url)
@@ -749,6 +760,7 @@ class DataManagerAPITest(AuthenticationTestCase):
 
                 # Test already loaded data
                 mock_send_slack.reset_mock()
+                self.reset_logs()
                 _set_file_iter_stdout([header, loaded_data_row])
                 response = self.client.post(url, content_type='application/json', data=json.dumps(body))
                 self.assertEqual(response.status_code, 200)
@@ -758,14 +770,13 @@ class DataManagerAPITest(AuthenticationTestCase):
                 ]
                 warnings = ['Skipped loading for 1 samples already loaded from this file']
                 self.assertDictEqual(response.json(), {'info': info, 'warnings': warnings, 'sampleGuids': [], 'fileName': mock.ANY})
-                mock_logger.info.assert_has_calls([mock.call(info_log, self.data_manager_user) for info_log in info])
-                mock_logger.warning.assert_has_calls([mock.call(warn_log, self.data_manager_user) for warn_log in warnings])
+                self._has_expected_file_loading_logs('gs://rna_data/muscle_samples.tsv.gz', info=info, warnings=warnings)
                 self.assertEqual(model_cls.objects.count(), params['initial_model_count'])
                 mock_send_slack.assert_not_called()
 
                 def _test_basic_data_loading(data, parsed_samples, loaded_samples, project_names, projects,
-                                             individual_id, sample_guid_idx):
-                    mock_logger.reset_mock()
+                                             individual_id, sample_guid_idx, warnings=None, additional_logs=None):
+                    self.reset_logs()
                     _set_file_iter_stdout([header] + data)
                     response = self.client.post(url, content_type='application/json', data=json.dumps(body))
                     self.assertEqual(response.status_code, 200)
@@ -776,49 +787,46 @@ class DataManagerAPITest(AuthenticationTestCase):
                     ]
                     file_name = RNA_FILENAME_TEMPLATE.format(data_type)
                     response_json = response.json()
-                    self.assertDictEqual(response_json, {'info': info, 'warnings': mock.ANY, 'sampleGuids': mock.ANY,
+                    self.assertDictEqual(response_json, {'info': info, 'warnings': warnings or [], 'sampleGuids': mock.ANY,
                                                          'fileName': file_name})
                     new_sample_guid = self._check_rna_sample_model(
                         individual_id=individual_id, data_source='new_muscle_samples.tsv.gz',
                         tissue_type=params.get('created_sample_tissue_type'),
                     )
                     self.assertTrue(new_sample_guid in response_json['sampleGuids'])
-                    info_log_calls = [mock.call(info_log, self.data_manager_user) for info_log in info]
                     if test_round == 0:
-                        info_log_calls.insert(1, mock.call(
-                            'create 1 Samples', self.data_manager_user, db_update={
-                                'dbEntity': 'Sample', 'entityIds': [response_json['sampleGuids'][sample_guid_idx]],
-                                'updateType': 'bulk_create',
-                            }
-                        ))
-                    mock_logger.info.assert_has_calls(info_log_calls)
+                        additional_logs = [('create 1 Samples', {'dbUpdate': {
+                            'dbEntity': 'Sample', 'entityIds': [response_json['sampleGuids'][sample_guid_idx]],
+                            'updateType': 'bulk_create',
+                        }})] + (additional_logs or [])
+                    self._has_expected_file_loading_logs(
+                        'gs://rna_data/new_muscle_samples.tsv.gz', info=info, warnings=warnings,
+                        additional_logs=additional_logs, additional_logs_offset=3)
 
                     return response_json, new_sample_guid
 
                 # Test loading new data
                 mock_open.reset_mock()
-                mock_logger.reset_mock()
+                self.reset_logs()
                 mock_load_uploaded_file.return_value = [['NA19675_D2', 'NA19675_1']]
                 mock_writes = []
                 def mock_write(content):
                     mock_writes.append(content)
                 mock_open.return_value.__enter__.return_value.write.side_effect = mock_write
                 body.update({'ignoreExtraSamples': True, 'mappingFile': {'uploadedFileId': 'map.tsv'}, 'file': RNA_FILE_ID})
-                response_json, new_sample_guid = _test_basic_data_loading(
-                    params['new_data'], params["num_parsed_samples"], 2,
-                    '1kg project nåme with uniçøde, Test Reprocessed Project', 2, 16, 1)
-                self.assertTrue(RNA_SAMPLE_GUID in response_json['sampleGuids'])
+                deleted_count = params.get('deleted_count', params['initial_model_count'])
                 warnings = [f'Skipped loading for the following {len(params["skipped_samples"].split(","))} '
                             f'unmatched samples: {params["skipped_samples"]}']
                 if params.get('extra_warnings'):
                     warnings = params['extra_warnings'] + warnings
-                deleted_count = params.get('deleted_count', params['initial_model_count'])
-                mock_model_logger.info.assert_called_with(
-                    f'delete {model_cls.__name__}s', self.data_manager_user,
-                    db_update={'dbEntity': model_cls.__name__, 'numEntities': deleted_count,
-                               'parentEntityIds': {RNA_SAMPLE_GUID}, 'updateType': 'bulk_delete'}
-                )
-                mock_logger.warning.assert_has_calls([mock.call(warn_log, self.data_manager_user) for warn_log in warnings])
+                response_json, new_sample_guid = _test_basic_data_loading(
+                    params['new_data'], params["num_parsed_samples"], 2,
+                    '1kg project nåme with uniçøde, Test Reprocessed Project', 2, 16, 1, warnings=warnings, additional_logs=[
+                        (f'delete {model_cls.__name__}s', {'dbUpdate': {
+                            'dbEntity': model_cls.__name__, 'numEntities': deleted_count,
+                           'parentEntityIds': [RNA_SAMPLE_GUID], 'updateType': 'bulk_delete'}}),
+                    ])
+                self.assertTrue(RNA_SAMPLE_GUID in response_json['sampleGuids'])
                 self.assertEqual(mock_send_slack.call_count, 2)
                 mock_send_slack.assert_has_calls([
                     mock.call(
@@ -851,9 +859,7 @@ class DataManagerAPITest(AuthenticationTestCase):
 
     @mock.patch('seqr.views.apis.data_manager_api.os')
     @mock.patch('seqr.views.apis.data_manager_api.gzip.open')
-    @mock.patch('seqr.views.apis.data_manager_api.logger')
-    @mock.patch('seqr.models.logger')
-    def test_load_rna_seq_sample_data(self, mock_model_logger, mock_logger, mock_open, mock_os):
+    def test_load_rna_seq_sample_data(self, mock_open, mock_os):
         mock_os.path.join.side_effect = lambda *args: '/'.join(args[1:])
 
         url = reverse(load_rna_seq_sample_data, args=[RNA_SAMPLE_GUID])
@@ -863,6 +869,7 @@ class DataManagerAPITest(AuthenticationTestCase):
             with self.subTest(data_type):
                 model_cls = params['model_cls']
                 model_cls.objects.all().delete()
+                self.reset_logs()
                 mock_open.return_value.__enter__.return_value.__iter__.return_value = params['parsed_file_data']
                 file_name = RNA_FILENAME_TEMPLATE.format(data_type)
 
@@ -878,13 +885,13 @@ class DataManagerAPITest(AuthenticationTestCase):
 
                 mock_open.assert_called_with(file_name, 'rt')
 
-                mock_logger.info.assert_called_with('Loading outlier data for NA19675_D2', self.data_manager_user)
-                mock_model_logger.info.assert_called_with(
-                    f'create {model_cls.__name__}s', self.data_manager_user, db_update={
-                        'dbEntity': model_cls.__name__, 'numEntities': 2, 'parentEntityIds': {RNA_SAMPLE_GUID},
+                self.assert_json_logs(self.data_manager_user, [
+                    ('Loading outlier data for NA19675_D2', None),
+                    (f'create {model_cls.__name__}s', {'dbUpdate': {
+                        'dbEntity': model_cls.__name__, 'numEntities': 2, 'parentEntityIds': [RNA_SAMPLE_GUID],
                         'updateType': 'bulk_create',
-                    }
-                )
+                    }}),
+                ])
 
                 self.assertListEqual(list(params['get_models_json'](models)), params['expected_models_json'])
 
@@ -893,8 +900,7 @@ class DataManagerAPITest(AuthenticationTestCase):
         return ['\t'.join(line).encode('utf-8') for line in data]
 
     @mock.patch('seqr.utils.file_utils.subprocess.Popen')
-    @mock.patch('seqr.models.logger')
-    def test_load_phenotype_prioritization_data(self, mock_logger, mock_subprocess):
+    def test_load_phenotype_prioritization_data(self, mock_subprocess):
         url = reverse(load_phenotype_prioritization_data)
         self.check_data_manager_login(url)
 
@@ -947,6 +953,7 @@ class DataManagerAPITest(AuthenticationTestCase):
         # Test a successful operation
         mock_subprocess.reset_mock()
         mock_subprocess.return_value.stdout = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + LIRICAL_DATA)
+        self.reset_logs()
         response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 200)
         info = [
@@ -955,16 +962,23 @@ class DataManagerAPITest(AuthenticationTestCase):
             'Project Test Reprocessed Project: loaded 1 record(s)'
         ]
         self.assertEqual(response.json()['info'], info)
-        db_update = {'dbEntity': 'PhenotypePrioritization', 'numEntities': 2,
-                     'parentEntityIds': {'I000002_na19678', 'I000015_na20885'}, 'updateType': 'bulk_create'}
-        mock_logger.info.assert_called_with('create PhenotypePrioritizations', self.data_manager_user, db_update=db_update)
+        self._has_expected_file_loading_logs('gs://seqr_data/lirical_data.tsv.gz', additional_logs=[
+            ('delete PhenotypePrioritizations', {'dbUpdate': {
+                'dbEntity': 'PhenotypePrioritization', 'numEntities': 1, 'updateType': 'bulk_delete',
+                'parentEntityIds': ['I000002_na19678'],
+            }}),
+            ('create PhenotypePrioritizations', {'dbUpdate': {
+                'dbEntity': 'PhenotypePrioritization', 'numEntities': 2, 'updateType': 'bulk_create',
+                'parentEntityIds': ['I000002_na19678', 'I000015_na20885'],
+            }}),
+        ])
         saved_data = _get_json_for_models(PhenotypePrioritization.objects.filter(tool='lirical').order_by('id'),
                                           nested_fields=[{'fields': ('individual', 'guid'), 'key': 'individualGuid'}])
         self.assertListEqual(saved_data, EXPECTED_LIRICAL_DATA)
         mock_subprocess.assert_called_with('gsutil cat gs://seqr_data/lirical_data.tsv.gz | gunzip -c -q - ', stdout=-1, stderr=-2, shell=True)
 
         # Test uploading new data
-        mock_logger.reset_mock()
+        self.reset_logs()
         mock_subprocess.return_value.stdout = self._join_data(PHENOTYPE_PRIORITIZATION_HEADER + UPDATE_LIRICAL_DATA)
         response = self.client.post(url, content_type='application/json', data=json.dumps(request_body))
         self.assertEqual(response.status_code, 200)
@@ -973,14 +987,15 @@ class DataManagerAPITest(AuthenticationTestCase):
             'Project 1kg project nåme with uniçøde: deleted 1 record(s), loaded 2 record(s)'
         ]
         self.assertEqual(response.json()['info'], info)
-        mock_logger.info.assert_has_calls([
-            mock.call('delete PhenotypePrioritizations', self.data_manager_user, db_update={
-                'dbEntity': 'PhenotypePrioritization', 'numEntities': 1,
-                'parentEntityIds': {'I000002_na19678'}, 'updateType': 'bulk_delete',
-            }),
-            mock.call('create PhenotypePrioritizations', self.data_manager_user,
-                      db_update={'dbEntity': 'PhenotypePrioritization', 'numEntities': 2,
-                     'parentEntityIds': {'I000002_na19678'}, 'updateType': 'bulk_create'}),
+        self._has_expected_file_loading_logs('gs://seqr_data/lirical_data.tsv.gz', additional_logs=[
+            ('delete PhenotypePrioritizations', {'dbUpdate': {
+                'dbEntity': 'PhenotypePrioritization', 'numEntities': 1, 'updateType': 'bulk_delete',
+                'parentEntityIds': ['I000002_na19678'],
+            }}),
+            ('create PhenotypePrioritizations', {'dbUpdate': {
+                'dbEntity': 'PhenotypePrioritization', 'numEntities': 2, 'updateType': 'bulk_create',
+                'parentEntityIds': ['I000002_na19678'],
+            }}),
         ])
         saved_data = _get_json_for_models(PhenotypePrioritization.objects.filter(tool='lirical'),
                                           nested_fields=[{'fields': ('individual', 'guid'), 'key': 'individualGuid'}])

--- a/seqr/views/utils/file_utils.py
+++ b/seqr/views/utils/file_utils.py
@@ -68,7 +68,7 @@ def _parse_excel_string_cell(cell):
 def get_temp_upload_directory():
     upload_directory = os.path.join(tempfile.gettempdir(), 'temp_uploads')
     if not os.path.isdir(upload_directory):
-        logger.info("Creating directory: " + upload_directory)
+        logger.debug("Creating directory: " + upload_directory)
         os.makedirs(upload_directory)
     return upload_directory
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -233,18 +233,11 @@ class AuthenticationTestCase(TestCase):
         self._log_stream.seek(0)
 
     def assert_json_logs(self, user, expected):
-        logs_iter = iter(self._log_stream.getvalue().split('\n'))
-        for message, extra in expected:
-            log = next(self._safe_load_json(row) for row in logs_iter)
-            self.assertDictEqual(
-                log, {'timestamp': mock.ANY, 'severity': 'INFO', 'user': user.email, 'message': message, **(extra or {})})
-
-    @staticmethod
-    def _safe_load_json(data):
-        try:
-            return json.loads(data)
-        except json.decoder.JSONDecodeError:
-            return None
+        logs = self._log_stream.getvalue().split('\n')
+        for i, (message, extra) in enumerate(expected):
+            self.assertDictEqual(json.loads(logs[i]), {
+                'timestamp': mock.ANY, 'severity': 'INFO', 'user': user.email, 'message': message, **(extra or {}),
+            })
 
 
 TEST_WORKSPACE_NAMESPACE = 'my-seqr-billing'


### PR DESCRIPTION
Based on the suggestion in the ticket I explored a few options for how to best test logging and ultimately decided to add a helper to our test function that redirects our log stream to a string buffer that we can access at any point in the. tests. This means we are able to test whatever the actual log output is. 

I then fixed the logging bug reported in the ticket, as well as a few other small bugs I caught once we actually had good testing for logs. I think eventually we will want to make these updates for everywhere in our tests that are mocking loggers, but that seems out of scope for this PR