### PR TITLE
Rename es-specific search helpers

### DIFF
--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -10,8 +10,8 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants
 from seqr.views.utils.variant_utils import reset_cached_search_results
 from seqr.utils.search.add_data_utils import add_new_search_samples
-from seqr.utils.search.utils import get_es_variants_for_variant_tuples, get_single_variant
-from seqr.utils.xpos_utils import get_xpos
+from seqr.utils.search.utils import get_variants_for_variant_ids, get_single_variant
+from seqr.utils.xpos_utils import get_xpos, get_chrom_pos
 
 logger = logging.getLogger(__name__)
 
@@ -46,12 +46,18 @@ class Command(BaseCommand):
         saved_variants_to_lift, hg37_to_hg38_xpos, lift_failed = _get_variants_to_lift(saved_variants)
 
         saved_variants_map = defaultdict(list)
+        variant_ids = []
         for v in saved_variants_to_lift:
             if hg37_to_hg38_xpos.get(v['xpos']):
                 variant_model = saved_variant_models_by_guid[v['variantGuid']]
-                saved_variants_map[(hg37_to_hg38_xpos[v['xpos']], v['ref'], v['alt'])].append(variant_model)
+                xpos_38 = hg37_to_hg38_xpos[v['xpos']]
+                saved_variants_map[(xpos_38, v['ref'], v['alt'])].append(variant_model)
 
-        es_variants = get_es_variants_for_variant_tuples(expected_families, list(saved_variants_map.keys()))
+                chrom, pos = get_chrom_pos(xpos_38)
+                variant_ids.append(f"{'MT' if chrom == 'M' else chrom}-{pos}-{v['ref']}-{v['alt']}")
+
+        es_variants = get_variants_for_variant_ids(
+            expected_families, variant_ids, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
 
         missing_variants =_validate_missing_variants(es_variants, saved_variants_map)
 

--- a/seqr/management/commands/lift_project_to_hg38.py
+++ b/seqr/management/commands/lift_project_to_hg38.py
@@ -10,7 +10,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants
 from seqr.views.utils.variant_utils import reset_cached_search_results
 from seqr.utils.search.add_data_utils import add_new_search_samples
-from seqr.utils.search.utils import get_es_variants_for_variant_tuples, get_single_es_variant
+from seqr.utils.search.utils import get_es_variants_for_variant_tuples, get_single_variant
 from seqr.utils.xpos_utils import get_xpos
 
 logger = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ def _update_saved_variants(es_variants, saved_variants_map):
                 variant_id, missing_saved_variants[0].xpos,
                 ', '.join(['{} ({})'.format(v.family.guid, v.guid) for v in missing_saved_variants]))
             )) == 'y':
-                var = get_single_es_variant([v.family for v in saved_variant_models], variant_id, return_all_queried_families=True)
+                var = get_single_variant([v.family for v in saved_variant_models], variant_id, return_all_queried_families=True)
                 missing_family_count += len(missing_saved_variants)
             else:
                 raise CommandError('Error: unable to find family data for lifted over variant')

--- a/seqr/management/commands/lift_variant_to_hg38.py
+++ b/seqr/management/commands/lift_variant_to_hg38.py
@@ -2,7 +2,7 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 
 from seqr.models import SavedVariant
-from seqr.utils.search.utils import get_single_es_variant
+from seqr.utils.search.utils import get_single_variant
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class Command(BaseCommand):
                 saved_variant.xpos, saved_variant.ref, saved_variant.alt, variant_id)) != 'y':
             raise CommandError('Error: user did not confirm')
 
-        es_variant = get_single_es_variant([saved_variant.family], variant_id, return_all_queried_families=True)
+        es_variant = get_single_variant([saved_variant.family], variant_id, return_all_queried_families=True)
 
         saved_variant.xpos = es_variant['xpos']
         saved_variant.ref = es_variant['ref']

--- a/seqr/management/tests/lift_project_to_hg38_tests.py
+++ b/seqr/management/tests/lift_project_to_hg38_tests.py
@@ -44,7 +44,7 @@ class LiftProjectToHg38Test(TestCase):
         return Sample.objects.filter(elasticsearch_index=ELASTICSEARCH_INDEX, is_active=True).count()
 
     @mock.patch('seqr.management.commands.lift_project_to_hg38.input')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_variants_for_variant_ids')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.LiftOver')
     def test_command(self, mock_liftover, mock_get_es_variants, mock_input, mock_get_es_samples, mock_logger):
         mock_get_es_samples.return_value = SAMPLE_IDS
@@ -79,8 +79,8 @@ class LiftProjectToHg38Test(TestCase):
 
         families = {family for family in Family.objects.filter(pk__in = [1, 2])}
         self.assertSetEqual(families, mock_get_es_variants.call_args.args[0])
-        self.assertSetEqual(set([(1001627057, 'G', 'C'), (21003343400, 'GAGA', 'G'), (1248203925, 'TC', 'T'),
-                                 (1046394160, 'G', 'A')]), set(mock_get_es_variants.call_args.args[1]))
+        self.assertSetEqual({'1-1627057-G-C', '21-3343400-GAGA-G', '1-248203925-TC-T', '1-46394160-G-A'},
+                            set(mock_get_es_variants.call_args.args[1]))
 
         # Test discontinue on lifted variants
         mock_logger.reset_mock()
