### PR TITLE
properly format vest

### DIFF
--- a/seqr/utils/search/elasticsearch/constants.py
+++ b/seqr/utils/search/elasticsearch/constants.py
@@ -338,7 +338,7 @@ PREDICTION_FIELDS_CONFIG = {
     'cadd_PHRED': {'response_key': 'cadd'},
     'dbnsfp_DANN_score': {},
     'eigen_Eigen_phred': {},
-    'dbnsfp_VEST4_score': {'response_key': 'vest'},
+    'dbnsfp_VEST4_score': {'response_key': 'vest', 'format_value': lambda x: x.split(';')[0]},
     'dbnsfp_MutPred_score': {'response_key': 'mut_pred'},
     'mpc_MPC': {},
     'dbnsfp_MutationTaster_pred': {'response_key': 'mut_taster'},

--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -76,6 +76,7 @@ ES_VARIANTS = [
           'exac_AC_Hom': 0,
           'topmed_AC': 21,
           'dbnsfp_REVEL_score': None,
+          'dbnsfp_VEST4_score': '0.335;0.341;0.38',
           'primate_ai_score': None,
           'variantId': '1-248367227-TC-T',
           'sortedTranscriptConsequences': [

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -1057,7 +1057,7 @@ PARSED_VARIANTS = [
         },
         'pos': 248367227,
         'predictions': {'splice_ai': 0.75, 'eigen': None, 'revel': None, 'mut_taster': None, 'fathmm': 'D',
-                        'vest': None, 'mut_pred': None,
+                        'vest': '0.335', 'mut_pred': None,
                         'hmtvar': None, 'apogee': None, 'haplogroup_defining': None, 'mitotip': None,
                         'polyphen': None, 'dann': None, 'sift': None, 'cadd': '25.9', 'primate_ai': None,
                         'mpc': None, 'strvctvre': None, 'splice_ai_consequence': None, 'gnomad_noncoding': 1.01272,},


### PR DESCRIPTION
recent changes to the UI cause an unhandled JS error on an invalid search results value which was previously being hidden from the user. The fix is to properly format this value so it is displayed properly