### PR TITLE
Rename `seqr-datasets` to `seqr-hail-search-data`

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -12,7 +12,7 @@ from seqr.views.utils.variant_utils import reset_cached_search_results
 
 logger = logging.getLogger(__name__)
 
-GS_PATH_TEMPLATE = 'gs://seqr-datasets/v03/{path}/runs/{version}/'
+GS_PATH_TEMPLATE = 'gs://seqr-hail-search-data/v03/{path}/runs/{version}/'
 
 
 class Command(BaseCommand):

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -94,8 +94,8 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         call_command('check_for_new_samples_from_pipeline', 'GRCh38/SNV_INDEL', 'auto__2023-08-08')
 
         mock_subprocess.assert_has_calls([mock.call(command, stdout=-1, stderr=-2, shell=True) for command in [
-            'gsutil ls gs://seqr-datasets/v03/GRCh38/SNV_INDEL/runs/auto__2023-08-08/_SUCCESS',
-            'gsutil cat gs://seqr-datasets/v03/GRCh38/SNV_INDEL/runs/auto__2023-08-08/metadata.json',
+            'gsutil ls gs://seqr-hail-search-data/v03/GRCh38/SNV_INDEL/runs/auto__2023-08-08/_SUCCESS',
+            'gsutil cat gs://seqr-hail-search-data/v03/GRCh38/SNV_INDEL/runs/auto__2023-08-08/metadata.json',
         ]], any_order=True)
 
         mock_logger.info.assert_has_calls([


### PR DESCRIPTION
This, I believe, is safe to go in at any time as I've rsync-ed everything over:

```
gsutil ls gs://seqr-hail-search-data/v03/GRCh38/
gs://seqr-hail-search-data/v03/GRCh38/GCNV/
gs://seqr-hail-search-data/v03/GRCh38/MITO/
gs://seqr-hail-search-data/v03/GRCh38/ONT_SNV_INDEL/
gs://seqr-hail-search-data/v03/GRCh38/SNV_INDEL/
gs://seqr-hail-search-data/v03/GRCh38/SV/
```