### PR TITLE
Fix error formatting for IGV loading 

### DIFF
--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -64,7 +64,7 @@ def receive_igv_table_handler(request, project_guid):
         all_updates = []
         for i in matched_individuals:
             all_updates += [
-                dict(individualGuid=i.guid, **update) for update in individual_dataset_mapping[i.individual_id]
+                dict(individualGuid=i.guid, individualId=i.individual_id, **update) for update in individual_dataset_mapping[i.individual_id]
                 if (i.individual_id, update['filePath']) not in unchanged_rows
             ]
 

--- a/seqr/views/apis/igv_api_tests.py
+++ b/seqr/views/apis/igv_api_tests.py
@@ -123,8 +123,8 @@ class IgvAPITest(AuthenticationTestCase):
         self.assertListEqual(
             response_json['info'], ['Parsed 3 rows in 2 individuals from samples.csv', 'No change detected for 1 rows'])
         self.assertListEqual(sorted(response_json['updates'], key=lambda o: o['individualGuid']), [
-            {'individualGuid': 'I000001_na19675', 'filePath': 'gs://readviz/batch_10.dcr.bed.gz', 'sampleId': 'NA19675'},
-            {'individualGuid': 'I000003_na19679', 'filePath': 'gs://readviz/NA19679.bam', 'sampleId': None},
+            {'individualGuid': 'I000001_na19675', 'individualId': 'NA19675_1', 'filePath': 'gs://readviz/batch_10.dcr.bed.gz', 'sampleId': 'NA19675'},
+            {'individualGuid': 'I000003_na19679', 'individualId': 'NA19679', 'filePath': 'gs://readviz/NA19679.bam', 'sampleId': None},
         ])
 
         # test data manager access

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -190,14 +190,14 @@ export const addVariantsDataset = values => (dispatch, getState) => new HttpRequ
   },
 ).post(values)
 
-export const addIGVDataset = ({ mappingFile, ...values }) => (dispatch, getState) => {
+export const addIGVDataset = ({ mappingFile, ...values }) => (dispatch) => {
   const errors = []
 
   return Promise.all(mappingFile.updates.map(
-    ({ individualGuid, ...update }) => new HttpRequestHelper(
+    ({ individualGuid, individualId, ...update }) => new HttpRequestHelper(
       `/api/individual/${individualGuid}/update_igv_sample`,
       responseJson => dispatch({ type: RECEIVE_DATA, updatesById: responseJson }),
-      e => errors.push(`Error updating ${getState().individualsByGuid[individualGuid].individualId}: ${e.body && e.body.error ? e.body.error : e.message}`),
+      e => errors.push(`Error updating ${individualId}: ${e.body && e.body.error ? e.body.error : e.message}`),
     ).post({ ...update, ...values }),
   )).then(() => {
     if (errors.length) {


### PR DESCRIPTION
`individualsByGuid` is no longer initially loaded with the project page state so formatting error messages on IGV loading is failing. This change more explicitly maps the user-provided ID to the error message shown to the user