### PR TITLE
Fix eslint

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -1,12 +1,13 @@
 {
   "extends": [
     "airbnb",
-    "plugin:react-perf/recommended",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:react-perf/recommended"
+    // "plugin:@typescript-eslint/recommended"
   ],
-
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
+  // TODO: https://github.com/broadinstitute/seqr/issues/2931 update linting after complete migration of the project into typescript.
+  // "parser": "@typescript-eslint/parser",
+  // "plugins": ["@typescript-eslint"],
+  "parser": "babel-eslint",
   "parserOptions": {
     "ecmaFeatures": {
       "experimentalObjectRestSpread": true
@@ -64,11 +65,6 @@
     "react/require-optimization": "error",
     "react/state-in-constructor": ["error", "never"],
     "react/static-property-placement": ["error", "static public field"],
-    // TODO: Remove all the rule below this after complete migration of the project into typescript.
-    "import/extensions": "off",
-    "@typescript-eslint/no-unused-vars": "off",
-    "react/prop-types": "off",
-    "no-use-before-define": "off",
-    "react/sort-comp": "off"
+    "import/extensions": "off"
   }
 }


### PR DESCRIPTION
https://github.com/broadinstitute/seqr/pull/3682 redid and disabled a lot of the linting rules. We should update linting for typescript once that whole migration is done, and in the meantime keep our linting as is