### PR TITLE
Deactivate project search command

### DIFF
--- a/seqr/management/commands/deactivate_project_search.py
+++ b/seqr/management/commands/deactivate_project_search.py
@@ -1,7 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
 from seqr.models import Project, Sample
-from seqr.utils.search.utils import backend_specific_call
 
 import logging
 logger = logging.getLogger(__name__)

--- a/seqr/management/commands/deactivate_project_search.py
+++ b/seqr/management/commands/deactivate_project_search.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from seqr.models import Project, Sample
+from seqr.utils.search.utils import backend_specific_call
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('project')
+
+    def handle(self, *args, **options):
+        project = Project.objects.get(guid=options['project'])
+
+        if input(f'Are you sure you want to deactivate search for {project.name} (y/n)? ') != 'y':
+            raise CommandError('Error: user did not confirm')
+
+        updated = Sample.bulk_update(user=None, update_json={'is_active': False}, individual__family__project=project)
+
+        logger.info(f'Deactivated {len(updated)} samples')

--- a/seqr/management/tests/deactivate_project_search_tests.py
+++ b/seqr/management/tests/deactivate_project_search_tests.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+import mock
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import call_command
+from django.test import TestCase
+from django.core.management.base import CommandError
+from seqr.models import Sample
+
+PROJECT_GUID = 'R0001_1kg'
+VARIANT_ID = '21-3343353-GAGA-G'
+
+
+class DeactivateProjectSearchTest(TestCase):
+    fixtures = ['users', '1kg_project']
+
+    @mock.patch('seqr.management.commands.deactivate_project_search.input')
+    @mock.patch('seqr.management.commands.deactivate_project_search.logger')
+    def test_command(self, mock_logger, mock_input):
+        mock_input.return_value = 'n'
+
+        # Test invalid project
+        with self.assertRaises(ObjectDoesNotExist):
+            call_command('deactivate_project_search', 'foo')
+
+        # Test user did not confirm.
+        with self.assertRaises(CommandError) as e:
+            call_command('deactivate_project_search', PROJECT_GUID)
+        self.assertEqual(str(e.exception), 'Error: user did not confirm')
+
+        # Test success
+        mock_input.return_value = 'y'
+        call_command('deactivate_project_search', PROJECT_GUID)
+        mock_logger.info.assert_called_with('Deactivated 14 samples')
+
+        active_samples = Sample.objects.filter(individual__family__project__guid=PROJECT_GUID, is_active=True)
+        self.assertEqual(active_samples.count(), 0)
+
+        # Re-running has no effect
+        call_command('deactivate_project_search', PROJECT_GUID)
+        mock_logger.info.assert_called_with('Deactivated 0 samples')


### PR DESCRIPTION
Since there are some projects where search will not be available after the hail backend go live, we need a way to safely disable search in those projects beforehand