@@ -154,7 +154,7 @@ class LiftProjectToHg38Test(TestCase):
         mock_get_es_samples.assert_called_with(ELASTICSEARCH_INDEX, 'samples', mock.ANY)
 
     @mock.patch('seqr.management.commands.lift_project_to_hg38.input')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_variants_for_variant_ids')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.get_single_variant')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.LiftOver')
     def test_command_other_exceptions(self, mock_liftover, mock_single_es_variants,
@@ -199,7 +199,7 @@ class LiftProjectToHg38Test(TestCase):
         self.assertSetEqual(mock_get_es_variants.call_args.args[0], families)
         self.assertSetEqual(
             set(mock_get_es_variants.call_args.args[1]),
-            {(1001627057, 'G', 'C'), (21003343400, 'GAGA', 'G'), (1248203925, 'TC', 'T'), (1046394160, 'G', 'A')}
+            {'1-1627057-G-C', '21-3343400-GAGA-G', '1-248203925-TC-T', '1-46394160-G-A'}
         )
 
         # Test discontinue on missing family data while updating the saved variants

--- a/seqr/management/tests/lift_project_to_hg38_tests.py
+++ b/seqr/management/tests/lift_project_to_hg38_tests.py
@@ -155,7 +155,7 @@ class LiftProjectToHg38Test(TestCase):
 
     @mock.patch('seqr.management.commands.lift_project_to_hg38.input')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.get_es_variants_for_variant_tuples')
-    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_single_es_variant')
+    @mock.patch('seqr.management.commands.lift_project_to_hg38.get_single_variant')
     @mock.patch('seqr.management.commands.lift_project_to_hg38.LiftOver')
     def test_command_other_exceptions(self, mock_liftover, mock_single_es_variants,
             mock_get_es_variants, mock_input, mock_get_es_samples, mock_logger):

--- a/seqr/management/tests/lift_variant_to_hg38_tests.py
+++ b/seqr/management/tests/lift_variant_to_hg38_tests.py
@@ -16,7 +16,7 @@ class LiftVariantToHg38Test(TestCase):
 
     @mock.patch('seqr.management.commands.lift_variant_to_hg38.input')
     @mock.patch('seqr.management.commands.lift_variant_to_hg38.logger')
-    @mock.patch('seqr.management.commands.lift_variant_to_hg38.get_single_es_variant')
+    @mock.patch('seqr.management.commands.lift_variant_to_hg38.get_single_variant')
     def test_command(self, mock_single_es_variants, mock_logger, mock_input):
         # Test user did not confirm.
         mock_input.return_value = 'n'

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -14,7 +14,7 @@ class ReloadSavedVariantJsonTest(TestCase):
     fixtures = ['users', '1kg_project']
 
     @mock.patch('logging.getLogger')
-    @mock.patch('seqr.views.utils.variant_utils.get_es_variants_for_variant_ids')
+    @mock.patch('seqr.views.utils.variant_utils.get_variants_for_variant_ids')
     def test_with_param_command(self, mock_get_variants, mock_get_logger):
         mock_get_variants.side_effect = lambda families, variant_ids, **kwargs: \
             [{'variantId': variant_id, 'familyGuids': [family.guid for family in families]}

--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -12,8 +12,8 @@ from urllib3.exceptions import ReadTimeoutError
 from urllib3_mock import Responses
 
 from seqr.models import Family, Sample, VariantSearch, VariantSearchResults
-from seqr.utils.search.utils import get_es_variants_for_variant_tuples, get_single_es_variant, get_es_variants, \
-    get_es_variant_gene_counts, get_es_variants_for_variant_ids, InvalidSearchException
+from seqr.utils.search.utils import get_es_variants_for_variant_tuples, get_single_variant, query_variants, \
+    get_variant_query_gene_counts, get_variants_for_variant_ids, InvalidSearchException
 from seqr.utils.search.elasticsearch.es_search import _get_family_affected_status, _liftover_grch38_to_grch37
 from seqr.utils.search.elasticsearch.es_utils import InvalidIndexException
 from seqr.views.utils.test_utils import PARSED_VARIANTS, PARSED_SV_VARIANT, PARSED_SV_WGS_VARIANT,\
@@ -1415,7 +1415,7 @@ class EsUtilsTest(TestCase):
     @urllib3_responses.activate
     def test_get_es_variants_for_variant_ids(self):
         setup_responses()
-        get_es_variants_for_variant_ids(self.families, ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL'])
+        get_variants_for_variant_ids(self.families, ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL'])
         self.assertExecutedSearch(
             filters=[{'terms': {'variantId': ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL']}}],
             size=9, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME, SV_INDEX_NAME]), unsorted=True,
@@ -1424,14 +1424,14 @@ class EsUtilsTest(TestCase):
     @urllib3_responses.activate
     def test_get_single_es_variant(self):
         setup_responses()
-        variant = get_single_es_variant(self.families, '2-103343353-GAGA-G')
+        variant = get_single_variant(self.families, '2-103343353-GAGA-G')
         self.assertDictEqual(variant, PARSED_NO_SORT_VARIANTS[1])
         self.assertExecutedSearch(
             filters=[{'terms': {'variantId': ['2-103343353-GAGA-G']}}],
             size=3, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME, SV_INDEX_NAME]), unsorted=True,
         )
 
-        variant = get_single_es_variant(self.families, '1-248367227-TC-T', return_all_queried_families=True)
+        variant = get_single_variant(self.families, '1-248367227-TC-T', return_all_queried_families=True)
         all_family_variant = deepcopy(PARSED_NO_SORT_VARIANTS[0])
         all_family_variant['familyGuids'] = ['F000002_2', 'F000003_3', 'F000005_5']
         all_family_variant['genotypes']['I000004_hg00731'] = {
@@ -1444,7 +1444,7 @@ class EsUtilsTest(TestCase):
         )
 
         with self.assertRaises(InvalidSearchException) as cm:
-            get_single_es_variant(self.families, '10-10334333-A-G')
+            get_single_variant(self.families, '10-10334333-A-G')
         self.assertEqual(str(cm.exception), 'Variant 10-10334333-A-G not found')
 
     @mock.patch('seqr.utils.search.elasticsearch.es_search.MAX_NO_LOCATION_COMP_HET_FAMILIES', 1)
@@ -1459,12 +1459,12 @@ class EsUtilsTest(TestCase):
         results_model.families.set(Family.objects.filter(family_id='no_individuals'))
 
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(str(cm.exception), 'No es index found for families no_individuals')
 
         results_model.families.set(Family.objects.all())
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(
             str(cm.exception),
             'Searching across multiple genome builds is not supported. Remove projects with differing genome builds from search: 37 - 1kg project nåme with uniçøde, Test Reprocessed Project; 38 - Non-Analyst Project',
@@ -1474,7 +1474,7 @@ class EsUtilsTest(TestCase):
         search_model.save()
         results_model.families.set([family for family in self.families if family.guid == 'F000005_5'])
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(
             str(cm.exception), 'Inheritance based search is disabled in families with no data loaded for affected individuals',
         )
@@ -1483,7 +1483,7 @@ class EsUtilsTest(TestCase):
         search_model.save()
         results_model.families.set([family for family in self.families if family.guid == 'F000003_3'])
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(
             str(cm.exception),
             'Inheritance based search is disabled in families with no data loaded for affected individuals',
@@ -1492,26 +1492,26 @@ class EsUtilsTest(TestCase):
         search_model.search['inheritance']['filter'] = {'genotype': {'I000004_hg00731': 'ref_ref'}}
         search_model.save()
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(str(cm.exception), 'Invalid custom inheritance')
 
         search_model.search['inheritance']['filter'] = {}
         search_model.search['annotations'] = {'structural': ['DEL']}
         search_model.save()
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         error = 'Unable to search against dataset type "SV". This may be because inheritance based search is disabled in families with no loaded affected individuals'
         self.assertEqual(str(cm.exception), error)
 
         results_model.families.set(self.families)
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model, page=200)
+            query_variants(results_model, page=200)
         self.assertEqual(str(cm.exception), 'Unable to load more than 10000 variants (20000 requested)')
 
         search_model.search = {'inheritance': {'mode': 'compound_het'}}
         search_model.save()
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(
             str(cm.exception),
             'Annotations must be specified to search for compound heterozygous variants')
@@ -1519,42 +1519,42 @@ class EsUtilsTest(TestCase):
         search_model.search['annotations'] = {'frameshift': ['frameshift_variant']}
         search_model.save()
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(
             str(cm.exception),
             'Location must be specified to search for compound heterozygous variants across many families')
 
         search_model.search['locus'] = {'rawVariantItems': 'chr2-A-C'}
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model, sort='cadd', num_results=2)
+            query_variants(results_model, sort='cadd', num_results=2)
         self.assertEqual(str(cm.exception), 'Invalid variants: chr2-A-C')
 
         search_model.search['locus']['rawVariantItems'] = 'rs9876,chr2-1234-A-C'
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model, sort='cadd', num_results=2)
+            query_variants(results_model, sort='cadd', num_results=2)
         self.assertEqual(str(cm.exception), 'Invalid variant notation: found both variant IDs and rsIDs')
 
         search_model.search['locus']['rawItems'] = 'chr27:1234-5678,2:40-400000000, ENSG00012345'
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model, sort='cadd', num_results=2)
+            query_variants(results_model, sort='cadd', num_results=2)
         self.assertEqual(str(cm.exception), 'Invalid genes/intervals: chr27:1234-5678, chr2:40-400000000, ENSG00012345')
 
         search_model.search['locus']['rawItems'] = 'DDX11L1'
         search_model.save()
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(
             str(cm.exception),
             'This search returned too many compound heterozygous variants. Please add stricter filters')
 
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variant_gene_counts(results_model, None)
+            get_variant_query_gene_counts(results_model, None)
         self.assertEqual(str(cm.exception), 'This search returned too many genes')
 
         search_model.search = {'qualityFilter': {'min_gq': 7}}
         search_model.save()
         with self.assertRaises(Exception) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(str(cm.exception), 'Invalid gq filter 7')
 
         search_model.search = {}
@@ -1567,7 +1567,7 @@ class EsUtilsTest(TestCase):
             456: {'running_time_in_nanos': 10 ** 12},
         }})
         with self.assertRaises(ConnectionTimeout):
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertListEqual(
             [call.request.url for call in urllib3_responses.calls],
             ['/_msearch', '/_tasks?actions=%2Asearch&group_by=parents'])
