### PR TITLE
use query table for variant id query

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -531,17 +531,15 @@ class BaseHailTableQuery(object):
         if not (intervals or is_x_linked):
             return intervals
 
-        reference_genome = hl.get_reference(self._genome_version)
-        should_add_chr_prefix = any(c.startswith('chr') for c in reference_genome.contigs)
-
         raw_intervals = intervals
-        if should_add_chr_prefix:
+        if self._genome_version == 'GRCh38':
             intervals = [
                 f'[chr{interval.replace("[", "")}' if interval.startswith('[') else f'chr{interval}'
                 for interval in (intervals or [])
             ]
 
         if is_x_linked:
+            reference_genome = hl.get_reference(self._genome_version)
             intervals = (intervals or []) + [reference_genome.x_contigs[0]]
 
         parsed_intervals = [

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -532,7 +532,7 @@ class BaseHailTableQuery(object):
             return intervals
 
         raw_intervals = intervals
-        if self._genome_version == 'GRCh38':
+        if self._should_add_chr_prefix():
             intervals = [
                 f'[chr{interval.replace("[", "")}' if interval.startswith('[') else f'chr{interval}'
                 for interval in (intervals or [])
@@ -551,6 +551,9 @@ class BaseHailTableQuery(object):
             raise HTTPBadRequest(reason=f'Invalid intervals: {", ".join(invalid_intervals)}')
 
         return parsed_intervals
+
+    def _should_add_chr_prefix(self):
+        return self._genome_version == 'GRCh38'
 
     def _filter_by_frequency(self, frequencies, pathogenicity):
         frequencies = {k: v for k, v in (frequencies or {}).items() if k in self.POPULATIONS}

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -181,7 +181,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
 
         return [
             hl.struct(
-                locus=hl.locus(f'chr{chrom}' if self._genome_version == 'GRCh38' else chrom, pos, reference_genome=self._genome_version),
+                locus=hl.locus(f'chr{chrom}' if self._should_add_chr_prefix() else chrom, pos, reference_genome=self._genome_version),
                 alleles=[ref, alt],
             ) for chrom, pos, ref, alt in variant_ids
         ]

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -9,6 +9,7 @@ from hail_search.queries.base import BaseHailTableQuery, PredictionPath, Quality
 class MitoHailTableQuery(BaseHailTableQuery):
 
     DATA_TYPE = 'MITO'
+    KEY_FIELD = ('locus', 'alleles')
 
     TRANSCRIPTS_FIELD = 'sorted_transcript_consequences'
     TRANSCRIPT_CONSEQUENCE_FIELD = 'consequence_term'
@@ -124,11 +125,11 @@ class MitoHailTableQuery(BaseHailTableQuery):
         self._filter_hts = {}
         super().__init__(*args, **kwargs)
 
-    def _parse_intervals(self, intervals, variant_ids, exclude_intervals=False, **kwargs):
-        parsed_intervals, variant_ids = super()._parse_intervals(intervals, variant_ids, **kwargs)
+    def _parse_intervals(self, intervals, exclude_intervals=False, **kwargs):
+        parsed_intervals = super()._parse_intervals(intervals,**kwargs)
         if parsed_intervals and not exclude_intervals:
             self._load_table_kwargs = {'_intervals': parsed_intervals, '_filter_intervals': True}
-        return parsed_intervals, variant_ids
+        return parsed_intervals
 
     def _get_family_passes_quality_filter(self, quality_filter, ht=None, pathogenicity=None, **kwargs):
         passes_quality = super()._get_family_passes_quality_filter(quality_filter)
@@ -173,6 +174,18 @@ class MitoHailTableQuery(BaseHailTableQuery):
                 for chrom, pos, ref, alt in variant_ids
             ])
         return ht.filter(variant_id_q)
+
+    def _parse_variant_keys(self, variant_ids=None, **kwargs):
+        if not variant_ids:
+            return variant_ids
+
+        should_add_chr_prefix = any(c.startswith('chr') for c in hl.get_reference(self._genome_version).contigs)
+        return [
+            hl.struct(
+                locus=hl.locus(f'chr{chrom}' if should_add_chr_prefix else chrom, pos, reference_genome=self._genome_version),
+                alleles=[ref, alt],
+            ) for chrom, pos, ref, alt in variant_ids
+        ]
 
     def _prefilter_entries_table(self, ht, parsed_intervals=None, exclude_intervals=False, **kwargs):
         if exclude_intervals and parsed_intervals:

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -179,10 +179,9 @@ class MitoHailTableQuery(BaseHailTableQuery):
         if not variant_ids:
             return variant_ids
 
-        should_add_chr_prefix = any(c.startswith('chr') for c in hl.get_reference(self._genome_version).contigs)
         return [
             hl.struct(
-                locus=hl.locus(f'chr{chrom}' if should_add_chr_prefix else chrom, pos, reference_genome=self._genome_version),
+                locus=hl.locus(f'chr{chrom}' if self._genome_version == 'GRCh38' else chrom, pos, reference_genome=self._genome_version),
                 alleles=[ref, alt],
             ) for chrom, pos, ref, alt in variant_ids
         ]

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -8,6 +8,7 @@ from hail_search.queries.base import BaseHailTableQuery, PredictionPath
 class SvHailTableQuery(BaseHailTableQuery):
 
     DATA_TYPE = 'SV_WGS'
+    KEY_FIELD = ('variant_id',)
 
     GENOTYPE_FIELDS = {f.lower(): f for f in ['CN', 'GQ']}
     COMPUTED_GENOTYPE_FIELDS = {
@@ -48,10 +49,6 @@ class SvHailTableQuery(BaseHailTableQuery):
             r.start_locus.contig == r.end_locus.contig, r.start_locus.position - r.end_locus.position, -50,
         )],
     }
-
-    def _parse_intervals(self, intervals, variant_ids, variant_keys=None, **kwargs):
-        parsed_intervals, _ = super()._parse_intervals(intervals, variant_ids=None, **kwargs)
-        return parsed_intervals, variant_keys
 
     def _filter_annotated_table(self, *args, parsed_intervals=None, exclude_intervals=False, **kwargs):
         if parsed_intervals:

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -10,7 +10,7 @@ from seqr.utils.search.utils import get_single_variant, get_variants_for_variant
     query_variants, InvalidSearchException
 from seqr.views.utils.test_utils import PARSED_VARIANTS, PARSED_COMPOUND_HET_VARIANTS_MULTI_PROJECT, GENE_FIELDS
 
-
+# TODO lookup tests
 class SearchTestHelper(object):
 
     def set_up(self):


### PR DESCRIPTION
Changes how variant-id specific queries are executed, uses query_table instead of filtering to specific variant IDs to improve performance 