### PR TITLE
properly format null vest values

### DIFF
--- a/seqr/utils/search/elasticsearch/constants.py
+++ b/seqr/utils/search/elasticsearch/constants.py
@@ -338,7 +338,7 @@ PREDICTION_FIELDS_CONFIG = {
     'cadd_PHRED': {'response_key': 'cadd'},
     'dbnsfp_DANN_score': {},
     'eigen_Eigen_phred': {},
-    'dbnsfp_VEST4_score': {'response_key': 'vest', 'format_value': lambda x: x.split(';')[0]},
+    'dbnsfp_VEST4_score': {'response_key': 'vest', 'format_value': lambda x: x and x.split(';')[0]},
     'dbnsfp_MutPred_score': {'response_key': 'mut_pred'},
     'mpc_MPC': {},
     'dbnsfp_MutationTaster_pred': {'response_key': 'mut_taster'},

--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -317,6 +317,7 @@ ES_VARIANTS = [
           'gnomad_genomes_AN': None,
           'dbnsfp_MetaSVM_pred': None,
           'dbnsfp_Polyphen2_HVAR_pred': None,
+          'dbnsfp_VEST4_score': None,
           'clinvar_allele_id': None,
           'gnomad_exomes_Hom': 0,
           'gnomad_exomes_AF_POPMAX_OR_GLOBAL': 0.00016269686320447742,


### PR DESCRIPTION
I did not properly handle the fact that in elasticsearch missing keyword fields are nulls and not empty strings