### PR TITLE
handle discovery variants with genotypes saved for multiple families

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -2024,6 +2024,7 @@
                         "aminoAcids": "V/M", "cdnaPosition": "3955"}
                 ]
             }, "chrom": "1", "genotypes": {
+                "I000002_na19675": {"sampleId": "NA19675", "ab": 0.5555556, "ad": null, "gq": 99, "dp": 9, "pl": null, "numAlt": 1},
                 "I000017_na20889": {"sampleId": "NA20885", "ab": 0.0, "ad": "71,0", "gq": 99.0, "dp": "71", "pl": "0,213,1918", "numAlt": 1}}},
         "family": 12
     }

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -642,7 +642,7 @@ def _get_gregor_genetic_findings_rows(rows, individual, participant_id, experime
                 'variant_inheritance': _get_variant_inheritance(individual, genotypes),
                 'additional_family_members_with_variant': '|'.join([
                     f'Broad_{_get_participant_id(family_individuals[guid])}' for guid, g in genotypes.items()
-                    if guid != individual.guid and g['numAlt'] > 0
+                    if guid != individual.guid and guid in family_individuals and g['numAlt'] > 0
                 ]),
                 'method_of_discovery': '|'.join([
                     METHOD_MAP.get(data_type) for data_type in individual_data_types if data_type != Sample.SAMPLE_TYPE_RNA


### PR DESCRIPTION
When a user saves a variant we make a copy of the full variant json, and if a user has done a multi-family search and they are saving a variant that was returned in multiple families, this means the genotypes json contains records for all the families that were returned, not just the single family the variant is being saved for. This is very common and generally does not cause problems, however there is now a [bug](https://github.com/broadinstitute/seqr-private/issues/1314) in the new genetics findings table report because it assumed that all the genotypes were for the saved family. Since this bug had relative urgency for delivering the reports next week, I fixed the bug by going into the django admin and manually cleaning up the genotypes for the 2 variants that were causing problems, thus "fixing" the bug. This is the code change that will prevent this from reoccuring in the future if anyone tags any other variants in that way