### PR TITLE
fix on success function order

### DIFF
--- a/ui/shared/components/panel/LoadWorkspaceDataForm.jsx
+++ b/ui/shared/components/panel/LoadWorkspaceDataForm.jsx
@@ -148,7 +148,7 @@ const onProjectCreateSuccess = (responseJson) => {
 
 const formatAddDataUrl = ({ projectGuid }) => (`/api/project/${projectGuid}/add_workspace_data`)
 
-const onAddDataFromWorkspace = dispatch => (responseJson) => {
+const onAddDataFromWorkspace = responseJson => (dispatch) => {
   dispatch({ type: RECEIVE_DATA, updatesById: responseJson })
 }
 


### PR DESCRIPTION
I'm not sure how these arguments got flipped, but they are supposed to be the other way around and everything works fine once this is changed