### PR TITLE
Gregor report - column refactor

### DIFF
--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -154,64 +154,59 @@ GREGOR_DATA_TYPES = ['wgs', 'wes', 'rna']
 SMID_FIELD = 'SMID'
 PARTICIPANT_ID_FIELD = 'CollaboratorParticipantID'
 COLLABORATOR_SAMPLE_ID_FIELD = 'CollaboratorSampleID'
-PARTICIPANT_TABLE_COLUMNS = [
+PARTICIPANT_TABLE_COLUMNS = {
     'participant_id', 'internal_project_id', 'gregor_center', 'consent_code', 'recontactable', 'prior_testing',
-    'pmid_id', 'family_id', 'paternal_id', 'maternal_id', 'twin_id', 'proband_relationship',
-    'proband_relationship_detail', 'sex', 'sex_detail', 'reported_race', 'reported_ethnicity', 'ancestry_detail',
+    'pmid_id', 'family_id', 'paternal_id', 'maternal_id', 'proband_relationship',
+    'sex', 'reported_race', 'reported_ethnicity', 'ancestry_detail',
     'age_at_last_observation', 'affected_status', 'phenotype_description', 'age_at_enrollment',
-]
-GREGOR_FAMILY_TABLE_COLUMNS = [
-    'family_id', 'consanguinity', 'consanguinity_detail', 'pedigree_file', 'pedigree_file_detail', 'family_history_detail',
-]
-PHENOTYPE_TABLE_COLUMNS = [
+}
+GREGOR_FAMILY_TABLE_COLUMNS = {'family_id', 'consanguinity'}
+PHENOTYPE_TABLE_COLUMNS = {
     'phenotype_id', 'participant_id', 'term_id', 'presence', 'ontology', 'additional_details', 'onset_age_range',
     'additional_modifiers',
-]
-ANALYTE_TABLE_COLUMNS = [
-    'analyte_id', 'participant_id', 'analyte_type', 'analyte_processing_details', 'primary_biosample',
-    'primary_biosample_id', 'primary_biosample_details', 'tissue_affected_status', 'age_at_collection',
-    'participant_drugs_intake', 'participant_special_diet', 'hours_since_last_meal', 'passage_number', 'time_to_freeze',
-    'sample_transformation_detail', 'quality_issues',
-]
+}
+ANALYTE_TABLE_COLUMNS = {
+    'analyte_id', 'participant_id', 'analyte_type', 'primary_biosample', 'tissue_affected_status',
+}
 EXPERIMENT_TABLE_AIRTABLE_FIELDS = [
     'seq_library_prep_kit_method', 'read_length', 'experiment_type', 'targeted_regions_method',
     'targeted_region_bed_file', 'date_data_generation', 'target_insert_size', 'sequencing_platform',
 ]
-EXPERIMENT_TABLE_COLUMNS = [
-    'experiment_dna_short_read_id', 'analyte_id', 'experiment_sample_id',
-] + EXPERIMENT_TABLE_AIRTABLE_FIELDS
+EXPERIMENT_COLUMNS = {'analyte_id', 'experiment_sample_id'}
+EXPERIMENT_TABLE_COLUMNS = {'experiment_dna_short_read_id'}
+EXPERIMENT_TABLE_COLUMNS.update(EXPERIMENT_COLUMNS)
+EXPERIMENT_TABLE_COLUMNS.update(EXPERIMENT_TABLE_AIRTABLE_FIELDS)
 EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS = [
     'library_prep_type', 'single_or_paired_ends', 'within_site_batch_name', 'RIN', 'estimated_library_size',
     'total_reads', 'percent_rRNA', 'percent_mRNA', '5prime3prime_bias',
 ]
-EXPERIMENT_RNA_TABLE_COLUMNS = ['experiment_rna_short_read_id'] + [
-    c for c in EXPERIMENT_TABLE_COLUMNS[1:] if not c.startswith('target')] + EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS + [
-    'percent_mtRNA', 'percent_Globin', 'percent_UMI',  'percent_GC', 'percent_chrX_Y',
-]
-EXPERIMENT_LOOKUP_TABLE_COLUMNS = ['experiment_id', 'table_name', 'id_in_table', 'participant_id']
+EXPERIMENT_RNA_TABLE_COLUMNS = {'experiment_rna_short_read_id'}
+EXPERIMENT_RNA_TABLE_COLUMNS.update(EXPERIMENT_COLUMNS)
+EXPERIMENT_RNA_TABLE_COLUMNS.update(EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS)
+EXPERIMENT_RNA_TABLE_COLUMNS.update([c for c in EXPERIMENT_TABLE_AIRTABLE_FIELDS if not c.startswith('target')])
+EXPERIMENT_LOOKUP_TABLE_COLUMNS = {'experiment_id', 'table_name', 'id_in_table', 'participant_id'}
 READ_TABLE_AIRTABLE_FIELDS = [
     'aligned_dna_short_read_file', 'aligned_dna_short_read_index_file', 'md5sum', 'reference_assembly',
     'mean_coverage', 'alignment_software', 'analysis_details',
 ]
-READ_TABLE_COLUMNS = ['aligned_dna_short_read_id', 'experiment_dna_short_read_id'] + READ_TABLE_AIRTABLE_FIELDS + ['quality_issues']
-READ_TABLE_COLUMNS.insert(6, 'reference_assembly_details')
-READ_TABLE_COLUMNS.insert(6, 'reference_assembly_uri')
+READ_TABLE_COLUMNS = {'aligned_dna_short_read_id', 'experiment_dna_short_read_id'}
+READ_TABLE_COLUMNS.update(READ_TABLE_AIRTABLE_FIELDS)
 READ_RNA_TABLE_AIRTABLE_ID_FIELDS = ['aligned_rna_short_read_file', 'aligned_rna_short_read_index_file']
 READ_RNA_TABLE_AIRTABLE_FIELDS = [
     'gene_annotation', 'alignment_software', 'alignment_log_file', 'percent_uniquely_aligned', 'percent_multimapped', 'percent_unaligned',
 ]
-READ_RNA_TABLE_COLUMNS = ['aligned_rna_short_read_id', 'experiment_rna_short_read_id'] + \
-    READ_RNA_TABLE_AIRTABLE_ID_FIELDS + READ_TABLE_COLUMNS[4:-3] + READ_RNA_TABLE_AIRTABLE_FIELDS + ['quality_issues']
-READ_RNA_TABLE_COLUMNS.insert(READ_RNA_TABLE_COLUMNS.index('gene_annotation')+1, 'gene_annotation_details')
-READ_RNA_TABLE_COLUMNS.insert(READ_RNA_TABLE_COLUMNS.index('alignment_log_file')+1, 'alignment_postprocessing')
-READ_SET_TABLE_COLUMNS = ['aligned_dna_short_read_set_id', 'aligned_dna_short_read_id']
+READ_RNA_TABLE_COLUMNS = {'aligned_rna_short_read_id', 'experiment_rna_short_read_id'}
+READ_RNA_TABLE_COLUMNS.update(READ_RNA_TABLE_AIRTABLE_ID_FIELDS)
+READ_RNA_TABLE_COLUMNS.update(READ_RNA_TABLE_AIRTABLE_FIELDS)
+READ_RNA_TABLE_COLUMNS.update(READ_TABLE_AIRTABLE_FIELDS[2:-1])
+READ_SET_TABLE_COLUMNS = {'aligned_dna_short_read_set_id', 'aligned_dna_short_read_id'}
 CALLED_VARIANT_FILE_COLUMN = 'called_variants_dna_file'
-CALLED_TABLE_COLUMNS = [
+CALLED_TABLE_COLUMNS = {
     'called_variants_dna_short_read_id', 'aligned_dna_short_read_set_id', CALLED_VARIANT_FILE_COLUMN, 'md5sum',
     'caller_software', 'variant_types', 'analysis_details',
-]
+}
 
-RNA_ONLY = EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS + READ_RNA_TABLE_AIRTABLE_FIELDS + ['reference_assembly_uri']
+RNA_ONLY = EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS + READ_RNA_TABLE_AIRTABLE_FIELDS
 DATA_TYPE_OMIT = {
     'wgs': ['targeted_regions_method'] + RNA_ONLY, 'wes': RNA_ONLY, 'rna': [
         'targeted_regions_method', 'target_insert_size', 'mean_coverage', 'aligned_dna_short_read_file',
@@ -226,8 +221,9 @@ NO_DATA_TYPE_FIELDS.update(READ_RNA_TABLE_AIRTABLE_ID_FIELDS)
 
 DATA_TYPE_AIRTABLE_COLUMNS = EXPERIMENT_TABLE_AIRTABLE_FIELDS + READ_TABLE_AIRTABLE_FIELDS + RNA_ONLY + [
     COLLABORATOR_SAMPLE_ID_FIELD, SMID_FIELD]
-ALL_AIRTABLE_COLUMNS = DATA_TYPE_AIRTABLE_COLUMNS + CALLED_TABLE_COLUMNS
-AIRTABLE_QUERY_COLUMNS = set(CALLED_TABLE_COLUMNS)
+ALL_AIRTABLE_COLUMNS = DATA_TYPE_AIRTABLE_COLUMNS + list(CALLED_TABLE_COLUMNS)
+AIRTABLE_QUERY_COLUMNS = set()
+AIRTABLE_QUERY_COLUMNS.update(CALLED_TABLE_COLUMNS)
 AIRTABLE_QUERY_COLUMNS.remove('md5sum')
 AIRTABLE_QUERY_COLUMNS.update(NO_DATA_TYPE_FIELDS)
 for data_type in GREGOR_DATA_TYPES:
@@ -397,20 +393,23 @@ def gregor_export(request):
         for analyte_id in analyte_ids:
             analyte_rows.append(dict(participant_id=participant_id, analyte_id=analyte_id, **_get_analyte_row(individual)))
 
-    data = {
-        'participant': participant_rows,
-        'family': list(family_map.values()),
-        'phenotype': phenotype_rows,
-        'analyte': analyte_rows,
-        'experiment_dna_short_read': airtable_rows,
-        'aligned_dna_short_read': airtable_rows,
-        'aligned_dna_short_read_set': airtable_rows,
-        'called_variants_dna_short_read': [row for row in airtable_rows if row.get(CALLED_VARIANT_FILE_COLUMN)],
-        'experiment_rna_short_read': airtable_rna_rows,
-        'aligned_rna_short_read': airtable_rna_rows,
-        'experiment': experiment_lookup_rows,
-    }
-    files, warnings = _populate_gregor_files(data)
+    file_data = [
+        ('participant', PARTICIPANT_TABLE_COLUMNS, participant_rows),
+        ('family', GREGOR_FAMILY_TABLE_COLUMNS, list(family_map.values())),
+        ('phenotype', PHENOTYPE_TABLE_COLUMNS, phenotype_rows),
+        ('analyte', ANALYTE_TABLE_COLUMNS, analyte_rows),
+        ('experiment_dna_short_read', EXPERIMENT_TABLE_COLUMNS, airtable_rows),
+        ('aligned_dna_short_read', READ_TABLE_COLUMNS, airtable_rows),
+        ('aligned_dna_short_read_set', READ_SET_TABLE_COLUMNS, airtable_rows),
+        ('called_variants_dna_short_read', CALLED_TABLE_COLUMNS, [
+            row for row in airtable_rows if row.get(CALLED_VARIANT_FILE_COLUMN)
+        ]),
+        ('experiment_rna_short_read', EXPERIMENT_RNA_TABLE_COLUMNS, airtable_rna_rows),
+        ('aligned_rna_short_read', READ_RNA_TABLE_COLUMNS, airtable_rna_rows),
+        ('experiment', EXPERIMENT_LOOKUP_TABLE_COLUMNS, experiment_lookup_rows),
+    ]
+
+    files, warnings = _populate_gregor_files(file_data)
     write_multiple_files_to_gs(files, file_path, request.user, file_format='tsv')
 
     return create_json_response({
@@ -548,7 +547,7 @@ def _populate_gregor_files(file_data):
     except Exception as e:
         raise ErrorsWarningsException([f'Unable to load data model: {e}'])
 
-    tables = set(file_data.keys())
+    tables = {f[0] for f in file_data}
     missing_tables = [
         table for table, validator in required_tables.items() if not _has_required_table(table, validator, tables)
     ]
@@ -558,7 +557,7 @@ def _populate_gregor_files(file_data):
         )
 
     files = []
-    for file_name, data in file_data.items():
+    for file_name, expected_columns, data in file_data:
         table_config = table_configs.get(file_name)
         if not table_config:
             errors.append(f'No data model found for "{file_name}" table so no validation was performed')
@@ -566,14 +565,22 @@ def _populate_gregor_files(file_data):
 
         files.append((file_name, list(table_config.keys()), data))
 
+        extra_columns = expected_columns.difference(table_config.keys())
+        if extra_columns:
+            col_summary = ', '.join(sorted(extra_columns))
+            warnings.insert(
+                f'The following columns are computed for the "{file_name}" table but are missing from the data model: {col_summary}',
+                0
+            )
         invalid_data_type_columns = {
             col: config['data_type'] for col, config in table_config.items()
             if config.get('data_type') and config['data_type'] not in DATA_TYPE_VALIDATORS
         }
         if invalid_data_type_columns:
             col_summary = ', '.join(sorted([f'{col} ({data_type})' for col, data_type in invalid_data_type_columns.items()]))
-            warnings.append(
-                f'The following columns are included in the "{file_name}" data model but have an unsupported data type: {col_summary}'
+            warnings.insert(
+                f'The following columns are included in the "{file_name}" data model but have an unsupported data type: {col_summary}',
+                0
             )
         invalid_enum_columns = [
             col for col, config in table_config.items()
@@ -583,8 +590,9 @@ def _populate_gregor_files(file_data):
             for col in invalid_enum_columns:
                 table_config[col]['data_type'] = None
             col_summary = ', '.join(sorted(invalid_enum_columns))
-            warnings.append(
-                f'The following columns are specified as "enumeration" in the "{file_name}" data model but are missing the allowed values definition: {col_summary}'
+            warnings.insert(
+                f'The following columns are specified as "enumeration" in the "{file_name}" data model but are missing the allowed values definition: {col_summary}',
+                0
             )
 
         for column, config in table_config.items():

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -206,7 +206,7 @@ CALLED_TABLE_COLUMNS = {
     'caller_software', 'variant_types', 'analysis_details',
 }
 
-RNA_ONLY = EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS + READ_RNA_TABLE_AIRTABLE_FIELDS
+RNA_ONLY = EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS + READ_RNA_TABLE_AIRTABLE_FIELDS + ['reference_assembly_uri']
 DATA_TYPE_OMIT = {
     'wgs': ['targeted_regions_method'] + RNA_ONLY, 'wes': RNA_ONLY, 'rna': [
         'targeted_regions_method', 'target_insert_size', 'mean_coverage', 'aligned_dna_short_read_file',
@@ -389,7 +389,9 @@ def gregor_export(request):
 
         # analyte table
         if not analyte_ids:
-            analyte_ids.add(_get_analyte_id(airtable_sample))
+            analyte_id = _get_analyte_id(airtable_sample)
+            if analyte_id:
+                analyte_ids.add(analyte_id)
         for analyte_id in analyte_ids:
             analyte_rows.append(dict(participant_id=participant_id, analyte_id=analyte_id, **_get_analyte_row(individual)))
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -560,7 +560,7 @@ def _populate_gregor_files(file_data):
     for file_name, expected_columns, data in file_data:
         table_config = table_configs.get(file_name)
         if not table_config:
-            errors.append(f'No data model found for "{file_name}" table so no validation was performed')
+            errors.insert(0, f'No data model found for "{file_name}" table')
             continue
 
         files.append((file_name, list(table_config.keys()), data))
@@ -569,8 +569,7 @@ def _populate_gregor_files(file_data):
         if extra_columns:
             col_summary = ', '.join(sorted(extra_columns))
             warnings.insert(
-                f'The following columns are computed for the "{file_name}" table but are missing from the data model: {col_summary}',
-                0
+                0, f'The following columns are computed for the "{file_name}" table but are missing from the data model: {col_summary}',
             )
         invalid_data_type_columns = {
             col: config['data_type'] for col, config in table_config.items()
@@ -579,8 +578,7 @@ def _populate_gregor_files(file_data):
         if invalid_data_type_columns:
             col_summary = ', '.join(sorted([f'{col} ({data_type})' for col, data_type in invalid_data_type_columns.items()]))
             warnings.insert(
-                f'The following columns are included in the "{file_name}" data model but have an unsupported data type: {col_summary}',
-                0
+                0, f'The following columns are included in the "{file_name}" data model but have an unsupported data type: {col_summary}',
             )
         invalid_enum_columns = [
             col for col, config in table_config.items()
@@ -591,8 +589,7 @@ def _populate_gregor_files(file_data):
                 table_config[col]['data_type'] = None
             col_summary = ', '.join(sorted(invalid_enum_columns))
             warnings.insert(
-                f'The following columns are specified as "enumeration" in the "{file_name}" data model but are missing the allowed values definition: {col_summary}',
-                0
+                0, f'The following columns are specified as "enumeration" in the "{file_name}" data model but are missing the allowed values definition: {col_summary}',
             )
 
         for column, config in table_config.items():

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -168,7 +168,7 @@ AIRTABLE_GREGOR_RECORDS = {
         'target_insert_size_wes': '385',
         'sequencing_platform_wes': 'NovaSeq',
         'aligned_dna_short_read_file_wes': 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/Broad_COL_FAM1_1_D1.cram',
-        'aligned_dna_short_read_index_file_wes': 'NA',
+        'aligned_dna_short_read_index_file_wes': 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/Broad_COL_FAM1_1_D1.crai',
         'md5sum_wes': '129c28163df082',
         'reference_assembly': 'GRCh38',
         'alignment_software_dna': 'BWA-MEM-2.3',
@@ -205,7 +205,6 @@ AIRTABLE_GREGOR_RECORDS = {
         'sequencing_platform_rna': 'NovaSeq',
         'aligned_rna_short_read_file': 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/NA19679.Aligned.out.cram',
         'aligned_rna_short_read_index_file': 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/NA19679.Aligned.out.crai',
-        'aligned_rna_short_read_id': '',
         'md5sum_rna': 'f6490b8ebdf2',
         '5prime3prime_bias_rna': '1.05',
         'gene_annotation_rna': 'GENCODEv26',
@@ -272,66 +271,8 @@ EXPECTED_GREGOR_FILES = [
     'experiment_rna_short_read', 'aligned_rna_short_read', 'experiment',
 ]
 
-# TODO remove
-PARTICIPANT_TABLE_COLUMNS = [
-    'participant_id', 'internal_project_id', 'gregor_center', 'consent_code', 'recontactable', 'prior_testing',
-    'pmid_id', 'family_id', 'paternal_id', 'maternal_id', 'twin_id', 'proband_relationship',
-    'proband_relationship_detail', 'sex', 'sex_detail', 'reported_race', 'reported_ethnicity', 'ancestry_detail',
-    'age_at_last_observation', 'affected_status', 'phenotype_description', 'age_at_enrollment',
-]
-GREGOR_FAMILY_TABLE_COLUMNS = [
-    'family_id', 'consanguinity', 'consanguinity_detail', 'pedigree_file', 'pedigree_file_detail', 'family_history_detail',
-]
-PHENOTYPE_TABLE_COLUMNS = [
-    'phenotype_id', 'participant_id', 'term_id', 'presence', 'ontology', 'additional_details', 'onset_age_range',
-    'additional_modifiers',
-]
-ANALYTE_TABLE_COLUMNS = [
-    'analyte_id', 'participant_id', 'analyte_type', 'analyte_processing_details', 'primary_biosample',
-    'primary_biosample_id', 'primary_biosample_details', 'tissue_affected_status', 'age_at_collection',
-    'participant_drugs_intake', 'participant_special_diet', 'hours_since_last_meal', 'passage_number', 'time_to_freeze',
-    'sample_transformation_detail', 'quality_issues',
-]
-EXPERIMENT_TABLE_AIRTABLE_FIELDS = [
-    'seq_library_prep_kit_method', 'read_length', 'experiment_type', 'targeted_regions_method',
-    'targeted_region_bed_file', 'date_data_generation', 'target_insert_size', 'sequencing_platform',
-]
-EXPERIMENT_TABLE_COLUMNS = [
-    'experiment_dna_short_read_id', 'analyte_id', 'experiment_sample_id',
-] + EXPERIMENT_TABLE_AIRTABLE_FIELDS
-EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS = [
-    'library_prep_type', 'single_or_paired_ends', 'within_site_batch_name', 'RIN', 'estimated_library_size',
-    'total_reads', 'percent_rRNA', 'percent_mRNA', '5prime3prime_bias',
-]
-EXPERIMENT_RNA_TABLE_COLUMNS = ['experiment_rna_short_read_id'] + [
-    c for c in EXPERIMENT_TABLE_COLUMNS[1:] if not c.startswith('target')] + EXPERIMENT_RNA_TABLE_AIRTABLE_FIELDS + [
-    'percent_mtRNA', 'percent_Globin', 'percent_UMI',  'percent_GC', 'percent_chrX_Y',
-]
-EXPERIMENT_LOOKUP_TABLE_COLUMNS = ['experiment_id', 'table_name', 'id_in_table', 'participant_id']
-READ_TABLE_AIRTABLE_FIELDS = [
-    'aligned_dna_short_read_file', 'aligned_dna_short_read_index_file', 'md5sum', 'reference_assembly',
-    'mean_coverage', 'alignment_software', 'analysis_details',
-]
-READ_TABLE_COLUMNS = ['aligned_dna_short_read_id', 'experiment_dna_short_read_id'] + READ_TABLE_AIRTABLE_FIELDS + ['quality_issues']
-READ_TABLE_COLUMNS.insert(6, 'reference_assembly_details')
-READ_TABLE_COLUMNS.insert(6, 'reference_assembly_uri')
-READ_RNA_TABLE_AIRTABLE_ID_FIELDS = ['aligned_rna_short_read_file', 'aligned_rna_short_read_index_file']
-READ_RNA_TABLE_AIRTABLE_FIELDS = [
-    'gene_annotation', 'alignment_software', 'alignment_log_file', 'percent_uniquely_aligned', 'percent_multimapped', 'percent_unaligned',
-]
-READ_RNA_TABLE_COLUMNS = ['aligned_rna_short_read_id', 'experiment_rna_short_read_id'] + \
-    READ_RNA_TABLE_AIRTABLE_ID_FIELDS + READ_TABLE_COLUMNS[4:-3] + READ_RNA_TABLE_AIRTABLE_FIELDS + ['quality_issues']
-READ_RNA_TABLE_COLUMNS.insert(READ_RNA_TABLE_COLUMNS.index('gene_annotation')+1, 'gene_annotation_details')
-READ_RNA_TABLE_COLUMNS.insert(READ_RNA_TABLE_COLUMNS.index('alignment_log_file')+1, 'alignment_postprocessing')
-READ_SET_TABLE_COLUMNS = ['aligned_dna_short_read_set_id', 'aligned_dna_short_read_id']
-CALLED_VARIANT_FILE_COLUMN = 'called_variants_dna_file'
-CALLED_TABLE_COLUMNS = [
-    'called_variants_dna_short_read_id', 'aligned_dna_short_read_set_id', CALLED_VARIANT_FILE_COLUMN, 'md5sum',
-    'caller_software', 'variant_types', 'analysis_details',
-]
-
 MOCK_DATA_MODEL_URL = 'http://raw.githubusercontent.com/gregor_data_model.json'
-MOCK_DATA_MODEL = {
+MOCK_INVALID_DATA_MODEL = {
     'name': 'test data model',
     'tables': [
         {
@@ -369,9 +310,9 @@ MOCK_DATA_MODEL = {
                 {'column': 'aligned_dna_short_read_id', 'required': True},
                 {'column': 'experiment_dna_short_read_id', 'required': True},
                 {'column': 'aligned_dna_short_read_file', 'is_unique': True, 'data_type': 'string', 'is_bucket_path': True},
-                {'column': 'aligned_dna_short_read_index_file', 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'aligned_dna_short_read_index_file'},
                 {'column': 'alignment_software', 'is_unique': True},
-                {'column': 'analysis_details'},
+                {'column': 'analysis_details', 'data_type': 'string', 'is_bucket_path': True},
                 {'column': 'md5sum', 'is_unique': True},
                 {'column': 'mean_coverage', 'required': True, 'data_type': 'float'},
                 {'column': 'reference_assembly', 'data_type': 'integer'},
@@ -421,6 +362,192 @@ MOCK_DATA_MODEL = {
                 {'column': '5prime3prime_bias', 'data_type': 'float'},
                 {'column': 'percent_GC', 'data_type': 'float'},
                 {'column': 'percent_chrX_Y', 'data_type': 'float'},
+            ],
+        },
+    ]
+}
+# TODO share with invalid
+MOCK_DATA_MODEL = {
+    'name': 'test data model',
+    'tables': [
+        {
+            'table': 'participant',
+            'required': True,
+            'columns': [
+                {'column': 'participant_id', 'required': True, 'data_type': 'string'},
+                {'column': 'internal_project_id'},
+                {'column': 'gregor_center', 'required': True, 'data_type': 'enumeration', 'enumerations': ['BCM', 'BROAD', 'UW']},
+                {'column': 'consent_code', 'required': True, 'data_type': 'enumeration', 'enumerations': ['GRU', 'HMB']},
+                {'column': 'recontactable', 'data_type': 'enumeration', 'enumerations': ['Yes', 'No']},
+                {'column': 'prior_testing'},
+                {'column': 'pmid_id'},
+                {'column': 'family_id', 'required': True},
+                {'column': 'paternal_id'},
+                {'column': 'maternal_id'},
+                {'column': 'twin_id'},
+                {'column': 'proband_relationship'},
+                {'column': 'proband_relationship_detail'},
+                {'column': 'sex', 'required': True, 'data_type': 'enumeration', 'enumerations': ['Male', 'Female', 'Unknown']},
+                {'column': 'sex_detail'},
+                {'column': 'reported_race', 'data_type': 'enumeration', 'enumerations': ['American Indian or Alaska Native', 'Asian', 'Black or African American', 'Native Hawaiian or Other Pacific Islander', 'Middle Eastern or North African', 'White']},
+                {'column': 'reported_ethnicity', 'data_type': 'enumeration', 'enumerations': ['Hispanic or Latino', 'Not Hispanic or Latino']},
+                {'column': 'ancestry_detail'},
+                {'column': 'age_at_last_observation'},
+                {'column': 'affected_status', 'required': True, 'data_type': 'enumeration', 'enumerations': ['Affected', 'Unaffected', 'Unknown']},
+                {'column': 'phenotype_description'},
+                {'column': 'age_at_enrollment'},
+            ],
+        },
+        {
+            'table': 'family',
+            'required': True,
+            'columns': [
+                {'column': 'family_id', 'required': True, 'data_type': 'string'},
+                {'column': 'consanguinity', 'required': True, 'data_type': 'enumeration', 'enumerations': ['None suspected', 'Suspected', 'Present', 'Unknown']},
+                {'column': 'consanguinity_detail'},
+            ]
+        },
+        {
+            'table': 'phenotype',
+            'required': True,
+            'columns': [
+                {'column': 'phenotype_id'},
+                {'column': 'participant_id', 'required': True, 'data_type': 'string'},
+                {'column': 'term_id', 'required': True},
+                {'column': 'presence', 'required': True, 'data_type': 'enumeration', 'enumerations': ['Present', 'Absent', 'Unknown']},
+                {'column': 'ontology', 'required': True, 'data_type': 'enumeration', 'enumerations': ['HPO', 'MONDO']},
+                {'column': 'additional_details'},
+                {'column': 'onset_age_range'},
+                {'column': 'additional_modifiers'},
+            ]
+        },
+        {
+            'table': 'analyte',
+            'required': True,
+            'columns': [
+                {'column': 'analyte_id', 'required': True, 'data_type': 'string'},
+                {'column': 'participant_id', 'required': True, 'data_type': 'string'},
+                {'column': 'analyte_type', 'data_type': 'enumeration', 'enumerations': ['DNA', 'RNA', 'cDNA', 'blood plasma', 'frozen whole blood', 'high molecular weight DNA', 'urine']},
+                {'column': 'analyte_processing_details'},
+                {'column': 'primary_biosample'},
+                {'column': 'primary_biosample_id'},
+                {'column': 'primary_biosample_details'},
+                {'column': 'tissue_affected_status', 'required': True, 'data_type': 'enumeration', 'enumerations': ['Yes', 'No']},
+            ]
+        },
+        {
+            'table': 'experiment',
+            'columns': [
+                {'column': 'experiment_id', 'required': True, 'data_type': 'string'},
+                {'column': 'table_name', 'required': True, 'data_type': 'enumeration', 'enumerations': ['experiment_dna_short_read', 'experiment_rna_short_read']},
+                {'column': 'id_in_table', 'required': True},
+                {'column': 'participant_id', 'required': True},
+            ]
+        },
+        {
+            'table': 'experiment_dna_short_read',
+            'required': 'CONDITIONAL (aligned_dna_short_read, aligned_dna_short_read_set, called_variants_dna_short_read)',
+            'columns': [
+                {'column': 'experiment_dna_short_read_id', 'required': True},
+                {'column': 'analyte_id', 'required': True},
+                {'column': 'experiment_sample_id', 'required': True},
+                {'column': 'seq_library_prep_kit_method'},
+                {'column': 'read_length', 'data_type': 'integer'},
+                {'column': 'experiment_type', 'required': True, 'data_type': 'enumeration', 'enumerations': ['targeted', 'genome', 'exome']},
+                {'column': 'targeted_regions_method'},
+                {'column': 'targeted_region_bed_file', 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'date_data_generation', 'data_type': 'date'},
+                {'column': 'target_insert_size', 'data_type': 'integer'},
+                {'column': 'sequencing_platform'},
+            ],
+        },
+        {
+            'table': 'aligned_dna_short_read',
+            'required': 'CONDITIONAL (aligned_dna_short_read_set, called_variants_dna_short_read)',
+            'columns': [
+                {'column': 'aligned_dna_short_read_id', 'required': True},
+                {'column': 'experiment_dna_short_read_id', 'required': True},
+                {'column': 'aligned_dna_short_read_file', 'is_unique': True, 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'aligned_dna_short_read_index_file', 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'md5sum', 'is_unique': True},
+                {'column': 'reference_assembly', 'data_type': 'enumeration', 'enumerations': ['GRCh38', 'GRCh37']},
+                {'column': 'reference_assembly_uri'},
+                {'column': 'reference_assembly_details'},
+                {'column': 'mean_coverage', 'data_type': 'float'},
+                {'column': 'alignment_software', 'required': True},
+                {'column': 'analysis_details'},
+                {'column': 'quality_issues'},
+            ],
+        },
+        {
+            'table': 'aligned_dna_short_read_set',
+            'required': 'CONDITIONAL (called_variants_dna_short_read)',
+            'columns': [
+                {'column': 'aligned_dna_short_read_set_id', 'required': True},
+                {'column': 'aligned_dna_short_read_id', 'required': True},
+            ],
+        },
+        {
+            'table': 'called_variants_dna_short_read',
+            'columns': [
+                {'column': 'called_variants_dna_short_read_id', 'required': True, 'is_unique': True},
+                {'column': 'aligned_dna_short_read_set_id', 'required': True},
+                {'column': 'called_variants_dna_file', 'is_unique': True, 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'md5sum', 'required': True, 'is_unique': True},
+                {'column': 'caller_software', 'required': True},
+                {'column': 'variant_types', 'required': True, 'data_type': 'enumeration', 'enumerations': ['SNV', 'INDEL', 'SV', 'CNV', 'RE','MEI', 'STR']},
+                {'column': 'analysis_details'},
+            ],
+        },
+        {
+            'table': 'experiment_rna_short_read',
+            'required': 'CONDITIONAL (aligned_rna_short_read)',
+            'columns': [
+                {'column': 'experiment_rna_short_read_id', 'required': True},
+                {'column': 'analyte_id', 'required': True},
+                {'column': 'experiment_sample_id'},
+                {'column': 'seq_library_prep_kit_method'},
+                {'column': 'read_length', 'data_type': 'integer'},
+                {'column': 'experiment_type'},
+                {'column': 'date_data_generation', 'data_type': 'date'},
+                {'column': 'sequencing_platform'},
+                {'column': 'library_prep_type'},
+                {'column': 'single_or_paired_ends'},
+                {'column': 'within_site_batch_name'},
+                {'column': 'RIN', 'data_type': 'float'},
+                {'column': 'estimated_library_size'},
+                {'column': 'total_reads', 'data_type': 'integer'},
+                {'column': 'percent_rRNA', 'data_type': 'float'},
+                {'column': 'percent_mRNA', 'data_type': 'float'},
+                {'column': '5prime3prime_bias', 'data_type': 'float'},
+                {'column': 'percent_mtRNA', 'data_type': 'float'},
+                {'column': 'percent_Globin', 'data_type': 'float'},
+                {'column': 'percent_UMI', 'data_type': 'float'},
+                {'column': 'percent_GC', 'data_type': 'float'},
+                {'column': 'percent_chrX_Y', 'data_type': 'float'},
+            ],
+        },
+        {
+            'table': 'aligned_rna_short_read',
+            'columns': [
+                {'column': 'aligned_rna_short_read_id', 'required': True},
+                {'column': 'experiment_rna_short_read_id', 'required': True},
+                {'column': 'aligned_rna_short_read_file', 'is_unique': True, 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'aligned_rna_short_read_index_file', 'data_type': 'string', 'is_bucket_path': True},
+                {'column': 'md5sum', 'is_unique': True},
+                {'column': 'reference_assembly', 'data_type': 'enumeration', 'enumerations': ['GRCh38', 'GRCh37']},
+                {'column': 'reference_assembly_uri'},
+                {'column': 'reference_assembly_details'},
+                {'column': 'mean_coverage', 'data_type': 'float'},
+                {'column': 'gene_annotation', 'required': True},
+                {'column': 'gene_annotation_details'},
+                {'column': 'alignment_software', 'required': True},
+                {'column': 'alignment_log_file', 'required': True},
+                {'column': 'alignment_postprocessing'},
+                {'column': 'percent_uniquely_aligned'},
+                {'column': 'percent_multimapped'},
+                {'column': 'percent_unaligned'},
+                {'column': 'quality_issues'},
             ],
         },
     ]
@@ -664,18 +791,21 @@ class ReportAPITest(AirtableTest):
             'Unable to load data model: 404 Client Error: Not Found for url: http://raw.githubusercontent.com/gregor_data_model.json',
         ])
 
-        responses.add(responses.GET, MOCK_DATA_MODEL_URL, json=MOCK_DATA_MODEL, status=200)
+        responses.add(responses.GET, MOCK_DATA_MODEL_URL, json=MOCK_INVALID_DATA_MODEL, status=200)
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 400)
-        self.assertListEqual(response.json()['warnings'], [
-            'The following columns are specified as "enumeration" in the "participant" data model but are missing the allowed values definition: prior_testing',
-            'The following columns are included in the "participant" data model but have an unsupported data type: internal_project_id (reference)',
-            'The following columns are computed for the "participant" table but are missing from the data model: age_at_last_observation, ancestry_detail, pmid_id',
+
+        recommended_warnings = [
             'The following entries are missing recommended "recontactable" in the "participant" table: Broad_HG00731, Broad_HG00732, Broad_HG00733, Broad_NA19678, Broad_NA20870, Broad_NA20872, Broad_NA20874, Broad_NA20875, Broad_NA20876, Broad_NA20881',
             'The following entries are missing recommended "reported_race" in the "participant" table: Broad_HG00732, Broad_HG00733, Broad_NA19678, Broad_NA19679, Broad_NA20870, Broad_NA20872, Broad_NA20874, Broad_NA20875, Broad_NA20876, Broad_NA20881, Broad_NA20888',
             'The following entries are missing recommended "phenotype_description" in the "participant" table: Broad_HG00731, Broad_HG00732, Broad_HG00733, Broad_NA20870, Broad_NA20872, Broad_NA20874, Broad_NA20875, Broad_NA20876, Broad_NA20881, Broad_NA20888',
             'The following entries are missing recommended "age_at_enrollment" in the "participant" table: Broad_HG00731, Broad_NA20870, Broad_NA20872, Broad_NA20875, Broad_NA20876, Broad_NA20881, Broad_NA20888',
-        ])
+        ]
+        self.assertListEqual(response.json()['warnings'], [
+            'The following columns are specified as "enumeration" in the "participant" data model but are missing the allowed values definition: prior_testing',
+            'The following columns are included in the "participant" data model but have an unsupported data type: internal_project_id (reference)',
+            'The following columns are computed for the "participant" table but are missing from the data model: age_at_last_observation, ancestry_detail, pmid_id',
+        ] + recommended_warnings)
         self.assertListEqual(response.json()['errors'], [
             f'No data model found for "{file}" table' for file in reversed(EXPECTED_GREGOR_FILES)
             if file not in {'participant', 'aligned_dna_short_read', 'aligned_dna_short_read_set', 'experiment_rna_short_read'}
@@ -685,8 +815,8 @@ class ReportAPITest(AirtableTest):
             'The following entries are missing required "proband_relationship" in the "participant" table: Broad_HG00731, Broad_HG00732, Broad_HG00733, Broad_NA19678, Broad_NA19679, Broad_NA20870, Broad_NA20872, Broad_NA20874, Broad_NA20875, Broad_NA20876, Broad_NA20881, Broad_NA20888',
             'The following entries have invalid values for "reported_race" in the "participant" table. Allowed values: Asian, White, Black. Invalid values: Broad_NA19675_1 (Middle Eastern or North African)',
             'The following entries have invalid values for "age_at_enrollment" in the "participant" table. Allowed values have data type date. Invalid values: Broad_NA19675_1 (18)',
-            'The following entries have invalid values for "aligned_dna_short_read_index_file" (from Airtable) in the "aligned_dna_short_read" table. Allowed values are a google bucket path starting with gs://. Invalid values: VCGS_FAM203_621_D2 (NA)',
             'The following entries have non-unique values for "alignment_software" (from Airtable) in the "aligned_dna_short_read" table: BWA-MEM-2.3 (NA20888, VCGS_FAM203_621_D2)',
+            'The following entries have invalid values for "analysis_details" (from Airtable) in the "aligned_dna_short_read" table. Allowed values are a google bucket path starting with gs://. Invalid values: VCGS_FAM203_621_D2 (DOI:10.5281/zenodo.4469317)',
             'The following entries are missing required "mean_coverage" (from Airtable) in the "aligned_dna_short_read" table: VCGS_FAM203_621_D2',
             'The following entries have invalid values for "reference_assembly" (from Airtable) in the "aligned_dna_short_read" table. Allowed values have data type integer. Invalid values: NA20888 (GRCh38), VCGS_FAM203_621_D2 (GRCh38)',
             'The following entries have invalid values for "date_data_generation" (from Airtable) in the "experiment_rna_short_read" table. Allowed values have data type float. Invalid values: NA19679 (2023-02-11)',
@@ -694,11 +824,12 @@ class ReportAPITest(AirtableTest):
 
         responses.calls.reset()
         mock_subprocess.reset_mock()
-        mock_google_authenticated.return_value = True
+        responses.add(responses.GET, MOCK_DATA_MODEL_URL, json=MOCK_DATA_MODEL, status=200)
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
         expected_response = {
             'info': ['Successfully validated and uploaded Gregor Report for 9 families'],
+            'warnings': recommended_warnings,
         }
         self.assertDictEqual(response.json(), expected_response)
         self._assert_expected_gregor_files(mock_open)
@@ -722,6 +853,9 @@ class ReportAPITest(AirtableTest):
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
         expected_response['info'][0] = expected_response['info'][0].replace('9', '10')
+        expected_response['warnings'][0] = expected_response['warnings'][0] + ', Broad_NA20885, Broad_NA20889'
+        expected_response['warnings'][2] = expected_response['warnings'][2].replace('Broad_NA20888', 'Broad_NA20885, Broad_NA20888, Broad_NA20889')
+        expected_response['warnings'][3] = expected_response['warnings'][3].replace('Broad_NA20888', 'Broad_NA20885, Broad_NA20888, Broad_NA20889')
         self.assertDictEqual(response.json(), expected_response)
         self._assert_expected_gregor_files(mock_open, has_second_project=True)
         self._test_expected_gregor_airtable_calls(additional_samples=['NA20885', 'NA20889'])
@@ -765,12 +899,11 @@ class ReportAPITest(AirtableTest):
 
         self.assertEqual(len(family_file), 11 if has_second_project else 10)
         self.assertEqual(family_file[0], [
-            'family_id', 'consanguinity', 'consanguinity_detail', 'pedigree_file', 'pedigree_file_detail',
-            'family_history_detail',
+            'family_id', 'consanguinity', 'consanguinity_detail',
         ])
-        self.assertIn(['Broad_1', 'Present', '', '', '', ''], family_file)
-        fam_8_row = ['Broad_8', 'Unknown', '', '', '', '']
-        fam_11_row = ['Broad_11', 'None suspected', '', '', '', '']
+        self.assertIn(['Broad_1', 'Present', ''], family_file)
+        fam_8_row = ['Broad_8', 'Unknown', '']
+        fam_11_row = ['Broad_11', 'None suspected', '']
         if has_second_project:
             self.assertIn(fam_11_row, family_file)
             self.assertNotIn(fam_8_row, family_file)
@@ -790,21 +923,19 @@ class ReportAPITest(AirtableTest):
             '', 'Broad_NA19675_1', 'HP:0001674', 'Absent', 'HPO', 'originally indicated', '', '',
         ], phenotype_file)
 
-        self.assertEqual(len(analyte_file), 17 if has_second_project else 14)
+        self.assertEqual(len(analyte_file), 6 if has_second_project else 5)
         self.assertEqual(analyte_file[0], [
             'analyte_id', 'participant_id', 'analyte_type', 'analyte_processing_details', 'primary_biosample',
-            'primary_biosample_id', 'primary_biosample_details', 'tissue_affected_status', 'age_at_collection',
-            'participant_drugs_intake', 'participant_special_diet', 'hours_since_last_meal', 'passage_number',
-            'time_to_freeze', 'sample_transformation_detail', 'quality_issues',
+            'primary_biosample_id', 'primary_biosample_details', 'tissue_affected_status',
         ])
         row = next(r for r in analyte_file if r[1] == 'Broad_NA19675_1')
         self.assertListEqual(
-            ['Broad_SM-AGHT', 'Broad_NA19675_1', 'DNA', '', 'UBERON:0003714', '', '', 'No', '', '', '', '', '', '', '', ''],
+            ['Broad_SM-AGHT', 'Broad_NA19675_1', 'DNA', '', 'UBERON:0003714', '', '', 'No'],
             row)
         self.assertIn(
-            ['Broad_SM-L5QMP', 'Broad_NA20888', '', '', '', '', '', 'No', '', '', '', '', '', '', '', ''], analyte_file)
+            ['Broad_SM-L5QMP', 'Broad_NA20888', '', '', '', '', '', 'No'], analyte_file)
         self.assertEqual(
-            ['Broad_SM-L5QMWP', 'Broad_NA20888', '', '', '', '', '', 'No', '', '', '', '', '', '', '', ''] in analyte_file,
+            ['Broad_SM-L5QMWP', 'Broad_NA20888', '', '', '', '', '', 'No'] in analyte_file,
             has_second_project
         )
 
@@ -837,7 +968,8 @@ class ReportAPITest(AirtableTest):
         self.assertIn([
             'Broad_exome_VCGS_FAM203_621_D2_1', 'Broad_exome_VCGS_FAM203_621_D2',
             'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/Broad_COL_FAM1_1_D1.cram',
-            'NA', '129c28163df082', 'GRCh38', '', '', '', 'BWA-MEM-2.3', 'DOI:10.5281/zenodo.4469317', '',
+            'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/Broad_COL_FAM1_1_D1.crai',
+            '129c28163df082', 'GRCh38', '', '', '', 'BWA-MEM-2.3', 'DOI:10.5281/zenodo.4469317', '',
         ], read_file)
         self.assertIn([
             'Broad_exome_NA20888_1', 'Broad_exome_NA20888',
@@ -891,7 +1023,7 @@ class ReportAPITest(AirtableTest):
             'percent_multimapped', 'percent_unaligned', 'quality_issues'
         ])
         self.assertEqual(aligned_rna_file[1], [
-            '', 'Broad_paired-end_NA19679', 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/NA19679.Aligned.out.cram',
+            'Broad_paired-end_NA19679_1', 'Broad_paired-end_NA19679', 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/NA19679.Aligned.out.cram',
             'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/NA19679.Aligned.out.crai', 'f6490b8ebdf2', 'GRCh38',
             'gs://gcp-public-data--broad-references/hg38/v0/Homo_sapiens_assembly38.fasta', '', '', 'GENCODEv26', '',
             'STARv2.7.10b', 'gs://fc-eb352699-d849-483f-aefe-9d35ce2b21ac/NA19679.Log.final.out', '', '80.53', '17.08',

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -272,101 +272,6 @@ EXPECTED_GREGOR_FILES = [
 ]
 
 MOCK_DATA_MODEL_URL = 'http://raw.githubusercontent.com/gregor_data_model.json'
-MOCK_INVALID_DATA_MODEL = {
-    'name': 'test data model',
-    'tables': [
-        {
-            'table': 'subject',
-            'required': True,
-            'columns': [{'column': 'subject_id', 'required': True}],
-        },
-        {
-            'table': 'participant',
-            'required': True,
-            'columns': [
-                {'column': 'participant_id', 'required': True, 'data_type': 'string'},
-                {'column': 'internal_project_id', 'data_type': 'reference'},
-                {'column': 'gregor_center', 'required': True, 'data_type': 'enumeration', 'enumerations': ['BCM', 'BROAD', 'UW']},
-                {'column': 'consent_code', 'required': True, 'data_type': 'enumeration', 'enumerations': ['GRU', 'HMB']},
-                {'column': 'recontactable', 'data_type': 'enumeration', 'enumerations': ['Yes', 'No']},
-                {'column': 'prior_testing', 'data_type': 'enumeration'},
-                {'column': 'family_id', 'required': True},
-                {'column': 'paternal_id'},
-                {'column': 'maternal_id'},
-                {'column': 'proband_relationship', 'required': True},
-                {'column': 'sex', 'required': True, 'data_type': 'enumeration', 'enumerations': ['Male', 'Female', 'Unknown']},
-                {'column': 'reported_race', 'data_type': 'enumeration', 'enumerations': ['Asian', 'White', 'Black']},
-                {'column': 'reported_ethnicity', 'data_type': 'enumeration', 'enumerations': ['Hispanic or Latino', 'Not Hispanic or Latino']},
-                {'column': 'ancestry_metadata'},
-                {'column': 'affected_status', 'required': True, 'data_type': 'enumeration', 'enumerations': ['Affected', 'Unaffected', 'Unknown']},
-                {'column': 'phenotype_description'},
-                {'column': 'age_at_enrollment', 'data_type': 'date'},
-            ],
-        },
-        {
-            'table': 'aligned_dna_short_read',
-            'required': 'CONDITIONAL (aligned_dna_short_read_set, called_variants_dna_short_read)',
-            'columns': [
-                {'column': 'aligned_dna_short_read_id', 'required': True},
-                {'column': 'experiment_dna_short_read_id', 'required': True},
-                {'column': 'aligned_dna_short_read_file', 'is_unique': True, 'data_type': 'string', 'is_bucket_path': True},
-                {'column': 'aligned_dna_short_read_index_file'},
-                {'column': 'alignment_software', 'is_unique': True},
-                {'column': 'analysis_details', 'data_type': 'string', 'is_bucket_path': True},
-                {'column': 'md5sum', 'is_unique': True},
-                {'column': 'mean_coverage', 'required': True, 'data_type': 'float'},
-                {'column': 'reference_assembly', 'data_type': 'integer'},
-                {'column': 'reference_assembly_details'},
-                {'column': 'reference_assembly_uri'},
-                {'column': 'quality_issues'},
-            ],
-        },
-        {
-            'table': 'aligned_dna_short_read_set',
-            'columns': [
-                {'column': 'aligned_dna_short_read_set_id', 'required': True},
-                {'column': 'aligned_dna_short_read_id', 'required': True},
-            ],
-        },
-        {
-            'table': 'dna_read_data',
-            'columns': [{'column': 'analyte_id', 'required': True}],
-        },
-        {
-            'table': 'dna_read_data_set',
-            'required': 'CONDITIONAL (aligned_dna_short_read_set, dna_read_data)',
-            'columns': [{'column': 'analyte_id', 'required': True}],
-        },
-        {
-            'table': 'experiment_rna_short_read',
-            'columns': [
-                {'column': 'experiment_rna_short_read_id', 'required': True},
-                {'column': 'analyte_id', 'required': True},
-                {'column': 'experiment_sample_id'},
-                {'column': 'seq_library_prep_kit_method'},
-                {'column': 'library_prep_type'},
-                {'column': 'experiment_type'},
-                {'column': 'read_length', 'data_type': 'integer'},
-                {'column': 'single_or_paired_ends'},
-                {'column': 'date_data_generation', 'data_type': 'float'},
-                {'column': 'sequencing_platform'},
-                {'column': 'within_site_batch_name'},
-                {'column': 'RIN', 'data_type': 'float'},
-                {'column': 'estimated_library_size'},
-                {'column': 'total_reads', 'data_type': 'integer'},
-                {'column': 'percent_rRNA', 'data_type': 'float'},
-                {'column': 'percent_mRNA', 'data_type': 'float'},
-                {'column': 'percent_mtRNA', 'data_type': 'float'},
-                {'column': 'percent_Globin', 'data_type': 'float'},
-                {'column': 'percent_UMI', 'data_type': 'float'},
-                {'column': '5prime3prime_bias', 'data_type': 'float'},
-                {'column': 'percent_GC', 'data_type': 'float'},
-                {'column': 'percent_chrX_Y', 'data_type': 'float'},
-            ],
-        },
-    ]
-}
-# TODO share with invalid
 MOCK_DATA_MODEL = {
     'name': 'test data model',
     'tables': [
@@ -475,7 +380,7 @@ MOCK_DATA_MODEL = {
                 {'column': 'reference_assembly_details'},
                 {'column': 'mean_coverage', 'data_type': 'float'},
                 {'column': 'alignment_software', 'required': True},
-                {'column': 'analysis_details'},
+                {'column': 'analysis_details', 'data_type': 'string'},
                 {'column': 'quality_issues'},
             ],
         },
@@ -551,6 +456,49 @@ MOCK_DATA_MODEL = {
             ],
         },
     ]
+}
+
+INVALID_MODEL_TABLES = {
+    'participant': {
+        'internal_project_id': {'data_type': 'reference'},
+        'prior_testing': {'data_type': 'enumeration'},
+        'proband_relationship': {'required': True},
+        'reported_race': {'enumerations': ['Asian', 'White', 'Black']},
+        'age_at_enrollment': {'data_type': 'date'}
+    },
+    'aligned_dna_short_read': {
+        'analysis_details': {'is_bucket_path': True},
+        'reference_assembly': {'data_type': 'integer'},
+        'mean_coverage': {'required': True},
+        'alignment_software': {'is_unique': True},
+    },
+    'aligned_dna_short_read_set': {},
+    'experiment_rna_short_read': {'date_data_generation': {'data_type': 'float'}},
+}
+INVALID_TABLES = [
+    {**t, 'columns': [{**c, **(INVALID_MODEL_TABLES[t['table']].get(c['column'], {}))} for c in t['columns']]}
+    for t in MOCK_DATA_MODEL['tables'] if t['table'] in INVALID_MODEL_TABLES
+]
+INVALID_TABLES[0]['columns'] = [c for c in INVALID_TABLES[0]['columns'] if c['column'] not in {
+    'pmid_id', 'age_at_last_observation', 'ancestry_detail',
+}]
+MOCK_INVALID_DATA_MODEL = {
+    'tables': [
+        {
+            'table': 'subject',
+            'required': True,
+            'columns': [{'column': 'subject_id', 'required': True}],
+        },
+        {
+            'table': 'dna_read_data',
+            'columns': [{'column': 'analyte_id', 'required': True}],
+        },
+        {
+            'table': 'dna_read_data_set',
+            'required': 'CONDITIONAL (aligned_dna_short_read_set, dna_read_data)',
+            'columns': [{'column': 'analyte_id', 'required': True}],
+        },
+    ] + INVALID_TABLES
 }
 
 
@@ -807,18 +755,17 @@ class ReportAPITest(AirtableTest):
             'The following columns are computed for the "participant" table but are missing from the data model: age_at_last_observation, ancestry_detail, pmid_id',
         ] + recommended_warnings)
         self.assertListEqual(response.json()['errors'], [
-            f'No data model found for "{file}" table' for file in reversed(EXPECTED_GREGOR_FILES)
-            if file not in {'participant', 'aligned_dna_short_read', 'aligned_dna_short_read_set', 'experiment_rna_short_read'}
+            f'No data model found for "{file}" table' for file in reversed(EXPECTED_GREGOR_FILES) if file not in INVALID_MODEL_TABLES
         ] + [
             'The following tables are required in the data model but absent from the reports: subject, dna_read_data_set',
         ] + [
             'The following entries are missing required "proband_relationship" in the "participant" table: Broad_HG00731, Broad_HG00732, Broad_HG00733, Broad_NA19678, Broad_NA19679, Broad_NA20870, Broad_NA20872, Broad_NA20874, Broad_NA20875, Broad_NA20876, Broad_NA20881, Broad_NA20888',
             'The following entries have invalid values for "reported_race" in the "participant" table. Allowed values: Asian, White, Black. Invalid values: Broad_NA19675_1 (Middle Eastern or North African)',
             'The following entries have invalid values for "age_at_enrollment" in the "participant" table. Allowed values have data type date. Invalid values: Broad_NA19675_1 (18)',
+            'The following entries have invalid values for "reference_assembly" (from Airtable) in the "aligned_dna_short_read" table. Allowed values have data type integer. Invalid values: NA20888 (GRCh38), VCGS_FAM203_621_D2 (GRCh38)',
+            'The following entries are missing required "mean_coverage" (from Airtable) in the "aligned_dna_short_read" table: VCGS_FAM203_621_D2',
             'The following entries have non-unique values for "alignment_software" (from Airtable) in the "aligned_dna_short_read" table: BWA-MEM-2.3 (NA20888, VCGS_FAM203_621_D2)',
             'The following entries have invalid values for "analysis_details" (from Airtable) in the "aligned_dna_short_read" table. Allowed values are a google bucket path starting with gs://. Invalid values: VCGS_FAM203_621_D2 (DOI:10.5281/zenodo.4469317)',
-            'The following entries are missing required "mean_coverage" (from Airtable) in the "aligned_dna_short_read" table: VCGS_FAM203_621_D2',
-            'The following entries have invalid values for "reference_assembly" (from Airtable) in the "aligned_dna_short_read" table. Allowed values have data type integer. Invalid values: NA20888 (GRCh38), VCGS_FAM203_621_D2 (GRCh38)',
             'The following entries have invalid values for "date_data_generation" (from Airtable) in the "experiment_rna_short_read" table. Allowed values have data type float. Invalid values: NA19679 (2023-02-11)',
         ])
 


### PR DESCRIPTION
Updates the Gregor metadata reports to use the columns as defined in the data model instead of us also maintaining our own lists of columns. This means that when adding or modifying tables we do not have to keep our list of columns in sync with the Gregor data model and its much easier to make such updates, and if they add new optional columns we need to make no changes on our end