### PR TITLE
Fiel upload in progress UI improvement

### DIFF
--- a/ui/shared/components/form/XHRUploaderField.jsx
+++ b/ui/shared/components/form/XHRUploaderField.jsx
@@ -17,6 +17,11 @@ class UploaderFieldComponent extends React.PureComponent {
     uploaderProps: PropTypes.object,
   }
 
+  onStarted = () => {
+    const { input } = this.props
+    input.onChange({ loading: true })
+  }
+
   onFinished = (xhrResponse, uploaderState) => {
     const { input } = this.props
     input.onChange({ uploaderState, ...xhrResponse })
@@ -29,6 +34,7 @@ class UploaderFieldComponent extends React.PureComponent {
     return ([
       <React.Suspense key="uploader" fallback={<Loader />}>
         <XHRUploaderWithEvents
+          onUploadStarted={this.onStarted}
           onUploadFinished={this.onFinished}
           initialState={input.value ? input.value.uploaderState : null}
           url={`${url}${path}`}
@@ -44,7 +50,15 @@ class UploaderFieldComponent extends React.PureComponent {
 
 }
 
-export const uploadedFileHasErrors = value => value && value.errors && (value.errors.length ? value.errors : undefined)
+export const uploadedFileHasErrors = (value) => {
+  if (value?.errors && value.errors.length) {
+    return value.errors
+  }
+  if (value?.loading) {
+    return 'File upload incomplete'
+  }
+  return undefined
+}
 const hasUploadedFile = value => (value && value.uploadedFileId ? undefined : 'File not uploaded')
 export const validateUploadedFile = value => uploadedFileHasErrors(value) || hasUploadedFile(value)
 export const warnUploadedFile = value => value && value.warnings && (value.warnings.length ? value.warnings : undefined)

--- a/ui/shared/components/form/XHRUploaderWithEvents.jsx
+++ b/ui/shared/components/form/XHRUploaderWithEvents.jsx
@@ -11,6 +11,7 @@ import XHRUploader from 'react-xhr-uploader'
 
 const NO_DISPLAY_STYLE = { display: 'none' }
 const POINTER_CURSOR_STYLE = { cursor: 'pointer' }
+const MAX_UNCOMPLETED_PROGRESS = 80
 
 const onClickInput = (event) => {
   // allows the same file to be selected more than once (see
@@ -82,7 +83,7 @@ class XHRUploaderWithEvents extends XHRUploader {
       }
       xhr.upload.onprogress = (e) => {
         const progress = e.lengthComputable ? (e.loaded / e.total * 100) : 50 // eslint-disable-line no-mixed-operators
-        progressCallback(progress === 100 ? 80 : progress)
+        progressCallback(progress > MAX_UNCOMPLETED_PROGRESS ? MAX_UNCOMPLETED_PROGRESS : progress)
       }
       xhr.open(this.props.method, this.props.url, true)
       xhr.setRequestHeader('X-CSRFToken', Cookies.get('csrf_token'))

--- a/ui/shared/components/form/XHRUploaderWithEvents.jsx
+++ b/ui/shared/components/form/XHRUploaderWithEvents.jsx
@@ -81,9 +81,8 @@ class XHRUploaderWithEvents extends XHRUploader {
         }
       }
       xhr.upload.onprogress = (e) => {
-        if (e.lengthComputable) {
-          progressCallback(e.loaded / e.total * 100) // eslint-disable-line no-mixed-operators
-        }
+        const progress = e.lengthComputable ? (e.loaded / e.total * 100) : 50 // eslint-disable-line no-mixed-operators
+        progressCallback(progress === 100 ? 80 : progress)
       }
       xhr.open(this.props.method, this.props.url, true)
       xhr.setRequestHeader('X-CSRFToken', Cookies.get('csrf_token'))


### PR DESCRIPTION
A user got a confusing error message caused by an edge case where he submitted a form while a required file was in the process of re-uploading. This updates behavior to prevent form submission while a fiel is uploading, and also ensures the file upload progress bar never shows a complete upload before teh fiel actually finishes, which currently happens frequently