### PR TITLE
Hail backend - add additional calls

### DIFF
--- a/seqr/management/tests/lift_project_to_hg38_tests.py
+++ b/seqr/management/tests/lift_project_to_hg38_tests.py
@@ -167,7 +167,7 @@ class LiftProjectToHg38Test(TestCase):
             with self.assertRaises(Exception) as ce:
                 call_command('lift_project_to_hg38', '--project={}'.format(PROJECT_NAME),
                              '--es-index={}'.format(ELASTICSEARCH_INDEX))
-        self.assertEqual(str(ce.exception), 'Elasticsearch backend is disabled')
+        self.assertEqual(str(ce.exception), 'Adding samples is disabled for the hail backend')
 
         # Test discontinue on a failed lift
         mock_liftover_to_38 = mock_liftover.return_value

--- a/seqr/utils/search/add_data_utils.py
+++ b/seqr/utils/search/add_data_utils.py
@@ -4,12 +4,19 @@ from seqr.utils.search.elasticsearch.es_utils import validate_es_index_metadata_
 from seqr.views.utils.dataset_utils import match_and_update_search_samples, load_mapping_file
 
 
+def _hail_backend_error(*args, **kwargs):
+    raise ValueError('Adding samples is disabled for the hail backend')
+
+
 def add_new_search_samples(request_json, project, user, summary_template=None, expected_families=None):
     dataset_type = request_json.get('datasetType')
     if dataset_type not in Sample.DATASET_TYPE_LOOKUP:
         raise ValueError(f'Invalid dataset type "{dataset_type}"')
 
-    sample_ids, sample_type, sample_data = backend_specific_call(validate_es_index_metadata_and_get_samples)(request_json, project)
+    sample_ids, sample_type, sample_data = backend_specific_call(
+        validate_es_index_metadata_and_get_samples,
+        _hail_backend_error,
+    )(request_json, project)
     if not sample_ids:
         raise ValueError('No samples found. Make sure the specified caller type is correct')
 

--- a/seqr/utils/search/constants.py
+++ b/seqr/utils/search/constants.py
@@ -18,12 +18,3 @@ RECESSIVE = 'recessive'
 NEW_SV_FIELD = 'new_structural_variants'
 SV_ANNOTATION_TYPES = {'structural_consequence', 'structural', NEW_SV_FIELD}
 ALL_DATA_TYPES = 'ALL'
-
-DATASET_TYPES_LOOKUP = {
-    data_types[0]: data_types for data_types in [
-        [Sample.DATASET_TYPE_VARIANT_CALLS, Sample.DATASET_TYPE_MITO_CALLS],
-        [Sample.DATASET_TYPE_SV_CALLS],
-    ]
-}
-DATASET_TYPES_LOOKUP[ALL_DATA_TYPES] = [dt for dts in DATASET_TYPES_LOOKUP.values() for dt in dts]
-

--- a/seqr/utils/search/constants.py
+++ b/seqr/utils/search/constants.py
@@ -1,5 +1,3 @@
-from seqr.models import Sample
-
 SEQR_DATSETS_GS_PATH = 'gs://seqr-datasets/v02'
 
 VCF_FILE_EXTENSIONS = ('.vcf', '.vcf.gz', '.vcf.bgz')

--- a/seqr/utils/search/constants.py
+++ b/seqr/utils/search/constants.py
@@ -1,3 +1,5 @@
+from seqr.models import Sample
+
 SEQR_DATSETS_GS_PATH = 'gs://seqr-datasets/v02'
 
 VCF_FILE_EXTENSIONS = ('.vcf', '.vcf.gz', '.vcf.bgz')
@@ -16,3 +18,12 @@ RECESSIVE = 'recessive'
 NEW_SV_FIELD = 'new_structural_variants'
 SV_ANNOTATION_TYPES = {'structural_consequence', 'structural', NEW_SV_FIELD}
 ALL_DATA_TYPES = 'ALL'
+
+DATASET_TYPES_LOOKUP = {
+    data_types[0]: data_types for data_types in [
+        [Sample.DATASET_TYPE_VARIANT_CALLS, Sample.DATASET_TYPE_MITO_CALLS],
+        [Sample.DATASET_TYPE_SV_CALLS],
+    ]
+}
+DATASET_TYPES_LOOKUP[ALL_DATA_TYPES] = [dt for dts in DATASET_TYPES_LOOKUP.values() for dt in dts]
+

--- a/seqr/utils/search/elasticsearch/es_utils.py
+++ b/seqr/utils/search/elasticsearch/es_utils.py
@@ -262,7 +262,7 @@ def _get_es_indices(client):
     return indices, seqr_index_projects
 
 
-def get_es_variants_for_variant_ids(samples, genome_version, variants_by_id, user=None, return_all_queried_families=False):
+def get_es_variants_for_variant_ids(samples, genome_version, variants_by_id, user, return_all_queried_families=False):
     variants = EsSearch(
         samples, genome_version, user=user, return_all_queried_families=return_all_queried_families,
     ).filter_by_variant_ids(list(variants_by_id.keys()))

--- a/seqr/utils/search/elasticsearch/es_utils.py
+++ b/seqr/utils/search/elasticsearch/es_utils.py
@@ -262,13 +262,11 @@ def _get_es_indices(client):
     return indices, seqr_index_projects
 
 
-def get_es_variants_for_variant_ids(samples, genome_version, variant_ids, user, dataset_type=None, return_all_queried_families=False):
+def get_es_variants_for_variant_ids(samples, genome_version, variants_by_id, user=None, return_all_queried_families=False):
     variants = EsSearch(
         samples, genome_version, user=user, return_all_queried_families=return_all_queried_families,
-    ).filter_by_variant_ids(variant_ids)
-    if dataset_type:
-        variants = variants.update_dataset_type(dataset_type)
-    return variants.search(num_results=len(variant_ids))
+    ).filter_by_variant_ids(list(variants_by_id.keys()))
+    return variants.search(num_results=len(variants_by_id))
 
 
 def get_es_variants(samples, search, user, previous_search_results, genome_version, sort=None, page=None, num_results=None,

--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -732,7 +732,7 @@ for variant in PARSED_COMPOUND_HET_VARIANTS_PROJECT_2:
 PARSED_NO_CONSEQUENCE_FILTER_VARIANTS = deepcopy(PARSED_VARIANTS)
 PARSED_NO_CONSEQUENCE_FILTER_VARIANTS[1]['selectedMainTranscriptId'] = None
 
-PARSED_NO_SORT_VARIANTS = deepcopy(PARSED_NO_CONSEQUENCE_FILTER_VARIANTS)
+PARSED_NO_SORT_VARIANTS = deepcopy(PARSED_NO_CONSEQUENCE_FILTER_VARIANTS + [PARSED_SV_VARIANT])
 for var in PARSED_NO_SORT_VARIANTS:
     del var['_sort']
 
@@ -1397,7 +1397,13 @@ class EsUtilsTest(TestCase):
         self.assertDictEqual(variant, PARSED_NO_SORT_VARIANTS[1])
         self.assertExecutedSearch(
             filters=[{'terms': {'variantId': ['2-103343353-GAGA-G']}}],
-            size=3, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME, SV_INDEX_NAME]), unsorted=True,
+            size=2, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME]), unsorted=True,
+        )
+
+        variant = get_single_variant(self.families, 'prefix_19107_DEL')
+        self.assertDictEqual(variant, PARSED_NO_SORT_VARIANTS[2])
+        self.assertExecutedSearch(
+            filters=[{'terms': {'variantId': ['prefix_19107_DEL']}}], size=1, index=SV_INDEX_NAME, unsorted=True,
         )
 
         variant = get_single_variant(self.families, '1-248367227-TC-T', return_all_queried_families=True)
@@ -1409,7 +1415,7 @@ class EsUtilsTest(TestCase):
         self.assertDictEqual(variant, all_family_variant)
         self.assertExecutedSearch(
             filters=[{'terms': {'variantId': ['1-248367227-TC-T']}}],
-            size=3, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME, SV_INDEX_NAME]), unsorted=True,
+            size=2, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME]), unsorted=True,
         )
 
         with self.assertRaises(InvalidSearchException) as cm:

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -51,7 +51,7 @@ def get_hail_variants(samples, search, user, previous_search_results, genome_ver
     return response_json['results'][end_offset - num_results:end_offset]
 
 
-def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_ids, user=None, return_all_queried_families=False):
+def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_ids, user, return_all_queried_families=False):
     search = {
         'variant_ids': [parsed_id for parsed_id in parsed_variant_ids.values() if parsed_id],
         'variant_keys': [variant_id for variant_id, parsed_id in parsed_variant_ids.itmes() if not parsed_id],

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -54,7 +54,7 @@ def get_hail_variants(samples, search, user, previous_search_results, genome_ver
 def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_ids, user, return_all_queried_families=False):
     search = {
         'variant_ids': [parsed_id for parsed_id in parsed_variant_ids.values() if parsed_id],
-        'variant_keys': [variant_id for variant_id, parsed_id in parsed_variant_ids.itmes() if not parsed_id],
+        'variant_keys': [variant_id for variant_id, parsed_id in parsed_variant_ids.items() if not parsed_id],
     }
     search_body = _format_search_body(samples, genome_version, user, len(parsed_variant_ids), search)
     response_json = _execute_search(search_body)

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -60,7 +60,8 @@ def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_id
     response_json = _execute_search(search_body)
 
     if return_all_queried_families:
-        _validate_expected_families(response_json['results'], {s['family_guid'] for s in search_body['sample_data']})
+        expected_family_guids = set(samples.values_list('individual__family__guid', flat=True))
+        _validate_expected_families(response_json['results'], expected_family_guids)
 
     return response_json['results']
 

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -190,3 +190,60 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
         self.assertDictEqual(gene_counts, MOCK_COUNTS)
         self.assert_cached_results({'gene_aggs': gene_counts})
         self._test_expected_search_call(sort=None)
+
+   # TODO
+   #  @responses.activate
+    # def test_get_single_variant(self, mock_get_variants_for_ids):
+    #     mock_get_variants_for_ids.return_value = [PARSED_VARIANTS[0]]
+    #     variant = get_single_variant(self.families, '2-103343353-GAGA-G', user=self.user)
+    #     self.assertDictEqual(variant, PARSED_VARIANTS[0])
+    #     mock_get_variants_for_ids.assert_called_with(
+    #         mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, user=self.user,
+    #     )
+    #     expected_samples = {
+    #         s for s in self.search_samples if s.guid not in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
+    #     }
+    #     self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
+    #
+    #     get_single_variant(self.families, '2-103343353-GAGA-G', user=self.user, return_all_queried_families=True)
+    #     mock_get_variants_for_ids.assert_called_with(
+    #         mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, user=self.user, return_all_queried_families=True,
+    #     )
+    #     self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
+    #
+    #     get_single_variant(self.families, 'prefix_19107_DEL', user=self.user)
+    #     mock_get_variants_for_ids.assert_called_with(
+    #         mock.ANY, '37', {'prefix_19107_DEL': None}, user=self.user,
+    #     )
+    #     expected_samples = {
+    #         s for s in self.search_samples if s.guid in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
+    #     }
+    #     self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
+    #
+    #     mock_get_variants_for_ids.return_value = []
+    #     with self.assertRaises(InvalidSearchException) as cm:
+    #         get_single_variant(self.families, '10-10334333-A-G')
+    #     self.assertEqual(str(cm.exception), 'Variant 10-10334333-A-G not found')
+
+    # TODO
+    # @responses.activate
+    # def test_get_variants_for_variant_ids(self):
+    #     variant_ids = ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL']
+    #     get_variants_for_variant_ids(self.families, variant_ids, user=self.user)
+    #     mock_get_variants_for_ids.assert_called_with(mock.ANY, '37', {
+    #         '2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G'),
+    #         '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
+    #         'prefix-938_DEL': None,
+    #     }, user=self.user)
+    #     self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), set(self.search_samples))
+    #
+    #     get_variants_for_variant_ids(
+    #         self.families, variant_ids, user=self.user, dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
+    #     mock_get_variants_for_ids.assert_called_with(mock.ANY, '37', {
+    #         '2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G'),
+    #         '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
+    #     }, user=self.user)
+    #     expected_samples = {
+    #         s for s in self.search_samples if s.guid not in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
+    #     }
+    #     self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -435,12 +435,9 @@ class HailSearchUtilsTests(TestCase, SearchUtilsTests):
     def setUp(self):
         self.set_up()
 
-    @mock.patch('seqr.utils.search.utils.ping_elasticsearch')
+    @mock.patch('seqr.utils.search.utils.get_hail_variants_for_variant_ids')
     def test_get_single_variant(self, mock_call):
-        with self.assertRaises(InvalidSearchException) as cm:
-            super(HailSearchUtilsTests, self).test_get_single_variant(mock_call)
-        self.assertEqual(str(cm.exception), 'Elasticsearch backend is disabled')
-        mock_call.assert_not_called()
+        super(HailSearchUtilsTests, self).test_get_single_variant(mock_call)
 
     @mock.patch('seqr.utils.search.utils.ping_elasticsearch')
     def test_get_variants_for_variant_ids(self, mock_call):

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -59,7 +59,7 @@ class SearchUtilsTests(SearchTestHelper):
         variant = get_single_variant(self.families, '2-103343353-GAGA-G', user=self.user)
         self.assertDictEqual(variant, PARSED_VARIANTS[0])
         mock_get_variants_for_ids.assert_called_with(
-            mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, user=self.user,
+            mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, self.user, return_all_queried_families=False,
         )
         expected_samples = {
             s for s in self.search_samples if s.guid not in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
@@ -68,13 +68,13 @@ class SearchUtilsTests(SearchTestHelper):
 
         get_single_variant(self.families, '2-103343353-GAGA-G', user=self.user, return_all_queried_families=True)
         mock_get_variants_for_ids.assert_called_with(
-            mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, user=self.user, return_all_queried_families=True,
+            mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, self.user, return_all_queried_families=True,
         )
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
 
         get_single_variant(self.families, 'prefix_19107_DEL', user=self.user)
         mock_get_variants_for_ids.assert_called_with(
-            mock.ANY, '37', {'prefix_19107_DEL': None}, user=self.user,
+            mock.ANY, '37', {'prefix_19107_DEL': None}, self.user, return_all_queried_families=False,
         )
         expected_samples = {
             s for s in self.search_samples if s.guid in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
@@ -93,7 +93,7 @@ class SearchUtilsTests(SearchTestHelper):
             '2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G'),
             '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
             'prefix-938_DEL': None,
-        }, user=self.user)
+        }, self.user)
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), set(self.search_samples))
 
         get_variants_for_variant_ids(
@@ -101,7 +101,7 @@ class SearchUtilsTests(SearchTestHelper):
         mock_get_variants_for_ids.assert_called_with(mock.ANY, '37', {
             '2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G'),
             '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
-        }, user=self.user)
+        }, self.user)
         expected_samples = {
             s for s in self.search_samples if s.guid not in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
         }

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -38,8 +38,10 @@ DATASET_TYPES_LOOKUP = {
 DATASET_TYPES_LOOKUP[ALL_DATA_TYPES] = [dt for dts in DATASET_TYPES_LOOKUP.values() for dt in dts]
 
 
-def _no_es_error(*args, **kwargs):
-    raise InvalidSearchException('Elasticsearch backend is disabled')
+def _raise_search_error(error):
+    def _wrapped(*args, **kwargs):
+        raise InvalidSearchException(error)
+    return _wrapped
 
 
 def backend_specific_call(es_func, other_func):
@@ -58,7 +60,7 @@ def ping_search_backend_admin():
 
 
 def get_search_backend_status():
-    return backend_specific_call(get_elasticsearch_status, _no_es_error)()
+    return backend_specific_call(get_elasticsearch_status, _raise_search_error('Elasticsearch is disabled'))()
 
 
 def _get_filtered_search_samples(search_filter, active_only=True):
@@ -103,11 +105,13 @@ def delete_search_backend_data(data_id):
         projects = set(active_samples.values_list('individual__family__project__name', flat=True))
         raise InvalidSearchException(f'"{data_id}" is still used by: {", ".join(projects)}')
 
-    return backend_specific_call(delete_es_index, _no_es_error)(data_id)
+    return backend_specific_call(
+        delete_es_index, _raise_search_error('Deleting indices is disabled for the hail backend'),
+    )(data_id)
 
 
 def get_single_variant(families, variant_id, return_all_queried_families=False, user=None):
-    variants = backend_specific_call(get_es_variants_for_variant_ids, _no_es_error)(  # TODO
+    variants = backend_specific_call(get_es_variants_for_variant_ids, _raise_search_error('Elasticsearch backend is disabled'))(  # TODO
         *_get_families_search_data(families), [variant_id], user, return_all_queried_families=return_all_queried_families,
     )
     if not variants:
@@ -116,7 +120,7 @@ def get_single_variant(families, variant_id, return_all_queried_families=False, 
 
 
 def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None):
-    return backend_specific_call(get_es_variants_for_variant_ids, _no_es_error)(  # TODO
+    return backend_specific_call(get_es_variants_for_variant_ids, _raise_search_error('Elasticsearch backend is disabled'))(  # TODO
         *_get_families_search_data(families), variant_ids, user, dataset_type=dataset_type,
     )
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -110,14 +110,20 @@ def delete_search_backend_data(data_id):
     )(data_id)
 
 
-def get_single_variant(families, variant_id, **kwargs):
-    variants = get_variants_for_variant_ids(families, [variant_id], **kwargs)
+def get_single_variant(families, variant_id, return_all_queried_families=False, user=None):
+    variants = _get_variants_for_variant_ids(
+        families, [variant_id], user, return_all_queried_families=return_all_queried_families,
+    )
     if not variants:
         raise InvalidSearchException('Variant {} not found'.format(variant_id))
     return variants[0]
 
 
-def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, **kwargs):
+def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None):
+    return _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=dataset_type)
+
+
+def _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=None, **kwargs):
     parsed_variant_ids = {}
     for variant_id in variant_ids:
         try:
