### PR TITLE
Sample metadata all error

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -2070,18 +2070,7 @@
         "variant_id": "12-48367227-TC-T",
         "saved_variant_json": {
             "liftedOverGenomeVersion": "38",  "liftedOverPos": "", "genomeVersion": "37", "pos": 248367227,
-            "mainTranscriptId": "ENST00000505820", "transcripts": {
-                "ENSG00000135953": [
-                    {"transcriptId": "ENST00000371839", "biotype": "protein_coding", "geneId": "ENSG00000228198"}
-                ],
-                "ENSG00000240361": [
-                    {"transcriptId": "ENST00000505820", "lofFilter": "", "biotype": "protein_coding",
-                        "geneSymbol": "MIB2", "majorConsequence": "intron_variant", "canonical": 1,
-                        "hgvsp": "ENST00000505820.2:c.1586-17C>G", "lof": "", "lofFlags": "", "codons": "Gtg/Atg",
-                        "hgvsc": "ENST00000262738.3:c.3955G>A", "transcriptRank": 0, "geneId": "ENSG00000240361",
-                        "aminoAcids": "V/M", "cdnaPosition": "3955"}
-                ]
-            }, "chrom": "1", "genotypes": {
+            "transcripts": {}, "chrom": "1", "genotypes": {
                 "I000018_na21234": {"sampleId": "NA20885", "ab": 0.0, "gq": 99.0, "numAlt": 1}}},
         "family": 14
     }

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -604,8 +604,8 @@ class ReportAPITest(AirtableTest):
         url = reverse(anvil_export, args=[PROJECT_GUID])
         self.check_analyst_login(url)
 
-        unauthorized_project_url = reverse(anvil_export, args=[NO_ANALYST_PROJECT_GUID])
-        response = self.client.get(unauthorized_project_url)
+        no_analyst_project_url = reverse(anvil_export, args=[NO_ANALYST_PROJECT_GUID])
+        response = self.client.get(no_analyst_project_url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
 
@@ -683,6 +683,12 @@ class ReportAPITest(AirtableTest):
             'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, '
             'p.Ala196Leu): 19-1912633-G-T, 19-1912634-C-T'],
             discovery_file)
+
+        added_perm = self.add_analyst_project(4)
+        if added_perm:
+            response = self.client.get(no_analyst_project_url)
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.json()['errors'], ['Discovery variant 12-48367227-TC-T in family 14 has no associated gene'])
 
         self.check_no_analyst_no_access(url)
 

