### PR TITLE
fix variant warning icon hover

### DIFF
--- a/ui/shared/components/panel/variants/VariantIndividuals.jsx
+++ b/ui/shared/components/panel/variants/VariantIndividuals.jsx
@@ -70,7 +70,7 @@ const AlleleContainer = styled(Header).attrs({ size: 'medium' })`
   }
 `
 
-const WarningIcon = styled(Icon).attrs({ name: 'warning sign', color: 'yellow' })``
+const WarningIcon = props => <Icon name="warning sign" color="yellow" {...props} />
 
 const PAR_REGIONS = {
   37: {


### PR DESCRIPTION
fixes a bug with ref forwarding for the styled components package by removing an unnecessary usage of said library