### PR TITLE
Fix read many files from GS

### DIFF
--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -109,7 +109,8 @@ def _run_gsutil_with_wait(command, gs_path, user=None):
 
 def _run_gsutil_with_stdout(command, gs_path, user=None):
     process = _run_gsutil_command(command, gs_path, user=user)
-    output, errors = process.communicate()
-    if errors:
+    output, errs = process.communicate()
+    if errs:
+        errors = errs.decode('utf-8').strip().replace('\n', ' ')
         raise Exception(f'Run command failed: {errors}')
-    return output.decode('utf-8').rstrip('\n').split('\n')
+    return [line for line in output.decode('utf-8').split('\n') if line]

--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -7,12 +7,12 @@ from seqr.utils.logging_utils import SeqrLogger
 logger = SeqrLogger(__name__)
 
 
-def run_command(command, user=None):
+def run_command(command, user=None, pipe_errors=False):
     logger.info('==> {}'.format(command), user)
-    return subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True) # nosec
+    return subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE if pipe_errors else subprocess.STDOUT, shell=True) # nosec
 
 
-def _run_gsutil_command(command, gs_path, gunzip=False, user=None):
+def _run_gsutil_command(command, gs_path, gunzip=False, user=None, pipe_errors=False):
     if not is_google_bucket_file_path(gs_path):
         raise Exception('A Google Storage path is expected.')
 
@@ -25,7 +25,7 @@ def _run_gsutil_command(command, gs_path, gunzip=False, user=None):
     if gunzip:
         command += " | gunzip -c -q - "
 
-    return run_command(command, user=user)
+    return run_command(command, user=user, pipe_errors=pipe_errors)
 
 
 def is_google_bucket_file_path(file_path):
@@ -108,7 +108,7 @@ def _run_gsutil_with_wait(command, gs_path, user=None):
 
 
 def _run_gsutil_with_stdout(command, gs_path, user=None):
-    process = _run_gsutil_command(command, gs_path, user=user)
+    process = _run_gsutil_command(command, gs_path, user=user, pipe_errors=True)
     output, errs = process.communicate()
     if errs:
         errors = errs.decode('utf-8').strip().replace('\n', ' ')

--- a/seqr/utils/file_utils_tests.py
+++ b/seqr/utils/file_utils_tests.py
@@ -44,7 +44,7 @@ class FileUtilsTest(TestCase):
             get_gs_file_list('gs://bucket/target_path/', user=None)
         self.assertEqual(str(ee.exception), 'Run command failed: -bash: gsutil: command not found. Please check the path.')
         mock_subproc.Popen.assert_called_with('gsutil ls gs://bucket/target_path', stdout=mock_subproc.PIPE,
-                                              stderr=mock_subproc.STDOUT, shell=True)
+                                              stderr=mock_subproc.PIPE, shell=True)
         mock_logger.info.assert_called_with('==> gsutil ls gs://bucket/target_path', None)
         process.communicate.assert_called_with()
 
@@ -55,7 +55,7 @@ class FileUtilsTest(TestCase):
                                            b'gs://bucket/target_path/data.vcf.gz\n', None
         file_list = get_gs_file_list('gs://bucket/target_path', user=None)
         mock_subproc.Popen.assert_called_with('gsutil ls gs://bucket/target_path/**', stdout=mock_subproc.PIPE,
-                                              stderr=mock_subproc.STDOUT, shell=True)
+                                              stderr=mock_subproc.PIPE, shell=True)
         mock_logger.info.assert_called_with('==> gsutil ls gs://bucket/target_path/**', None)
         process.communicate.assert_called_with()
         self.assertEqual(file_list, ['gs://bucket/target_path/id_file.txt', 'gs://bucket/target_path/data.vcf.gz'])

--- a/seqr/utils/file_utils_tests.py
+++ b/seqr/utils/file_utils_tests.py
@@ -39,7 +39,7 @@ class FileUtilsTest(TestCase):
         self.assertEqual(str(ee.exception),  'A Google Storage path is expected.')
 
         process = mock_subproc.Popen.return_value
-        process.communicate.return_value = None, b'-bash: gsutil: command not found.\nPlease check the path.\n'
+        process.communicate.return_value = b'', b'-bash: gsutil: command not found.\nPlease check the path.\n'
         with self.assertRaises(Exception) as ee:
             get_gs_file_list('gs://bucket/target_path/', user=None)
         self.assertEqual(str(ee.exception), 'Run command failed: -bash: gsutil: command not found. Please check the path.')
