### PR TITLE
Update LOCAL_INSTALL.md

### DIFF
--- a/deploy/LOCAL_INSTALL.md
+++ b/deploy/LOCAL_INSTALL.md
@@ -53,7 +53,7 @@ docker-compose logs -f seqr  # (optional) continuously print seqr logs to see wh
 
 To update reference data in seqr, such as OMIM, HPO, etc., run the following
 ```bash
-docker-compose exec seqr manage.py update_all_reference_data --use-cached-omim --skip-gencode
+docker-compose exec seqr ./manage.py update_all_reference_data --use-cached-omim --skip-gencode
 ```
    
 ### Annotating and loading VCF callsets 


### PR DESCRIPTION
To update reference data in seqr code section it writes manage.py and that causes errors need to write  ./manage.py  
![image](https://github.com/broadinstitute/seqr/assets/129230763/33f6dcbf-6ccb-4c57-9e11-ab1c03599dd5)



Wrong one (in docs) : 
docker-compose exec seqr manage.py update_all_reference_data --use-cached-omim --skip-gencode
![image](https://github.com/broadinstitute/seqr/assets/129230763/c364a73f-d88a-46f8-ae09-51216aef1972)



Fixed one : 
docker-compose exec seqr ./manage.py update_all_reference_data --use-cached-omim --skip-gencode