@@ -1581,7 +1581,7 @@ class EsUtilsTest(TestCase):
         ]}, method=urllib3_responses.POST)
 
         with self.assertRaises(TransportError) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertDictEqual(
             cm.exception.info,
             {'type': 'search_phase_execution_exception', 'root_cause': [{'type': 'too_many_clauses'}]})
@@ -1590,12 +1590,12 @@ class EsUtilsTest(TestCase):
         urllib3_responses.add(
             urllib3_responses.GET, f'/{INDEX_NAME},{MITO_WGS_INDEX_NAME},{SV_INDEX_NAME}/_mapping', body=Exception('Connection error'))
         with self.assertRaises(InvalidIndexException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(str(cm.exception), 'test_index,test_index_mito_wgs,test_index_sv - Error accessing index: Connection error')
 
         urllib3_responses.replace_json(f'/{INDEX_NAME},{MITO_WGS_INDEX_NAME},{SV_INDEX_NAME}/_mapping', {})
         with self.assertRaises(InvalidIndexException) as cm:
-            get_es_variants(results_model)
+            query_variants(results_model)
         self.assertEqual(str(cm.exception), 'Could not find expected indices: test_index_sv, test_index_mito_wgs, test_index')
 
     @mock.patch('seqr.utils.search.utils.MAX_VARIANTS')
@@ -1608,7 +1608,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertDictEqual(variants[0], PARSED_VARIANTS[0])
         self.assertDictEqual(variants[1], PARSED_VARIANTS[1])
@@ -1620,13 +1620,13 @@ class EsUtilsTest(TestCase):
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY, ALL_INHERITANCE_QUERY])
 
         # does not save non-consecutive pages
-        variants, total_results = get_es_variants(results_model, page=3, num_results=2)
+        variants, total_results = query_variants(results_model, page=3, num_results=2)
         self.assertEqual(total_results, 5)
         self.assertCachedResults(results_model, {'all_results': variants, 'total_results': 5})
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY, ALL_INHERITANCE_QUERY], start_index=4, size=2)
 
         # test pagination
-        variants, total_results = get_es_variants(results_model, page=2, num_results=2)
+        variants, total_results = query_variants(results_model, page=2, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertEqual(total_results, 5)
         self.assertCachedResults(results_model, {'all_results': PARSED_VARIANTS + PARSED_VARIANTS, 'total_results': 5})
@@ -1634,7 +1634,7 @@ class EsUtilsTest(TestCase):
 
         # test does not re-fetch page
         urllib3_responses.reset()
-        variants, total_results = get_es_variants(results_model, page=1, num_results=3)
+        variants, total_results = query_variants(results_model, page=1, num_results=3)
         self.assertEqual(len(variants), 3)
         self.assertListEqual(variants, PARSED_VARIANTS + PARSED_VARIANTS[:1])
         self.assertEqual(total_results, 5)
@@ -1643,11 +1643,11 @@ class EsUtilsTest(TestCase):
         setup_responses()
         mock_max_variants.__int__.return_value = 5
         with self.assertRaises(InvalidSearchException) as cm:
-            get_es_variants(results_model, page=1, num_results=2, load_all=True)
+            query_variants(results_model, page=1, num_results=2, load_all=True)
         self.assertEqual(str(cm.exception), 'Too many variants to load. Please refine your search and try again')
 
         mock_max_variants.__int__.return_value = 100
-        variants, _ = get_es_variants(results_model, page=1, num_results=2, load_all=True)
+        variants, _ = query_variants(results_model, page=1, num_results=2, load_all=True)
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY, ALL_INHERITANCE_QUERY], start_index=4, size=1)
         self.assertEqual(len(variants), 5)
         self.assertListEqual(variants, PARSED_VARIANTS + PARSED_VARIANTS + PARSED_VARIANTS[:1])