--- a/seqr/views/apis/summary_data_api.py
+++ b/seqr/views/apis/summary_data_api.py
@@ -226,6 +226,7 @@ def sample_metadata_export(request, project_guid):
 
     parse_anvil_metadata(
         projects, request.GET.get('loadedBefore') or datetime.now().strftime('%Y-%m-%d'), request.user, _add_row,
+        allow_missing_discovery_genes=True,
         omit_airtable=not include_airtable,
         get_additional_variant_fields=_get_additional_variant_fields,
         get_additional_sample_fields=lambda sample, airtable_metadata: {

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -85,6 +85,40 @@ EXPECTED_SAMPLE_METADATA_ROW = {
     "multiple_datasets": "No",
 }
 EXPECTED_SAMPLE_METADATA_ROW.update(EXPECTED_NO_AIRTABLE_SAMPLE_METADATA_ROW)
+EXPECTED_NO_GENE_SAMPLE_METADATA_ROW = {
+    'subject_id': 'NA21234',
+    'sample_id': 'NA21234',
+    'family_guid': 'F000014_14',
+    'family_id': '14',
+    'project_guid': 'R0004_non_analyst_project',
+    'project_id': 'Non-Analyst Project',
+    'affected_status': 'Affected',
+    'ancestry': '',
+    'congenital_status': 'Unknown',
+    'consanguinity': 'None suspected',
+    'data_type': 'WGS',
+    'date_data_generation': '2018-02-05',
+    'hpo_absent': '',
+    'hpo_present': '',
+    'inheritance_description-1': 'Autosomal dominant',
+    'maternal_id': '',
+    'MME': 'Y',
+    'novel_mendelian_gene-1': 'Y',
+    'num_saved_variants': 1,
+    'paternal_id': '',
+    'phenotype_description': None,
+    'phenotype_group': '',
+    'pmid_id': None,
+    'proband_relationship': '',
+    'sex': 'Female',
+    'solve_state': 'Tier 1',
+    'Alt-1': 'T',
+    'Chrom-1': '1',
+    'Gene_Class-1': 'Tier 1 - Candidate',
+    'Pos-1': '248367227',
+    'Ref-1': 'TC',
+    'Zygosity-1': 'Heterozygous',
+}
 
 AIRTABLE_SAMPLE_RECORDS = {
   "records": [
@@ -248,8 +282,6 @@ class SummaryDataAPITest(AirtableTest):
         expected_variant_guids = {
             'SV0000001_2103343353_r0390_100', 'SV0000007_prefix_19107_DEL_r00', 'SV0000006_1248367227_r0003_tes',
         }
-        if self.MANAGER_VARIANT_GUID:
-            expected_variant_guids.add(self.MANAGER_VARIANT_GUID)
         self.assertSetEqual(set(response_json['savedVariantsByGuid'].keys()), expected_variant_guids)
         self.assertSetEqual(
             set(response_json['projectsByGuid'][PROJECT_GUID].keys()),
@@ -262,7 +294,6 @@ class SummaryDataAPITest(AirtableTest):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), SAVED_VARIANT_RESPONSE_KEYS)
-        expected_variant_guids.discard(self.MANAGER_VARIANT_GUID)
         self.assertSetEqual(set(response_json['savedVariantsByGuid'].keys()), expected_variant_guids)
 
         all_tag_url = reverse(saved_variants_page, args=['ALL'])
@@ -437,10 +468,16 @@ class SummaryDataAPITest(AirtableTest):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
 
+        # Test no gene for discovery variant
+        self.login_manager()
+        no_analyst_project_url = reverse(sample_metadata_export, args=['R0004_non_analyst_project'])
+        response = self.client.get(no_analyst_project_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), {'rows': [EXPECTED_NO_GENE_SAMPLE_METADATA_ROW]})
+
         # Test analyst access
         self.login_analyst_user()
-        unauthorized_project_url = reverse(sample_metadata_export, args=['R0004_non_analyst_project'])
-        response = self.client.get(unauthorized_project_url)
+        response = self.client.get(no_analyst_project_url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
 
@@ -537,7 +574,6 @@ class SummaryDataAPITest(AirtableTest):
 class LocalSummaryDataAPITest(AuthenticationTestCase, SummaryDataAPITest):
     fixtures = ['users', '1kg_project', 'reference_data']
     NUM_MANAGER_SUBMISSIONS = 4
-    MANAGER_VARIANT_GUID = 'SV0000006_1248367227_r0004_non'
     ADDITIONAL_SAMPLES = ['NA21234']
 
 
@@ -554,7 +590,6 @@ def assert_has_expected_calls(self, users, skip_group_call_idxs=None):
 class AnvilSummaryDataAPITest(AnvilAuthenticationTestCase, SummaryDataAPITest):
     fixtures = ['users', 'social_auth', '1kg_project', 'reference_data']
     NUM_MANAGER_SUBMISSIONS = 4
-    MANAGER_VARIANT_GUID = 'SV0000006_1248367227_r0004_non'
     ADDITIONAL_SAMPLES = []
 
     def test_mme_details(self, *args):

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -104,7 +104,7 @@ def is_internal_anvil_project(project):
 
 
 def get_internal_projects():
-    if anvil_enabled():
+    if anvil_enabled() or True:
         return Project.objects.filter(workspace_namespace__in=INTERNAL_NAMESPACES)
     return Project.objects.all()
 

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -104,7 +104,7 @@ def is_internal_anvil_project(project):
 
 
 def get_internal_projects():
-    if anvil_enabled() or True:
+    if anvil_enabled():
         return Project.objects.filter(workspace_namespace__in=INTERNAL_NAMESPACES)
     return Project.objects.all()
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -89,6 +89,12 @@ class AuthenticationTestCase(TestCase):
         pm_group = Group.objects.get(pk=5)
         pm_group.user_set.add(cls.pm_user)
 
+    @classmethod
+    def add_analyst_project(cls, project_id):
+        analyst_group = Group.objects.get(pk=4)
+        assign_perm(user_or_group=analyst_group, perm=CAN_VIEW, obj=Project.objects.filter(id=project_id))
+        return True
+
     def check_require_login(self, url, **request_kwargs):
         self._check_login(url, self.AUTHENTICATED_USER, **request_kwargs)
 
@@ -529,6 +535,10 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
     def add_additional_user_groups(cls):
         analyst_group = Group.objects.get(pk=4)
         analyst_group.user_set.add(cls.analyst_user, cls.pm_user)
+
+    @classmethod
+    def add_analyst_project(cls, project_id):
+        return False
 
     def assert_no_extra_anvil_calls(self):
         self.mock_get_ws_acl.assert_not_called()


### PR DESCRIPTION
Allow sample metadata report generation to succeed if variants with no genes have discovery tags. Fail Anvil report, as this should not happen for any of our internally supported/reported projects