### PR TITLE
handle invalid version directories for dag trigger

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -449,7 +449,8 @@ def load_data(request):
 
     version_path_prefix = f'{SEQR_DATSETS_GS_PATH}/GRCh38/{dag_name}'
     version_paths = get_gs_file_list(version_path_prefix, user=request.user, allow_missing=True, check_subfolders=False)
-    curr_version = max([int(re.findall(f'{version_path_prefix}/v(\d\d)/', p)[0]) for p in version_paths] + [0])
+    versions = [re.findall(f'{version_path_prefix}/v(\d\d)/', p) for p in version_paths]
+    curr_version = max([int(v[0]) for v in versions if v] + [0])
     dag_variables = {'version_path': f'{version_path_prefix}/v{curr_version+1:02d}'}
 
     success_message = f'*{request.user.email}* triggered loading internal {sample_type} {dataset_type} data for {len(projects)} projects'

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1295,7 +1295,7 @@ class LoadDataAPITest(AirflowTestCase):
         # Test loading trigger error
         self.mock_slack.reset_mock()
         responses.calls.reset()
-        mock_subprocess.return_value.communicate.return_value = b'gs://seqr-datasets/v02/GRCh38/RDG_WGS_Broad_Internal_SV/v01/\ngs://seqr-datasets/v02/GRCh38/RDG_WGS_Broad_Internal_SV/v02/', b''
+        mock_subprocess.return_value.communicate.return_value = b'gs://seqr-datasets/v02/GRCh38/RDG_WGS_Broad_Internal_SV/\ngs://seqr-datasets/v02/GRCh38/RDG_WGS_Broad_Internal_SV/v01/\ngs://seqr-datasets/v02/GRCh38/RDG_WGS_Broad_Internal_SV/v02/', b''
 
         body.update({'datasetType': 'SV', 'filePath': 'gs://test_bucket/sv_callset.vcf'})
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))


### PR DESCRIPTION
Triggering the dag through the new UI fails if the directory has any non-version files or folders