@@ -1655,7 +1655,7 @@ class EsUtilsTest(TestCase):
         # test does not re-fetch once all loaded
         urllib3_responses.reset()
         mock_max_variants.__int__.return_value = 1
-        variants, _ = get_es_variants(results_model, page=1, num_results=2, load_all=True)
+        variants, _ = query_variants(results_model, page=1, num_results=2, load_all=True)
         self.assertEqual(len(variants), 5)
         self.assertListEqual(variants, PARSED_VARIANTS + PARSED_VARIANTS + PARSED_VARIANTS[:1])
 
@@ -1690,7 +1690,7 @@ class EsUtilsTest(TestCase):
 
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
-        variants, total_results = get_es_variants(results_model, sort='cadd', num_results=2)
+        variants, total_results = query_variants(results_model, sort='cadd', num_results=2)
 
         self.assertListEqual(variants, PARSED_CADD_VARIANTS)
         self.assertEqual(total_results, 5)
@@ -1944,7 +1944,7 @@ class EsUtilsTest(TestCase):
         ], sort=[{'cadd_PHRED': {'order': 'desc', 'unmapped_type': 'keyword'}}, 'xpos', 'variantId'])
 
         # Test sort does not error on pagination
-        get_es_variants(results_model, sort='cadd', num_results=2, page=2)
+        query_variants(results_model, sort='cadd', num_results=2, page=2)
 
     @urllib3_responses.activate
     def test_sv_get_es_variants(self):