@@ -52,7 +52,7 @@ class FileUtilsTest(TestCase):
         mock_logger.reset_mock()
         process.communicate.return_value = b'\n\nUpdates are available for some Cloud SDK components.  To install them,\n' \
                                            b'please run:\n  $ gcloud components update\ngs://bucket/target_path/id_file.txt\n' \
-                                           b'gs://bucket/target_path/data.vcf.gz\n', None
+                                           b'gs://bucket/target_path/data.vcf.gz\n', b''
         file_list = get_gs_file_list('gs://bucket/target_path', user=None)
         mock_subproc.Popen.assert_called_with('gsutil ls gs://bucket/target_path/**', stdout=mock_subproc.PIPE,
                                               stderr=mock_subproc.PIPE, shell=True)

--- a/seqr/utils/file_utils_tests.py
+++ b/seqr/utils/file_utils_tests.py
@@ -39,25 +39,23 @@ class FileUtilsTest(TestCase):
         self.assertEqual(str(ee.exception),  'A Google Storage path is expected.')
 
         process = mock_subproc.Popen.return_value
-        process.wait.return_value = -1
-        process.stdout = [b'-bash: gsutil: command not found.\n', b'Please check the path.\n']
+        process.communicate.return_value = None, b'-bash: gsutil: command not found.\nPlease check the path.\n'
         with self.assertRaises(Exception) as ee:
             get_gs_file_list('gs://bucket/target_path/', user=None)
         self.assertEqual(str(ee.exception), 'Run command failed: -bash: gsutil: command not found. Please check the path.')
         mock_subproc.Popen.assert_called_with('gsutil ls gs://bucket/target_path', stdout=mock_subproc.PIPE,
                                               stderr=mock_subproc.STDOUT, shell=True)
         mock_logger.info.assert_called_with('==> gsutil ls gs://bucket/target_path', None)
-        process.wait.assert_called_with()
+        process.communicate.assert_called_with()
 
         mock_subproc.reset_mock()
         mock_logger.reset_mock()
-        process.wait.return_value = 0
-        process.stdout = [b'\n', b'\n', b'Updates are available for some Cloud SDK components.  To install them,\n',
-                          b'please run:\n', b'  $ gcloud components update\n',
-                          b'gs://bucket/target_path/id_file.txt\n', b'gs://bucket/target_path/data.vcf.gz\n']
+        process.communicate.return_value = b'\n\nUpdates are available for some Cloud SDK components.  To install them,\n' \
+                                           b'please run:\n  $ gcloud components update\ngs://bucket/target_path/id_file.txt\n' \
+                                           b'gs://bucket/target_path/data.vcf.gz\n', None
         file_list = get_gs_file_list('gs://bucket/target_path', user=None)
         mock_subproc.Popen.assert_called_with('gsutil ls gs://bucket/target_path/**', stdout=mock_subproc.PIPE,
                                               stderr=mock_subproc.STDOUT, shell=True)
         mock_logger.info.assert_called_with('==> gsutil ls gs://bucket/target_path/**', None)
-        process.wait.assert_called_with()
+        process.communicate.assert_called_with()
         self.assertEqual(file_list, ['gs://bucket/target_path/id_file.txt', 'gs://bucket/target_path/data.vcf.gz'])

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -462,8 +462,9 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         mock_subprocess.side_effect = [mock_file_exist_or_list_subproc] * 2 + [mock_get_header_subproc]
         mock_file_exist_or_list_subproc.wait.return_value = 0
         mock_get_header_subproc.wait.return_value = 0
-        mock_file_exist_or_list_subproc.stdout = [b'gs://test_bucket/test_path-001.vcf.gz', b'gs://test_bucket/test_path-102.vcf.gz']
+        mock_file_exist_or_list_subproc.communicate.return_value = b'gs://test_bucket/test_path-001.vcf.gz\ngs://test_bucket/test_path-102.vcf.gz\n', None
         mock_get_header_subproc.stdout = BASIC_META + INFO_META + FORMAT_META + HEADER_LINE + DATA_LINES
+        mock_get_header_subproc.communicate.return_value = b'\n'.join(BASIC_META + INFO_META + FORMAT_META + HEADER_LINE + DATA_LINES), None
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_SHARDED_DATA_PATH))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'fullDataPath': 'gs://test_bucket/test_path-*.vcf.gz', 'vcfSamples': ['HG00735', 'NA19675', 'NA19678']})
@@ -497,8 +498,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
                                                      self.collaborator_user)
 
         # Test empty bucket
