### PR TITLE
split parse pedigree functionality

### DIFF
--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -28,7 +28,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.file_utils import load_uploaded_file
 from seqr.views.utils.terra_api_utils import add_service_account, has_service_account_access, TerraAPIException, \
     TerraRefreshTokenFailedException
-from seqr.views.utils.pedigree_info_utils import parse_pedigree_table, JsonConstants
+from seqr.views.utils.pedigree_info_utils import parse_basic_pedigree_table, JsonConstants
 from seqr.views.utils.individual_utils import add_or_update_individuals_and_families
 from seqr.utils.communication_utils import safe_post_to_slack, send_html_email
 from seqr.utils.file_utils import does_file_exist, mv_file_to_gs, get_gs_file_list
@@ -192,7 +192,7 @@ def create_project_from_workspace(request, namespace, name):
         error = 'Field(s) "{}" are required'.format(', '.join(missing_fields))
         return create_json_response({'error': error}, status=400, reason=error)
 
-    pedigree_records = _parse_uploaded_pedigree(request_json, request.user)
+    pedigree_records = _parse_uploaded_pedigree(request_json)
 
     # Create a new Project in seqr
     project_args = {
@@ -232,7 +232,7 @@ def add_workspace_data(request, project_guid):
         error = 'Field(s) "{}" are required'.format(', '.join(missing_fields))
         return create_json_response({'error': error}, status=400, reason=error)
 
-    pedigree_records = _parse_uploaded_pedigree(request_json, request.user)
+    pedigree_records = _parse_uploaded_pedigree(request_json)
 
     previous_samples = get_search_samples([project]).filter(
         dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS).prefetch_related('individual')
@@ -257,11 +257,11 @@ def add_workspace_data(request, project_guid):
     return create_json_response(pedigree_json)
 
 
-def _parse_uploaded_pedigree(request_json, user):
+def _parse_uploaded_pedigree(request_json):
     # Parse families/individuals in the uploaded pedigree file
     json_records = load_uploaded_file(request_json['uploadedFileId'])
-    pedigree_records, _ = parse_pedigree_table(
-        json_records, 'uploaded pedigree file', user=user, fail_on_warnings=True, required_columns=[
+    pedigree_records, _ = parse_basic_pedigree_table(
+        json_records, 'uploaded pedigree file', required_columns=[
             JsonConstants.SEX_COLUMN, JsonConstants.AFFECTED_COLUMN,
         ])
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -103,12 +103,16 @@ class DatasetAPITest(object):
         )
         self.assertDictEqual(response_json['individualsByGuid'], {
             'I000002_na19678': {'sampleGuids': mock.ANY},
-            'I000003_na19679': {'sampleGuids': ['S000153_na19679', existing_sample_guid]},
+            'I000003_na19679': {'sampleGuids': mock.ANY},
             'I000013_na20878': {'sampleGuids': [new_sample_guid]},
         })
         self.assertSetEqual(
             set(response_json['individualsByGuid']['I000002_na19678']['sampleGuids']),
             {replaced_sample_guid, existing_old_index_sample_guid}
+        )
+        self.assertSetEqual(
+            set(response_json['individualsByGuid']['I000003_na19679']['sampleGuids']),
+            {'S000153_na19679', existing_sample_guid}
         )
 
         self.assertDictEqual(response_json['familiesByGuid'], {

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -542,20 +542,20 @@ class IndividualAPITest(object):
         response = _send_request_data(data)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {
-            'errors': ['Error while parsing file: sample_manifest.tsv. Unsupported file format'], 'warnings': [],
+            'errors': ['Unsupported file format'], 'warnings': [],
         })
 
         data[1] = header_2[:5] + header_2[7:10] + header_2[14:17] + ['Coded Phenotype'] + header_2[19:]
         response = _send_request_data(data)
         self.assertDictEqual(response.json(), {
-            'errors': ['Error while parsing file: sample_manifest.tsv. Unsupported file format'], 'warnings': [],
+            'errors': ['Unsupported file format'], 'warnings': [],
         })
 
         self.login_pm_user()
         response = _send_request_data(data)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'warnings': [], 'errors': [
-            'Error while parsing file: sample_manifest.tsv. Expected vs. actual header columns: | '
+            'Expected vs. actual header columns: | '
             'Sample ID| Family ID| Alias|-Alias|-Paternal Sample ID| Maternal Sample ID| Gender| Affected Status|'
             '-Primary Biosample|-Analyte Type|-Tissue Affected Status|-Recontactable| Volume| Concentration| Notes|'
             '-MONDO Label|-MONDO ID|+Coded Phenotype| Consent Code| Data Use Restrictions',
@@ -566,7 +566,6 @@ class IndividualAPITest(object):
         response = _send_request_data(data)
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'warnings': [], 'errors': [
-            'Error while parsing file: sample_manifest.tsv. '
             'Expected vs. actual header columns: |-Collaborator Participant ID| Collaborator Sample ID|+',
         ]})
 

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -24,21 +24,21 @@ RELATIONSHIP_REVERSE_LOOKUP = {v.lower(): k for k, v in Individual.RELATIONSHIP_
 def parse_pedigree_table(parsed_file, filename, user, project):
     """Validates and parses pedigree information from a .fam, .tsv, or Excel file.
 
-        Args:
-            parsed_file (array): The parsed output from the raw file.
-            filename (string): The original filename - used to determine the file format based on the suffix.
-            user (User): (optional) Django User object
-            project (Project): (optional) Django Project object
+    Args:
+        parsed_file (array): The parsed output from the raw file.
+        filename (string): The original filename - used to determine the file format based on the suffix.
+        user (User): (optional) Django User object
+        project (Project): (optional) Django Project object
 
-        Return:
-            A 3-tuple that contains:
-            (
-                json_records (list): list of dictionaries, with each dictionary containing info about
-                    one of the individuals in the input data
-                errors (list): list of error message strings
-                warnings (list): list of warning message strings
-            )
-        """
+    Return:
+        A 3-tuple that contains:
+        (
+            json_records (list): list of dictionaries, with each dictionary containing info about
+                one of the individuals in the input data
+            errors (list): list of error message strings
+            warnings (list): list of warning message strings
+        )
+    """
     header_string = str(parsed_file[0])
     is_merged_pedigree_sample_manifest = "do not modify" in header_string.lower() and "Broad" in header_string
     if is_merged_pedigree_sample_manifest:

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -27,8 +27,8 @@ def parse_pedigree_table(parsed_file, filename, user, project):
     Args:
         parsed_file (array): The parsed output from the raw file.
         filename (string): The original filename - used to determine the file format based on the suffix.
-        user (User): (optional) Django User object
-        project (Project): (optional) Django Project object
+        user (User): Django User object
+        project (Project): Django Project object
 
     Return:
         A 3-tuple that contains:


### PR DESCRIPTION
while implementing https://github.com/broadinstitute/seqr/pull/3444 there was an edge case in the code that was nearly impossible to test, essentially because `parse_pedigree_table` was being called in 2 different places with 2 pretty different sets of arguments, but the code had error handling for all the possible argument combinations. This splits the functionality out, creating a `parse_basic_pedigree_table` helper that only works on standard pedigree formats and does not allow all the extra arguments for the sample manifest