### PR TITLE
remove GC from MITO variant search and hover over

### DIFF
--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -19,7 +19,6 @@ class MitoHailTableQuery(BaseHailTableQuery):
     TRANSCRIPT_CONSEQUENCE_FIELD = 'consequence_term'
     GENOTYPE_FIELDS = {
         'dp': 'DP',
-        'gq': 'GQ',
         'hl': 'HL',
         'mitoCn': 'mito_cn',
         'contamination': 'contamination',

--- a/hail_search/test_search.py
+++ b/hail_search/test_search.py
@@ -454,7 +454,7 @@ class HailSearchTestCase(AioHTTPTestCase):
         )
 
         await self._assert_expected_search(
-            [MITO_VARIANT3], quality_filter={'min_gq': 60, 'min_hl': 5}, sample_data=FAMILY_2_MITO_SAMPLE_DATA,
+            [MITO_VARIANT1, MITO_VARIANT3], quality_filter={'min_gq': 60, 'min_hl': 5}, sample_data=FAMILY_2_MITO_SAMPLE_DATA,
         )
 
         gcnv_quality_filter = {'min_gq': 40, 'min_qs': 20}

--- a/hail_search/test_utils.py
+++ b/hail_search/test_utils.py
@@ -755,7 +755,7 @@ MITO_VARIANT1 = {
     'familyGuids': ['F000002_2'],
     'genotypes': {'I000006_hg00733': {
         'sampleId': 'HG00733', 'sampleType': 'WGS', 'individualGuid': 'I000006_hg00733', 'familyGuid': 'F000002_2',
-        'numAlt': 1, 'dp': 3955, 'gq': 53.0, 'hl': 0.083, 'mitoCn': 230, 'contamination': 0.0,
+        'numAlt': 1, 'dp': 3955, 'hl': 0.083, 'mitoCn': 230, 'contamination': 0.0,
     }},
     'genotypeFilters': '',
     'populations': {
@@ -809,7 +809,7 @@ MITO_VARIANT2 = {
     'familyGuids': ['F000002_2'],
     'genotypes': {'I000006_hg00733': {
         'sampleId': 'HG00733', 'sampleType': 'WGS', 'individualGuid': 'I000006_hg00733', 'familyGuid': 'F000002_2',
-        'numAlt': 1, 'dp': 3845, 'gq': 60.0, 'hl': 0.029, 'mitoCn': 247, 'contamination': 0.015,
+        'numAlt': 1, 'dp': 3845, 'hl': 0.029, 'mitoCn': 247, 'contamination': 0.015,
     }},
     'genotypeFilters': '',
     'populations': {
@@ -856,7 +856,7 @@ MITO_VARIANT3 = {
     'familyGuids': ['F000002_2'],
     'genotypes': {'I000006_hg00733': {
         'sampleId': 'HG00733', 'sampleType': 'WGS', 'individualGuid': 'I000006_hg00733', 'familyGuid': 'F000002_2',
-        'numAlt': 2, 'dp': 3943, 'gq': 60.0, 'hl': 1.0, 'mitoCn': 214, 'contamination': 0.0,
+        'numAlt': 2, 'dp': 3943, 'hl': 1.0, 'mitoCn': 214, 'contamination': 0.0,
     }},
     'genotypeFilters': 'artifact_prone_site',
     'populations': {


### PR DESCRIPTION
Variant hover over before:
<img width="285" alt="Screenshot 2023-12-15 at 1 52 25 PM" src="https://github.com/broadinstitute/seqr/assets/25799914/7bed4c8c-acd4-4283-9b6a-cb91b0c80d85">

After:
<img width="264" alt="Screenshot 2023-12-15 at 4 25 57 PM" src="https://github.com/broadinstitute/seqr/assets/25799914/2c8ae72d-a6ea-4d92-ad2f-230ca3e4a961">

Variant search before this change used the GQ filter and excluded MITO variants. After the change, the GQ filter no longer applies to MITO variants even if it's included in the request. Here's a screenshot from debugging, see that `field` is `None` even though `min_qc` is included in the filters:
<img width="1005" alt="Screenshot 2023-12-15 at 4 31 56 PM" src="https://github.com/broadinstitute/seqr/assets/25799914/64f1cc83-9095-41d9-9de5-06cef6e310e6">
