### PR TITLE
do not delete uploaded files after reading

### DIFF
--- a/seqr/views/utils/file_utils.py
+++ b/seqr/views/utils/file_utils.py
@@ -111,6 +111,4 @@ def load_uploaded_file(upload_file_id):
     with gzip.open(serialized_file_path, "rt") as f:
         json_records = json.load(f)
 
-    os.remove(serialized_file_path)
-
     return json_records

--- a/seqr/views/utils/file_utils_tests.py
+++ b/seqr/views/utils/file_utils_tests.py
@@ -85,9 +85,9 @@ class FileUtilsTest(AuthenticationTestCase):
         uploaded_file_id = response_json['uploadedFileId']
         file_content = load_uploaded_file(uploaded_file_id)
         self.assertListEqual(file_content, PARSED_DATA)
-        # File should be removed after loading it once
-        with self.assertRaises(IOError):
-            load_uploaded_file(uploaded_file_id)
+        # File should be unchanged if reloaded multiple times
+        reload_file_content = load_uploaded_file(uploaded_file_id)
+        self.assertEqual(file_content, reload_file_content)
 
         # Test uploading with returned data and test with file formats
         wb = xl.Workbook()


### PR DESCRIPTION
There are plenty of places in seqr where a user uploads a file and then submits a form. seqr currently deleted these files after they are read, but this means if any of the downstream code for parsing that form and file return an error to the user and the user then resubmits the form, the file no longer exists. This is not intuitive to users, as the form still shows that a file has been loaded and also nothing else in the form was cleared after form submission failed so there no reason why that would be true for the file. Since these temporary files are always saved in a temp directory, there is really no need to clean them up explicitly and so leaving them and allowing them to be accessed on future form submissions will make for a better user experience. Also, accessing these files currently raises an unhandled 500 errr that is causing alert fatigue