### PR TITLE
Remove hail shuffle

### DIFF
--- a/hail_search/constants.py
+++ b/hail_search/constants.py
@@ -6,7 +6,6 @@ AFFECTED_ID = 0
 UNAFFECTED_ID = 1
 MALE = 'M'
 
-VARIANT_KEY_FIELD = 'variantId'
 GROUPED_VARIANTS_FIELD = 'variants'
 GNOMAD_GENOMES_FIELD = 'gnomad_genomes'
 SPLICE_AI_FIELD = 'splice_ai'

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -745,8 +745,7 @@ class BaseHailTableQuery(object):
         ch_ht = ch_ht.filter(ch_ht.valid_families.any(lambda x: x))
 
         # Format pairs as lists and de-duplicate
-        # TODO not deduplicating
-        ch_ht = ch_ht.key_by(key=hl.str(':').join(hl.sorted([ch_ht.v1.variant_id, ch_ht.v2.variant_id])))
+        ch_ht = ch_ht.key_by(key_field=hl.str(':').join(hl.sorted([ch_ht.v1.variant_id, ch_ht.v2.variant_id])))
         ch_ht = ch_ht.distinct()
         ch_ht = ch_ht.select(**{k: self._annotated_comp_het_variant(ch_ht, k) for k in ['v1', 'v2']})
 
@@ -803,8 +802,7 @@ class BaseHailTableQuery(object):
         if self._ht:
             ht = self._format_results(self._ht.key_by(), annotation_fields=annotation_fields)
             if ch_ht:
-                ht = ht.join(ch_ht, 'outer')
-                ht = ht.transmute(_sort=hl.or_else(ht._sort, ht._sort_1))
+                ht = ht.union(ch_ht, unify=True)
         else:
             ht = ch_ht
         return ht

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -1,7 +1,6 @@
 import hail as hl
 
-from hail_search.constants import ALT_ALT, REF_REF, CONSEQUENCE_SORT, OMIM_SORT, GROUPED_VARIANTS_FIELD, \
-    VARIANT_KEY_FIELD
+from hail_search.constants import ALT_ALT, REF_REF, CONSEQUENCE_SORT, OMIM_SORT, GROUPED_VARIANTS_FIELD
 from hail_search.queries.base import BaseHailTableQuery
 from hail_search.queries.mito import MitoHailTableQuery
 from hail_search.queries.snv_indel import SnvIndelHailTableQuery
@@ -112,8 +111,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
         return ht
 
     def _format_comp_het_result(self, v, data_type):
-        return self._data_type_queries[data_type]._format_results(v).annotate(
-            **{VARIANT_KEY_FIELD: v[VARIANT_KEY_FIELD]})
+        return self._data_type_queries[data_type]._format_results(v)
 
     def _merged_sort_expr(self, data_type, ht):
         # Certain sorts have an extra element for variant-type data, so need to add an element for SV data

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -41,7 +41,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
             sv_query = self._data_type_queries[data_type]
             merged_ht = self._filter_data_type_comp_hets(variant_ht, variant_families, sv_query)
             if merged_ht is not None:
-                self._comp_het_hts[data_type] = merged_ht
+                self._comp_het_hts[data_type] = merged_ht.key_by()
 
     def _filter_data_type_comp_hets(self, variant_ht, variant_families, sv_query):
         sv_ht = sv_query.unfiltered_comp_het_ht
@@ -105,8 +105,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
 
         ht = hts[0]
         for sub_ht in hts[1:]:
-            ht = ht.join(sub_ht, 'outer')
-            ht = ht.transmute(_sort=hl.or_else(ht._sort, ht._sort_1))
+            ht = ht.union(sub_ht, unify=True)
 
         return ht
 

--- a/hail_search/test_search.py
+++ b/hail_search/test_search.py
@@ -300,9 +300,9 @@ class HailSearchTestCase(AioHTTPTestCase):
             inheritance_mode=inheritance_mode, gene_counts={
                 'ENSG00000097046': {'total': 2, 'families': {'F000002_2': 2}},
                 'ENSG00000177000': {'total': 2, 'families': {'F000002_2': 2}},
-                'ENSG00000275023': {'total': 2, 'families': {'F000002_2': 2}},
-                'ENSG00000277258': {'total': 2, 'families': {'F000002_2': 2}},
-                'ENSG00000277972': {'total': 1, 'families': {'F000002_2': 1}},
+                'ENSG00000275023': {'total': 3, 'families': {'F000002_2': 3}},
+                'ENSG00000277258': {'total': 3, 'families': {'F000002_2': 3}},
+                'ENSG00000277972': {'total': 2, 'families': {'F000002_2': 2}},
             }, **COMP_HET_ALL_PASS_FILTERS,
         )
 
@@ -342,9 +342,9 @@ class HailSearchTestCase(AioHTTPTestCase):
             inheritance_mode=inheritance_mode, gene_counts={
                 'ENSG00000097046': {'total': 2, 'families': {'F000002_2': 2}},
                 'ENSG00000177000': {'total': 3, 'families': {'F000002_2': 3}},
-                'ENSG00000275023': {'total': 3, 'families': {'F000002_2': 3}},
-                'ENSG00000277258': {'total': 3, 'families': {'F000002_2': 3}},
-                'ENSG00000277972': {'total': 1, 'families': {'F000002_2': 1}},
+                'ENSG00000275023': {'total': 4, 'families': {'F000002_2': 4}},
+                'ENSG00000277258': {'total': 4, 'families': {'F000002_2': 4}},
+                'ENSG00000277972': {'total': 2, 'families': {'F000002_2': 2}},
             }, **COMP_HET_ALL_PASS_FILTERS,
         )
 


### PR DESCRIPTION
Updates key_by behavior to keep datasets sorted by locus-allele instead of switching to the non-sorted variant_id