### PR TITLE
Correct length of cram block is returned by dd.

### DIFF
--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -52,9 +52,9 @@ def file_iter(file_path, byte_range=None, raw_content=False, user=None):
         for line in _google_bucket_file_iter(file_path, byte_range=byte_range, raw_content=raw_content, user=user):
             yield line
     elif byte_range:
-        command = 'dd skip={offset} count={size} bs=1 if={file_path}'.format(
+        command = 'dd skip={offset} count={size} bs=1 if={file_path} status="none"'.format(
             offset=byte_range[0],
-            size=byte_range[1]-byte_range[0],
+            size=byte_range[1]-byte_range[0] + 1,
             file_path=file_path,
         )
         process = run_command(command, user=user)

--- a/seqr/views/apis/igv_api_tests.py
+++ b/seqr/views/apis/igv_api_tests.py
@@ -87,7 +87,7 @@ class IgvAPITest(AuthenticationTestCase):
         self.assertEqual(response.status_code, 206)
         self.assertListEqual([val for val in response.streaming_content], STREAMING_READS_CONTENT)
         mock_subprocess.assert_called_with(
-            'dd skip=100 count=150 bs=1 if=/project_A/sample_1.bai',
+            'dd skip=100 count=151 bs=1 if=/project_A/sample_1.bai status="none"',
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
         mock_open.assert_not_called()
 


### PR DESCRIPTION
Alright, I think I got it. It is because this [length here](https://github.com/broadinstitute/seqr/blob/6bd1328dad35c2182afb64b9756bd0a46cd13461/seqr/utils/file_utils.py#L57C28-L57C28) does not match [this length here](https://github.com/broadinstitute/seqr/blob/6bd1328dad35c2182afb64b9756bd0a46cd13461/seqr/views/apis/igv_api.py#L243).

Off by one error.

Discussion here: https://github.com/broadinstitute/seqr/discussions/3755

I also kept the status="none" in dd command.
