### PR TITLE
Fix gnomad v2 links

### DIFF
--- a/ui/shared/components/panel/variants/Frequencies.jsx
+++ b/ui/shared/components/panel/variants/Frequencies.jsx
@@ -177,6 +177,7 @@ const POPULATIONS = [
     fieldTitle: 'gnomAD v2 exomes',
     titleContainer: gnomadLink,
     urls: { [GENOME_VERSION_37]: 'gnomad.broadinstitute.org' },
+    queryParams: { [GENOME_VERSION_37]: 'dataset=gnomad_r2_1' },
   },
   {
     field: 'gnomad_genomes',


### PR DESCRIPTION
(cherry picked from commit 38b4bbdb98883fc6909ba82d09db71b264c9084e)

Gnomad website have defaulted to V4 so the Gnomad V2 links are broken unless `dataset=gnomad_r2_1` query param is provided in the URL.