-        mock_subprocess.return_value.wait.return_value = 0
-        mock_subprocess.return_value.stdout = []
+        mock_subprocess.return_value.communicate.return_value = b'', None
         response = self.client.get(url, content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'dataPathList': []})
@@ -508,7 +508,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         # Test a valid operation
         mock_subprocess.reset_mock()
         mock_file_logger.reset_mock()
-        mock_subprocess.return_value.stdout = [
+        mock_subprocess.return_value.communicate.return_value = b'\n'.join([
             b'Warning: some packages are out of date',
             b'gs://test_bucket/test.vcf', b'gs://test_bucket/test.tsv',
             # path with common prefix but not sharded VCFs
@@ -516,17 +516,17 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
             b'gs://test_bucket/data/test-102.vcf.gz',
             # sharded VCFs
             b'gs://test_bucket/sharded/test-101.vcf.gz', b'gs://test_bucket/sharded/test-102.vcf.gz',
-            b'gs://test_bucket/sharded/test-2345.vcf.gz'
-        ]
+            b'gs://test_bucket/sharded/test-2345.vcf.gz\n'
+        ]), None
         response = self.client.get(url, content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'dataPathList': ['/test.vcf', '/data/test.vcf.gz', '/data/test-101.vcf.gz',
                                                                 '/data/test-102.vcf.gz', '/sharded/test-*.vcf.gz']})
         mock_subprocess.assert_has_calls([
             mock.call('gsutil ls gs://test_bucket', stdout=-1, stderr=-2, shell=True),
-            mock.call().wait(),
+            mock.call().communicate(),
             mock.call('gsutil ls gs://test_bucket/**', stdout=-1, stderr=-2, shell=True),
-            mock.call().wait(),
+            mock.call().communicate(),
         ])
         mock_file_logger.info.assert_has_calls([
             mock.call('==> gsutil ls gs://test_bucket', self.manager_user),

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -470,7 +470,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         self.assertEqual(response.json(), {'fullDataPath': 'gs://test_bucket/test_path-*.vcf.gz', 'vcfSamples': ['HG00735', 'NA19675', 'NA19678']})
         mock_subprocess.assert_has_calls([
             mock.call('gsutil ls gs://test_bucket/test_path-*.vcf.gz', stdout=-1, stderr=-2, shell=True),
-            mock.call('gsutil ls gs://test_bucket/test_path-*.vcf.gz', stdout=-1, stderr=-2, shell=True),
+            mock.call('gsutil ls gs://test_bucket/test_path-*.vcf.gz', stdout=-1, stderr=-1, shell=True),
             mock.call('gsutil cat -r 0-65536 gs://test_bucket/test_path-001.vcf.gz | gunzip -c -q - ', stdout=-1, stderr=-2, shell=True),
         ])
         mock_file_logger.info.assert_has_calls([
@@ -502,7 +502,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         response = self.client.get(url, content_type='application/json')
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'dataPathList': []})
-        mock_subprocess.assert_called_with('gsutil ls gs://test_bucket', stdout=-1, stderr=-2, shell=True)
+        mock_subprocess.assert_called_with('gsutil ls gs://test_bucket', stdout=-1, stderr=-1, shell=True)
         mock_file_logger.info.assert_called_with('==> gsutil ls gs://test_bucket', self.manager_user)
 
         # Test a valid operation
@@ -523,9 +523,9 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         self.assertDictEqual(response.json(), {'dataPathList': ['/test.vcf', '/data/test.vcf.gz', '/data/test-101.vcf.gz',
                                                                 '/data/test-102.vcf.gz', '/sharded/test-*.vcf.gz']})
         mock_subprocess.assert_has_calls([
-            mock.call('gsutil ls gs://test_bucket', stdout=-1, stderr=-2, shell=True),
+            mock.call('gsutil ls gs://test_bucket', stdout=-1, stderr=-1, shell=True),
             mock.call().communicate(),
-            mock.call('gsutil ls gs://test_bucket/**', stdout=-1, stderr=-2, shell=True),
+            mock.call('gsutil ls gs://test_bucket/**', stdout=-1, stderr=-1, shell=True),
             mock.call().communicate(),
         ])
         mock_file_logger.info.assert_has_calls([


### PR DESCRIPTION
For many files, we are running into a documented issue when using `wait` with stdout piping. Switching to the recommended `communicate` function fixes the issue: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait