### PR TITLE
better test stablity for gregor report

### DIFF
--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -870,7 +870,7 @@ def _get_gregor_airtable_data(individuals, user):
     fields = ALL_AIRTABLE_COLUMNS
     airtable_metadata = session.fetch_records(
         'GREGoR Data Model',
-        fields=[SMID_FIELD] + fields,
+        fields=[SMID_FIELD] + sorted(fields),
         or_filters={f'{SMID_FIELD}': {r[SMID_FIELD] for r in sample_records.values()}},
     )
     airtable_metadata_by_smid = {r[SMID_FIELD]: r for r in airtable_metadata.values()}

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -825,12 +825,12 @@ class ReportAPITest(object):
         sample_fields[0] = 'SeqrCollaboratorSampleID'
         self._assert_expected_airtable_call(1, secondary_sample_filter, sample_fields)
         metadata_fields = [
-            'SMID', 'seq_library_prep_kit_method', 'read_length', 'experiment_type', 'targeted_regions_method',
-            'targeted_region_bed_file', 'date_data_generation', 'target_insert_size', 'sequencing_platform',
-            'aligned_dna_short_read_file', 'aligned_dna_short_read_index_file', 'md5sum', 'reference_assembly',
-            'alignment_software', 'mean_coverage', 'analysis_details',
-            'called_variants_dna_short_read_id', 'aligned_dna_short_read_set_id',
-            'called_variants_dna_file', 'md5sum', 'caller_software', 'variant_types', 'analysis_details',
+            'SMID', 'aligned_dna_short_read_file', 'aligned_dna_short_read_index_file', 'aligned_dna_short_read_set_id',
+            'alignment_software', 'analysis_details', 'analysis_details', 'called_variants_dna_file',
+            'called_variants_dna_short_read_id', 'caller_software', 'date_data_generation', 'experiment_type',
+            'md5sum', 'md5sum', 'mean_coverage', 'read_length', 'reference_assembly', 'seq_library_prep_kit_method',
+            'sequencing_platform', 'target_insert_size', 'targeted_region_bed_file', 'targeted_regions_method',
+            'variant_types',
         ]
         self._assert_expected_airtable_call(2, "OR(SMID='SM-AGHT',SMID='SM-JDBTM')", metadata_fields)
 


### PR DESCRIPTION
There are going to be substantial changes to which fields we query from airtable, so I would like the order of these fields to be  clear in the test so its easy to see what changed