@@ -137,7 +143,7 @@ def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, **kwa
         dataset_type = Sample.DATASET_TYPE_SV_CALLS
 
     return backend_specific_call(get_es_variants_for_variant_ids, get_hail_variants_for_variant_ids)(
-        *_get_families_search_data(families, dataset_type=dataset_type), parsed_variant_ids, **kwargs
+        *_get_families_search_data(families, dataset_type=dataset_type), parsed_variant_ids, user, **kwargs
     )
 
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -135,7 +135,7 @@ def _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=None
         parsed_variant_ids = {
             k: v for k, v in parsed_variant_ids.items()
             if (dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS and v) or
-               (dataset_type == Sample.DATASET_TYPE_SV_CALLS and not v)
+               (dataset_type != Sample.DATASET_TYPE_VARIANT_CALLS and not v)
         }
     elif all(v for v in parsed_variant_ids.values()):
         dataset_type = Sample.DATASET_TYPE_VARIANT_CALLS

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -38,11 +38,11 @@ DATASET_TYPES_LOOKUP = {
 DATASET_TYPES_LOOKUP[ALL_DATA_TYPES] = [dt for dts in DATASET_TYPES_LOOKUP.values() for dt in dts]
 
 
-def _no_backend_error(*args, **kwargs):
+def _no_es_error(*args, **kwargs):
     raise InvalidSearchException('Elasticsearch backend is disabled')
 
 
-def backend_specific_call(es_func, other_func=_no_backend_error):
+def backend_specific_call(es_func, other_func):
     if es_backend_enabled():
         return es_func
     else:
@@ -58,7 +58,7 @@ def ping_search_backend_admin():
 
 
 def get_search_backend_status():
-    return backend_specific_call(get_elasticsearch_status)()
+    return backend_specific_call(get_elasticsearch_status, _no_es_error)()
 
 
 def _get_filtered_search_samples(search_filter, active_only=True):
@@ -103,11 +103,11 @@ def delete_search_backend_data(data_id):
         projects = set(active_samples.values_list('individual__family__project__name', flat=True))
         raise InvalidSearchException(f'"{data_id}" is still used by: {", ".join(projects)}')
 
-    return backend_specific_call(delete_es_index)(data_id)
+    return backend_specific_call(delete_es_index, _no_es_error)(data_id)
 
 
 def get_single_variant(families, variant_id, return_all_queried_families=False, user=None):
-    variants = backend_specific_call(get_es_variants_for_variant_ids)(
+    variants = backend_specific_call(get_es_variants_for_variant_ids, _no_es_error)(  # TODO
         *_get_families_search_data(families), [variant_id], user, return_all_queried_families=return_all_queried_families,
     )
     if not variants:
@@ -116,7 +116,7 @@ def get_single_variant(families, variant_id, return_all_queried_families=False, 
 
 
 def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None):
-    return backend_specific_call(get_es_variants_for_variant_ids)(
+    return backend_specific_call(get_es_variants_for_variant_ids, _no_es_error)(  # TODO
         *_get_families_search_data(families), variant_ids, user, dataset_type=dataset_type,
     )
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -132,11 +132,11 @@ def _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=None
             parsed_variant_ids[variant_id] = None
 
     if dataset_type:
-        def is_valid(v_id):
-            if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
-                return bool(v_id)
-            return not v_id
-        parsed_variant_ids = {k: v for k, v in parsed_variant_ids.items() if is_valid(v)}
+        parsed_variant_ids = {
+            k: v for k, v in parsed_variant_ids.items()
+            if (dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS and v) or
+               (dataset_type == Sample.DATASET_TYPE_SV_CALLS and not v)
+        }
     elif all(v for v in parsed_variant_ids.values()):
         dataset_type = Sample.DATASET_TYPE_VARIANT_CALLS
     elif all(v is None for v in parsed_variant_ids.values()):

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -412,7 +412,7 @@ class DataManagerAPITest(AuthenticationTestCase):
         with mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', ''):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json()['error'], 'Elasticsearch backend is disabled')
+            self.assertEqual(response.json()['error'], 'Elasticsearch is disabled')
 
     @mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', 'testhost')
     @urllib3_responses.activate
@@ -446,7 +446,7 @@ class DataManagerAPITest(AuthenticationTestCase):
         with mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', ''):
             response = self.client.post(url, content_type='application/json', data=json.dumps({'index': 'unused_index'}))
             self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json()['error'], 'Elasticsearch backend is disabled')
+            self.assertEqual(response.json()['error'], 'Deleting indices is disabled for the hail backend')
 
     @mock.patch('seqr.utils.file_utils.subprocess.Popen')
     def test_upload_qc_pipeline_output(self, mock_subprocess):

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -311,7 +311,7 @@ We have loaded 1 samples from the AnVIL workspace {anvil_link} to the correspond
         with mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', ''):
             response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['error'], 'Elasticsearch backend is disabled')
+        self.assertEqual(response.json()['errors'][0], 'Adding samples is disabled for the hail backend')
 
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
This implements all the remaining requests to the hail backend, or explicitly sets exceptions for requests we do not plan to support