@@ -1959,7 +1959,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, _ = get_es_variants(results_model, num_results=2)
+        variants, _ = query_variants(results_model, num_results=2)
 
         self.assertListEqual(variants, [PARSED_SV_VARIANT])
         self.assertExecutedSearch(filters=[
@@ -2005,7 +2005,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, _ = get_es_variants(results_model, num_results=2)
+        variants, _ = query_variants(results_model, num_results=2)
         self.assertListEqual(variants, [PARSED_SV_WGS_VARIANT])
 
         self.assertExecutedSearch(filters=[
@@ -2034,7 +2034,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, _ = get_es_variants(results_model, num_results=5)
+        variants, _ = query_variants(results_model, num_results=5)
         self.assertListEqual(variants, [PARSED_SV_VARIANT] + PARSED_NO_CONSEQUENCE_FILTER_VARIANTS + [PARSED_MITO_VARIANT])
         path_filter = {'terms': {
             'clinvar_clinical_significance': [
@@ -2052,7 +2052,7 @@ class EsUtilsTest(TestCase):
         search_model.save()
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
 
-        get_es_variants(results_model, num_results=5)
+        query_variants(results_model, num_results=5)
         filter = {'bool': {'should': [{'terms': {'transcriptConsequenceTerms': ['frameshift_variant']}}, path_filter]}}
         self.assertExecutedSearches([
             dict(filters=[filter], start_index=0, size=5, index=MITO_WGS_INDEX_NAME),
@@ -2064,7 +2064,7 @@ class EsUtilsTest(TestCase):
         search_model.save()
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
 
-        get_es_variants(results_model, num_results=5)
+        query_variants(results_model, num_results=5)
         self.assertExecutedSearch(
             filters=[{'bool': {'should': [{'terms': {
                 'transcriptConsequenceTerms': ['DEL', 'DUP_LOF', 'INTRAGENIC_EXON_DUP', 'MSV_EXON_OVERLAP', 'MSV_EXON_OVR']
@@ -2081,7 +2081,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(guid='F000002_2'))
 
-        get_es_variants(results_model, num_results=2)
+        query_variants(results_model, num_results=2)
         self.assertExecutedSearch(filters=[{'bool': {
             'must': [{'bool': {
                 'minimum_should_match': 1,
@@ -2111,7 +2111,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 1)
         self.assertListEqual(variants, [PARSED_COMPOUND_HET_VARIANTS])
         self.assertEqual(total_results, 1)
@@ -2130,7 +2130,7 @@ class EsUtilsTest(TestCase):
 
         # test pagination does not fetch
         urllib3_responses.reset()
-        get_es_variants(results_model, page=2, num_results=2)
+        query_variants(results_model, page=2, num_results=2)
 
     @urllib3_responses.activate
     def test_compound_het_get_es_variants_secondary_annotation(self):
@@ -2145,7 +2145,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 1)
         self.assertListEqual(variants, [PARSED_COMPOUND_HET_VARIANTS])
         self.assertEqual(total_results, 1)
@@ -2171,7 +2171,7 @@ class EsUtilsTest(TestCase):
 
         # test pagination does not fetch
         urllib3_responses.reset()
-        get_es_variants(results_model, page=2, num_results=2)
+        query_variants(results_model, page=2, num_results=2)
 
         # variants require both primary and secondary annotations
         setup_responses()
@@ -2180,7 +2180,7 @@ class EsUtilsTest(TestCase):
         search_model.save()
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertIsNone(variants)
         self.assertEqual(total_results, 0)
 
@@ -2204,7 +2204,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertDictEqual(variants[0], PARSED_VARIANTS[0])
         self.assertDictEqual(variants[1][0], PARSED_COMPOUND_HET_VARIANTS[0])
@@ -2236,7 +2236,7 @@ class EsUtilsTest(TestCase):
 
         # test pagination
 
-        variants, total_results = get_es_variants(results_model, page=3, num_results=2)
+        variants, total_results = query_variants(results_model, page=3, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertDictEqual(variants[0], PARSED_VARIANTS[0])
         self.assertDictEqual(variants[1], PARSED_MULTI_SAMPLE_VARIANT)
@@ -2256,7 +2256,7 @@ class EsUtilsTest(TestCase):
         self.assertExecutedSearches([dict(filters=[pass_filter_query, ANNOTATION_QUERY, RECESSIVE_INHERITANCE_QUERY], start_index=2, size=4)])
 
         urllib3_responses.reset()
-        get_es_variants(results_model, page=2, num_results=2)
+        query_variants(results_model, page=2, num_results=2)
 
     @urllib3_responses.activate
     def test_multi_datatype_recessive_get_es_variants(self):
@@ -2268,7 +2268,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, _ = get_es_variants(results_model, num_results=10)
+        variants, _ = query_variants(results_model, num_results=10)
         self.assertEqual(len(variants), 4)
         self.assertDictEqual(variants[0], PARSED_SV_VARIANT)
         self.assertDictEqual(variants[1], PARSED_VARIANTS[0])
@@ -2388,7 +2388,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, _ = get_es_variants(results_model, num_results=10)
+        variants, _ = query_variants(results_model, num_results=10)
         self.assertEqual(len(variants), 2)
         self.assertDictEqual(variants[0], PARSED_SV_VARIANT)
         self.assertDictEqual(variants[1][0], PARSED_SV_COMPOUND_HET_VARIANTS[0])
@@ -2472,7 +2472,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__guid='R0001_1kg'))
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertListEqual(variants, PARSED_VARIANTS)
         self.assertEqual(total_results, 5)
 
@@ -2488,7 +2488,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__guid='R0001_1kg'))
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertListEqual(variants, PARSED_ANY_AFFECTED_VARIANTS)
         self.assertEqual(total_results, 5)
 
@@ -2513,7 +2513,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(self.families)
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
 
         self.assertEqual(len(variants), 2)
         self.assertEqual(total_results, 9)
@@ -2620,7 +2620,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(guid__in=['F000011_11', 'F000003_3', 'F000002_2']))
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertDictEqual(variants[0], PARSED_VARIANTS[0])
         self.assertDictEqual(variants[1][0], PARSED_COMPOUND_HET_VARIANTS_PROJECT_2[0])
@@ -2690,7 +2690,7 @@ class EsUtilsTest(TestCase):
         ])
 
         # test pagination
-        variants, total_results = get_es_variants(results_model, num_results=2, page=2)
+        variants, total_results = query_variants(results_model, num_results=2, page=2)
         self.assertEqual(len(variants), 2)
         self.assertListEqual(variants, [PARSED_VARIANTS[0], PARSED_COMPOUND_HET_VARIANTS_MULTI_PROJECT])
         self.assertEqual(total_results, 9)
@@ -2723,7 +2723,7 @@ class EsUtilsTest(TestCase):
         # If one project is fully loaded, only query the second project
         cache_results['loaded_variant_counts'][INDEX_NAME]['total'] = 4
         _set_cache('search_results__{}__xpos'.format(results_model.guid), json.dumps(cache_results))
-        get_es_variants(results_model, num_results=2, page=3)
+        query_variants(results_model, num_results=2, page=3)
         project_2_search['start_index'] = 2
         project_2_search['size'] = 4
         self.assertExecutedSearches([project_2_search])
@@ -2737,7 +2737,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__id__in=[1, 3]))
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         expected_variants = [PARSED_VARIANTS[0], PARSED_MULTI_INDEX_VARIANT]
         self.assertListEqual(variants, expected_variants)
         self.assertEqual(total_results, 4)
@@ -2756,7 +2756,7 @@ class EsUtilsTest(TestCase):
         )
 
         # test pagination
-        variants, total_results = get_es_variants(results_model, num_results=2, page=2)
+        variants, total_results = query_variants(results_model, num_results=2, page=2)
         expected_variants = [PARSED_MITO_VARIANT, PARSED_VARIANTS[0]]
         self.assertListEqual(variants, expected_variants)
         self.assertEqual(total_results, 3)
@@ -2776,7 +2776,7 @@ class EsUtilsTest(TestCase):
 
         # test skipping page fetches all consecutively
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
-        get_es_variants(results_model, num_results=2, page=2)
+        query_variants(results_model, num_results=2, page=2)
         self.assertExecutedSearch(
             index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME, SECOND_INDEX_NAME]),
             filters=[ANNOTATION_QUERY],
@@ -2793,7 +2793,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__id__in=[1, 3]))
 
-        variants, total_results = get_es_variants(results_model, num_results=2)
+        variants, total_results = query_variants(results_model, num_results=2)
         expected_variants = [PARSED_VARIANTS[0], PARSED_ANY_AFFECTED_MULTI_INDEX_VERSION_VARIANT]
         self.assertListEqual(variants, expected_variants)
         self.assertEqual(total_results, 9)
@@ -2835,7 +2835,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__id__in=[1, 3]))
 
-        _, total_results = get_es_variants(results_model, num_results=2)
+        _, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(total_results, 14)
 
         gene_filter = {'terms': {'geneIds': ['ENSG00000228198']}}
@@ -2939,7 +2939,7 @@ class EsUtilsTest(TestCase):
         search_model.search['locus']['rawItems'] = 'ENSG00000186092'
         search_model.save()
 
-        _, total_results = get_es_variants(results_model, num_results=2)
+        _, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(total_results, 1)
         self.assertEqual(len(urllib3_responses.calls), 4)
         self.assertExecutedSearch(call_index=2, **prefilter_search)
@@ -2952,7 +2952,7 @@ class EsUtilsTest(TestCase):
         search_model.search['locus']['rawItems'] = 'ENSG00000269732'
         search_model.save()
 
-        _, total_results = get_es_variants(results_model, num_results=2)
+        _, total_results = query_variants(results_model, num_results=2)
         self.assertEqual(total_results, 0)
         # Only the prefliter search is run, no multi-search
         self.assertEqual(len(urllib3_responses.calls), 5)
@@ -2970,7 +2970,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__id__in=[1, 3]))
 
-        variants, _ = get_es_variants(results_model, num_results=2, skip_genotype_filter=True)
+        variants, _ = query_variants(results_model, num_results=2, skip_genotype_filter=True)
         expected_transcript_variant = deepcopy(PARSED_VARIANTS[0])
         expected_transcript_variant['selectedMainTranscriptId'] = PARSED_VARIANTS[1]['selectedMainTranscriptId']
         self.assertListEqual(variants, [expected_transcript_variant, PARSED_MULTI_INDEX_VARIANT])
@@ -2984,7 +2984,7 @@ class EsUtilsTest(TestCase):
         search_model.search['inheritance'] = {'mode': 'any_affected'}
         search_model.save()
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
-        get_es_variants(results_model, num_results=2, skip_genotype_filter=True)
+        query_variants(results_model, num_results=2, skip_genotype_filter=True)
 
         self.assertExecutedSearches([
             dict(
@@ -3033,7 +3033,7 @@ class EsUtilsTest(TestCase):
             'liftedOverChrom': None,
             'liftedOverPos': None,
         })
-        variants, _ = get_es_variants(results_model, num_results=2)
+        variants, _ = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertListEqual(variants, [PARSED_HG38_VARIANT, expected_no_lift_grch38_variant])
         self.assertIsNone(_liftover_grch38_to_grch37())
@@ -3042,7 +3042,7 @@ class EsUtilsTest(TestCase):
         _set_cache('search_results__{}__xpos'.format(results_model.guid), None)
         mock_liftover.side_effect = None
         mock_liftover.return_value.convert_coordinate.side_effect = lambda chrom, pos: [[chrom, pos - 10]]
-        variants, _ = get_es_variants(results_model, num_results=2)
+        variants, _ = query_variants(results_model, num_results=2)
         self.assertEqual(len(variants), 2)
         self.assertListEqual(variants, [PARSED_HG38_VARIANT, PARSED_HG38_VARIANT])
         self.assertIsNotNone(_liftover_grch38_to_grch37())
@@ -3060,7 +3060,7 @@ class EsUtilsTest(TestCase):
             '/{}/_mapping'.format(INDEX_ALIAS), {k: {'mappings': v} for k, v in CORE_INDEX_METADATA.items()})
         urllib3_responses.add_json('/_aliases', {'success': True}, method=urllib3_responses.POST)
 
-        get_es_variants(results_model, num_results=2)
+        query_variants(results_model, num_results=2)
 
         self.assertExecutedSearch(index=INDEX_ALIAS, size=8)
         self.assertDictEqual(urllib3_responses.call_request_json(index=0), {
@@ -3079,7 +3079,7 @@ class EsUtilsTest(TestCase):
         urllib3_responses.add_json('/{}/_mapping'.format(SECOND_INDEX_NAME), {
             k: {'mappings': INDEX_METADATA[SECOND_INDEX_NAME]} for k in SUB_INDICES})
 
-        get_es_variants(results_model, num_results=2)
+        query_variants(results_model, num_results=2)
 
         expected_search = {
             'start_index': 0, 'size': 2, 'filters': [ANNOTATION_QUERY, {
@@ -3115,7 +3115,7 @@ class EsUtilsTest(TestCase):
         aliases.update({k: {'aliases': {SECOND_INDEX_NAME: {}, INDEX_ALIAS: {}}} for k in SECOND_SUB_INDICES})
         urllib3_responses.add_json('/{},{}/_alias'.format(INDEX_NAME, SECOND_INDEX_NAME), aliases)
 
-        get_es_variants(results_model, num_results=2)
+        query_variants(results_model, num_results=2)
 
         second_alias_expected_search = {
             'start_index': 0, 'size': 2, 'filters': [ANNOTATION_QUERY, {
@@ -3169,7 +3169,7 @@ class EsUtilsTest(TestCase):
         _set_cache('search_results__{}__xpos'.format(results_model.guid), json.dumps(initial_cached_results))
 
         #  Test gene counts
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
         self.assertDictEqual(gene_counts, {
             'ENSG00000135953': {'total': 3, 'families': {'F000003_3': 2, 'F000002_2': 1, 'F000005_5': 1}},
             'ENSG00000228198': {'total': 5, 'families': {'F000003_3': 4, 'F000002_2': 1, 'F000005_5': 1}},
@@ -3211,7 +3211,7 @@ class EsUtilsTest(TestCase):
         _set_cache('search_results__{}__xpos'.format(results_model.guid), json.dumps(initial_cached_results))
 
         #  Test gene counts
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
         self.assertDictEqual(gene_counts, {
             'ENSG00000135953': {'total': 6, 'families': {'F000003_3': 2, 'F000002_2': 1, 'F000005_5': 1, 'F000011_11': 4}},
             'ENSG00000228198': {'total': 4, 'families': {'F000003_3': 4, 'F000002_2': 1, 'F000005_5': 1, 'F000011_11': 4}}
@@ -3250,7 +3250,7 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__id__in=[1, 3]))
         _set_cache('search_results__{}__xpos'.format(results_model.guid), json.dumps({'total_results': 5}))
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
 
         self.assertDictEqual(gene_counts, {
             'ENSG00000135953': {'total': 6, 'families': {'F000003_3': 2, 'F000002_2': 2, 'F000011_11': 2}},
@@ -3278,7 +3278,7 @@ class EsUtilsTest(TestCase):
         })
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__guid='R0001_1kg'))
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
 
         self.assertDictEqual(gene_counts, {
             'ENSG00000135953': {'total': 5, 'families': {'F000003_3': 3, 'F000002_2': 2}},
@@ -3316,11 +3316,11 @@ class EsUtilsTest(TestCase):
             'ENSG00000228198': {'total': 5, 'families': {'F000003_3': 4, 'F000002_2': 1, 'F000011_11': 4}}
         }
         _set_cache(cache_key, json.dumps({'total_results': 5, 'gene_aggs': cached_gene_counts}))
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
         self.assertDictEqual(gene_counts, cached_gene_counts)
 
         _set_cache(cache_key, json.dumps({'all_results': PARSED_COMPOUND_HET_VARIANTS_MULTI_PROJECT, 'total_results': 2}))
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
         self.assertDictEqual(gene_counts, {
             'ENSG00000135953': {'total': 1, 'families': {'F000003_3': 1, 'F000011_11': 1}},
             'ENSG00000228198': {'total': 1, 'families': {'F000003_3': 1, 'F000011_11': 1}}
@@ -3338,7 +3338,7 @@ class EsUtilsTest(TestCase):
             },
             'total_results': 4,
         }))
-        gene_counts = get_es_variant_gene_counts(results_model, None)
+        gene_counts = get_variant_query_gene_counts(results_model, None)
         self.assertDictEqual(gene_counts, {
             'ENSG00000135953': {'total': 2, 'families': {'F000003_3': 2, 'F000002_2': 1, 'F000011_11': 1}},
             'ENSG00000228198': {'total': 2, 'families': {'F000003_3': 2, 'F000011_11': 2}}
@@ -3372,14 +3372,14 @@ class EsUtilsTest(TestCase):
         results_model = VariantSearchResults.objects.create(variant_search=search_model)
         results_model.families.set(Family.objects.filter(project__guid='R0001_1kg'))
 
-        variants, _ = get_es_variants(results_model, sort='primate_ai', num_results=2)
+        variants, _ = query_variants(results_model, sort='primate_ai', num_results=2)
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY], sort=[
             {'primate_ai_score': {'order': 'desc', 'unmapped_type': 'double', 'numeric_type': 'double'}}, 'xpos', 'variantId'],
                                   index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME]), size=4)
         self.assertEqual(variants[0]['_sort'][0], maxsize)
         self.assertEqual(variants[1]['_sort'][0], -1)
 
-        variants, _ = get_es_variants(results_model, sort='gnomad', num_results=2)
+        variants, _ = query_variants(results_model, sort='gnomad', num_results=2)
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY], index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME]), size=4, sort=[
             {
                 '_script': {
@@ -3393,7 +3393,7 @@ class EsUtilsTest(TestCase):
         self.assertEqual(variants[0]['_sort'][0], 0.00012925741614425127)
         self.assertEqual(variants[1]['_sort'][0], maxsize)
 
-        variants, _ = get_es_variants(results_model, sort='in_omim', num_results=2)
+        variants, _ = query_variants(results_model, sort='in_omim', num_results=2)
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY], index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME]), size=4, sort=[
             {
                 '_script': {
@@ -3418,11 +3418,11 @@ class EsUtilsTest(TestCase):
             }, 'xpos', 'variantId'])
 
         with self.assertRaises(InvalidSearchException) as se:
-            get_es_variants(results_model, sort='prioritized_gene', num_results=2)
+            query_variants(results_model, sort='prioritized_gene', num_results=2)
         self.assertEqual(str(se.exception), 'Phenotype sort is only supported for single-family search.')
 
         results_model.families.set(Family.objects.filter(guid='F000001_1'))
-        get_es_variants(results_model, sort='prioritized_gene', num_results=2)
+        query_variants(results_model, sort='prioritized_gene', num_results=2)
         family_sample_filter = {'bool': {'_name': 'F000001_1', 'must': mock.ANY}}
         self.assertExecutedSearch(filters=[ANNOTATION_QUERY, family_sample_filter], index=INDEX_NAME, size=2, sort=[
             {
@@ -3459,7 +3459,7 @@ class EsUtilsTest(TestCase):
                 'annotations': annotations,
             }
             search_model.save()
-            get_es_variants(results_model, num_results=2)
+            query_variants(results_model, num_results=2)
 
             index = INDEX_NAME if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS else SV_INDEX_NAME
             annotation_query = {'terms': {'transcriptConsequenceTerms': next(iter(annotations.values()))}}

--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -12,7 +12,7 @@ from urllib3.exceptions import ReadTimeoutError
 from urllib3_mock import Responses
 
 from seqr.models import Family, Sample, VariantSearch, VariantSearchResults
-from seqr.utils.search.utils import get_es_variants_for_variant_tuples, get_single_variant, query_variants, \
+from seqr.utils.search.utils import get_single_variant, query_variants, \
     get_variant_query_gene_counts, get_variants_for_variant_ids, InvalidSearchException
 from seqr.utils.search.elasticsearch.es_search import _get_family_affected_status, _liftover_grch38_to_grch37
 from seqr.utils.search.elasticsearch.es_utils import InvalidIndexException
@@ -1392,25 +1392,6 @@ class EsUtilsTest(TestCase):
         self.assertIn(cache_key, REDIS_CACHE.keys())
         self.assertDictEqual(json.loads(REDIS_CACHE[cache_key]), expected_results)
         MOCK_REDIS.expire.assert_called_with(cache_key, timedelta(weeks=2))
-
-    @urllib3_responses.activate
-    def test_get_es_variants_for_variant_tuples(self):
-        setup_responses()
-
-        variants = get_es_variants_for_variant_tuples(
-            self.families,
-            [(2103343353, 'GAGA', 'G'), (1248367227, 'TC', 'T'), (25138367346, 'A', 'C')]
-        )
-
-        self.assertEqual(len(variants), 2)
-        self.assertDictEqual(variants[0], PARSED_NO_SORT_VARIANTS[0])
-        self.assertDictEqual(variants[1], PARSED_NO_SORT_VARIANTS[1])
-
-        self.assertExecutedSearch(
-            filters=[{'terms': {'variantId': ['2-103343353-GAGA-G', '1-248367227-TC-T', 'MT-138367346-A-C']}}], size=6,
-            unsorted=True,
-            index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME])
-        )
 
     @urllib3_responses.activate
     def test_get_es_variants_for_variant_ids(self):

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -40,7 +40,7 @@ def delete_search_backend_data(data_id):
     return delete_es_index(data_id)
 
 
-def get_single_es_variant(families, variant_id, return_all_queried_families=False, user=None):
+def get_single_variant(families, variant_id, return_all_queried_families=False, user=None):
     variants = EsSearch(
         families, return_all_queried_families=return_all_queried_families, user=user,
     ).filter_by_variant_ids([variant_id]).search(num_results=1)
@@ -49,7 +49,7 @@ def get_single_es_variant(families, variant_id, return_all_queried_families=Fals
     return variants[0]
 
 
-def get_es_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None):
+def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None):
     variants = EsSearch(families, user=user).filter_by_variant_ids(variant_ids)
     if dataset_type:
         variants = variants.update_dataset_type(dataset_type)
@@ -63,10 +63,10 @@ def get_es_variants_for_variant_tuples(families, xpos_ref_alt_tuples):
         if chrom == 'M':
             chrom = 'MT'
         variant_ids.append('{}-{}-{}-{}'.format(chrom, pos, ref, alt))
-    return get_es_variants_for_variant_ids(families, variant_ids, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
+    return get_variants_for_variant_ids(families, variant_ids, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
 
 
-def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, skip_genotype_filter=False, load_all=False, user=None, page=1, num_results=100):
+def query_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, skip_genotype_filter=False, load_all=False, user=None, page=1, num_results=100):
     cache_key = 'search_results__{}__{}'.format(search_model.guid, sort or XPOS_SORT_KEY)
     previous_search_results = safe_redis_get_json(cache_key) or {}
     total_results = previous_search_results.get('total_results')
@@ -120,8 +120,8 @@ def get_es_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, sk
     return variant_results, es_search.previous_search_results.get('total_results')
 
 
-def get_es_variant_gene_counts(search_model, user):
-    gene_counts, _ = get_es_variants(search_model, es_search_cls=EsGeneAggSearch, sort=None, user=user)
+def get_variant_query_gene_counts(search_model, user):
+    gene_counts, _ = query_variants(search_model, es_search_cls=EsGeneAggSearch, sort=None, user=user)
     return gene_counts
 
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -57,6 +57,7 @@ def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=
 
 
 def get_es_variants_for_variant_tuples(families, xpos_ref_alt_tuples):
+    # TODO
     variant_ids = []
     for xpos, ref, alt in xpos_ref_alt_tuples:
         chrom, pos = get_chrom_pos(xpos)

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -9,7 +9,7 @@ from seqr.utils.search.elasticsearch.es_search import EsSearch
 from seqr.utils.search.elasticsearch.es_utils import ping_elasticsearch, delete_es_index, get_elasticsearch_status, \
     ES_EXCEPTION_ERROR_MAP, ES_EXCEPTION_MESSAGE_MAP, ES_ERROR_LOG_EXCEPTIONS
 from seqr.utils.gene_utils import parse_locus_list_items
-from seqr.utils.xpos_utils import get_xpos, get_chrom_pos
+from seqr.utils.xpos_utils import get_xpos
 
 
 class InvalidSearchException(Exception):
@@ -54,17 +54,6 @@ def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=
     if dataset_type:
         variants = variants.update_dataset_type(dataset_type)
     return variants.search(num_results=len(variant_ids))
-
-
-def get_es_variants_for_variant_tuples(families, xpos_ref_alt_tuples):
-    # TODO
-    variant_ids = []
-    for xpos, ref, alt in xpos_ref_alt_tuples:
-        chrom, pos = get_chrom_pos(xpos)
-        if chrom == 'M':
-            chrom = 'MT'
-        variant_ids.append('{}-{}-{}-{}'.format(chrom, pos, ref, alt))
-    return get_variants_for_variant_ids(families, variant_ids, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
 
 
 def query_variants(search_model, es_search_cls=EsSearch, sort=XPOS_SORT_KEY, skip_genotype_filter=False, load_all=False, user=None, page=1, num_results=100):

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -876,7 +876,7 @@ class SavedVariantAPITest(object):
 
     @mock.patch('seqr.views.utils.variant_utils.MAX_VARIANTS_FETCH', 3)
     @mock.patch('seqr.views.apis.saved_variant_api.logger')
-    @mock.patch('seqr.views.utils.variant_utils.get_es_variants_for_variant_ids')
+    @mock.patch('seqr.views.utils.variant_utils.get_variants_for_variant_ids')
     def test_update_saved_variant_json(self, mock_get_variants, mock_logger):
         mock_get_variants.side_effect = lambda families, variant_ids, **kwargs: \
             [{'variantId': variant_id, 'familyGuids': [family.guid for family in families]}

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -224,8 +224,8 @@ class VariantSearchAPITest(object):
 
 
     @mock.patch('seqr.utils.middleware.logger.error')
-    @mock.patch('seqr.views.apis.variant_search_api.get_es_variant_gene_counts')
-    @mock.patch('seqr.views.apis.variant_search_api.get_es_variants')
+    @mock.patch('seqr.views.apis.variant_search_api.get_variant_query_gene_counts')
+    @mock.patch('seqr.views.apis.variant_search_api.query_variants')
     def test_query_variants(self, mock_get_variants, mock_get_gene_counts, mock_error_logger):
         url = reverse(query_variants_handler, args=['abc'])
         self.check_collaborator_login(url, request_data={'projectFamilies': PROJECT_FAMILIES})
@@ -461,7 +461,7 @@ class VariantSearchAPITest(object):
         })
         mock_error_logger.assert_not_called()
 
-    @mock.patch('seqr.views.apis.variant_search_api.get_es_variants')
+    @mock.patch('seqr.views.apis.variant_search_api.query_variants')
     def test_query_all_projects_variants(self, mock_get_variants):
         url = reverse(query_variants_handler, args=[SEARCH_HASH])
         self.check_require_login(url)
@@ -531,7 +531,7 @@ class VariantSearchAPITest(object):
         self.assertSetEqual(
             set(response_json['search']['projectFamilies'][0]['familyGuids']), expected_searched_families)
 
-    @mock.patch('seqr.views.apis.variant_search_api.get_es_variants')
+    @mock.patch('seqr.views.apis.variant_search_api.query_variants')
     def test_query_all_project_families_variants(self, mock_get_variants):
         url = reverse(query_variants_handler, args=['abc'])
         self.check_collaborator_login(url, request_data={'projectGuids': ['R0003_test']})
@@ -640,7 +640,7 @@ class VariantSearchAPITest(object):
         self._assert_expected_search_context(response_json)
 
 
-    @mock.patch('seqr.views.apis.variant_search_api.get_single_es_variant')
+    @mock.patch('seqr.views.apis.variant_search_api.get_single_variant')
     def test_query_single_variant(self, mock_get_variant):
         single_family_variant = deepcopy(VARIANTS[0])
         single_family_variant['familyGuids'] = ['F000001_1']

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -8,7 +8,7 @@ from matchmaker.models import MatchmakerSubmissionGenes, MatchmakerSubmission
 from reference_data.models import TranscriptInfo
 from seqr.models import SavedVariant, VariantSearchResults, Family, LocusList, LocusListInterval, LocusListGene, \
     RnaSeqOutlier, RnaSeqTpm, PhenotypePrioritization, Project
-from seqr.utils.search.utils import get_es_variants_for_variant_ids
+from seqr.utils.search.utils import get_variants_for_variant_ids
 from seqr.utils.gene_utils import get_genes_for_variants
 from seqr.views.utils.json_to_orm_utils import update_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_discovery_tags, get_json_for_locus_lists, \
@@ -43,7 +43,7 @@ def update_project_saved_variant_json(project, family_id=None, user=None):
     families = sorted(families, key=lambda f: f.guid)
     variants_json = []
     for sub_var_ids in [variant_ids[i:i+MAX_VARIANTS_FETCH] for i in range(0, len(variant_ids), MAX_VARIANTS_FETCH)]:
-        variants_json += get_es_variants_for_variant_ids(families, sub_var_ids, user=user)
+        variants_json += get_variants_for_variant_ids(families, sub_var_ids, user=user)
 
     updated_saved_variant_guids = []
     for var in variants_json:


### PR DESCRIPTION
This renames the generic search functions in the search utils file, although it does not change the logic. There will be a subsequent PR to move the es-specific code out of the generic helpers, but the diff was already pretty big for this given that these functions are tested and mocked by name so I wanted to keep the PR separate to keep the test changes simple