### PR TITLE
Project overview performance

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -138,7 +138,8 @@ from seqr.views.apis.igv_api import fetch_igv_track, receive_igv_table_handler, 
 from seqr.views.apis.analysis_group_api import update_analysis_group_handler, delete_analysis_group_handler
 from seqr.views.apis.project_api import create_project_handler, update_project_handler, delete_project_handler, \
     project_page_data, project_families, project_overview, project_mme_submisssions, project_individuals, \
-    project_analysis_groups, update_project_workspace, project_family_notes, project_collaborators, project_locus_lists
+    project_analysis_groups, update_project_workspace, project_family_notes, project_collaborators, project_locus_lists, \
+    project_samples
 from seqr.views.apis.project_categories_api import update_project_categories_handler
 from seqr.views.apis.anvil_workspace_api import anvil_workspace_page, create_project_from_workspace, \
     grant_workspace_access, validate_anvil_vcf, add_workspace_data, get_anvil_vcf_list
@@ -202,6 +203,7 @@ api_endpoints = {
     'project/(?P<project_guid>[^/]+)/details': project_page_data,
     'project/(?P<project_guid>[^/]+)/get_families': project_families,
     'project/(?P<project_guid>[^/]+)/get_individuals': project_individuals,
+    'project/(?P<project_guid>[^/]+)/get_samples': project_samples,
     'project/(?P<project_guid>[^/]+)/get_family_notes': project_family_notes,
     'project/(?P<project_guid>[^/]+)/get_mme_submissions': project_mme_submisssions,
     'project/(?P<project_guid>[^/]+)/get_analysis_groups': project_analysis_groups,

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -269,6 +269,17 @@ def project_individuals(request, project_guid):
         'individualsByGuid': {i['individualGuid']: i for i in individuals},
     })
 
+
+@login_and_policies_required
+def project_samples(request, project_guid):
+    project = get_project_and_check_permissions(project_guid, request.user)
+    samples = Sample.objects.filter(individual__family__project=project)
+
+    return create_json_response({
+        'samplesByGuid': {s['sampleGuid']: s for s in get_json_for_samples(samples, project_guid=project_guid)},
+    })
+
+
 @login_and_policies_required
 def project_analysis_groups(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -257,7 +257,7 @@ class ProjectAPITest(object):
         self.assertSetEqual(set(response_json.keys()), response_keys)
 
         project_fields = {
-            'variantTagTypes', 'variantFunctionalTagTypes',
+            'variantTagTypes', 'variantFunctionalTagTypes', 'sampleCounts',
             'projectGuid', 'mmeDeletedSubmissionCount', 'mmeSubmissionCount',
         }
         project_response = response_json['projectsByGuid'][PROJECT_GUID]
@@ -285,9 +285,22 @@ class ProjectAPITest(object):
             'order': 99,
             'numTags': 1,
         })
+        self.assertDictEqual(project_response['sampleCounts'], {
+            'WES__SNV_INDEL': [{
+                'familyCounts': {
+                    'F000001_1': 3, 'F000002_2': 3, 'F000003_3': 1, 'F000004_4': 1, 'F000005_5': 1, 'F000006_6': 1,
+                    'F000007_7': 1, 'F000008_8': 1, 'F000010_10': 1,
+                },
+                'loadedDate': '2017-02-05',
+            }],
+            'WES__SV': [{'familyCounts': {'F000002_2': 3}, 'loadedDate': '2018-02-05'}],
+            'WGS__MITO': [{'familyCounts': {'F000002_2': 1}, 'loadedDate': '2022-02-05'}],
+            'RNA__SNV_INDEL': [{'familyCounts': {'F000001_1': 3}, 'loadedDate': '2017-02-05'}],
+        })
         self.assertEqual(project_response['mmeSubmissionCount'], 1)
         self.assertEqual(project_response['mmeDeletedSubmissionCount'], 0)
 
+        self.assertEqual(len(response_json['samplesByGuid']), 19)
         self.assertSetEqual(set(next(iter(response_json['samplesByGuid'].values())).keys()), SAMPLE_FIELDS)
         self.assertDictEqual(response_json['familyTagTypeCounts'],  {
             'F000001_1': {'Review': 1, 'Tier 1 - Novel gene and phenotype': 1, 'MME Submission': 1},

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -9,7 +9,8 @@ import responses
 from seqr.models import Project
 from seqr.views.apis.project_api import create_project_handler, delete_project_handler, update_project_handler, \
     project_page_data, project_families, project_overview, project_mme_submisssions, project_individuals, \
-    project_analysis_groups, update_project_workspace, project_family_notes, project_collaborators, project_locus_lists
+    project_analysis_groups, update_project_workspace, project_family_notes, project_collaborators, project_locus_lists, \
+    project_samples
 from seqr.views.utils.terra_api_utils import TerraAPIException, TerraRefreshTokenFailedException
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, \
     PROJECT_FIELDS, LOCUS_LIST_FIELDS, PA_LOCUS_LIST_FIELDS, NO_INTERNAL_CASE_REVIEW_INDIVIDUAL_FIELDS, \
@@ -451,6 +452,24 @@ class ProjectAPITest(object):
             set(next(iter(response.json()['individualsByGuid'].values())).keys()),
             NO_INTERNAL_CASE_REVIEW_INDIVIDUAL_FIELDS,
         )
+
+    def test_project_samples(self):
+        url = reverse(project_samples, args=[PROJECT_GUID])
+        self.check_collaborator_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        response_json = response.json()
+        response_keys = {'samplesByGuid'}
+        self.assertSetEqual(set(response_json.keys()), response_keys)
+
+        self.assertEqual(len(response_json['samplesByGuid']), 20)
+        self.assertSetEqual(set(next(iter(response_json['samplesByGuid'].values())).keys()), SAMPLE_FIELDS)
+
+        # Test empty project
+        empty_url = reverse(project_samples, args=[EMPTY_PROJECT_GUID])
+        self._check_empty_project(empty_url, response_keys)
 
     def test_project_analysis_groups(self):
         url = reverse(project_analysis_groups, args=[PROJECT_GUID])

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -328,15 +328,7 @@ def add_individual_hpo_details(parsed_individuals):
                 feature.update({'category': hpo.category_id, 'label': hpo.name})
 
 
-def get_json_for_samples(samples, project_guid=None, family_guid=None, individual_guid=None, skip_nested=False, **kwargs):
-    """Returns a JSON representation of the given list of Samples.
-
-    Args:
-        samples (array): array of django models for the Samples.
-    Returns:
-        array: array of json objects
-    """
-
+def _get_sample_json_kwargs(project_guid=None, family_guid=None, individual_guid=None, skip_nested=False, **kwargs):
     if project_guid or not skip_nested:
         additional_kwargs = {'nested_fields': [
             {'fields': ('individual', 'guid'), 'value': individual_guid},
@@ -345,8 +337,19 @@ def get_json_for_samples(samples, project_guid=None, family_guid=None, individua
         ]}
     else:
         additional_kwargs = {'additional_model_fields': ['individual_id']}
+    return {'guid_key': 'sampleGuid', **additional_kwargs, **kwargs}
 
-    return _get_json_for_models(samples, guid_key='sampleGuid', **additional_kwargs, **kwargs)
+
+def get_json_for_samples(samples, **kwargs):
+    """Returns a JSON representation of the given list of Samples.
+
+    Args:
+        samples (array): array of django models for the Samples.
+    Returns:
+        array: array of json objects
+    """
+
+    return get_json_for_queryset(samples, **_get_sample_json_kwargs(**kwargs))
 
 
 def get_json_for_sample(sample, **kwargs):
@@ -358,7 +361,7 @@ def get_json_for_sample(sample, **kwargs):
         dict: json object
     """
 
-    return _get_json_for_model(sample, get_json_for_models=get_json_for_samples, **kwargs)
+    return _get_json_for_model(sample, **_get_sample_json_kwargs(**kwargs))
 
 
 def get_json_for_analysis_groups(analysis_groups, project_guid=None, skip_nested=False, **kwargs):

--- a/settings.py
+++ b/settings.py
@@ -95,7 +95,7 @@ CSP_STYLE_SRC = ('https://fonts.googleapis.com', "'self'") + IGV_CSS_HASHES
 CSP_STYLE_SRC_ELEM = ('https://fonts.googleapis.com', "'self'") + IGV_CSS_HASHES
 
 # django-debug-toolbar settings
-ENABLE_DJANGO_DEBUG_TOOLBAR = True
+ENABLE_DJANGO_DEBUG_TOOLBAR = False
 if ENABLE_DJANGO_DEBUG_TOOLBAR:
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
     INSTALLED_APPS = ['debug_toolbar'] + INSTALLED_APPS

--- a/settings.py
+++ b/settings.py
@@ -95,7 +95,7 @@ CSP_STYLE_SRC = ('https://fonts.googleapis.com', "'self'") + IGV_CSS_HASHES
 CSP_STYLE_SRC_ELEM = ('https://fonts.googleapis.com', "'self'") + IGV_CSS_HASHES
 
 # django-debug-toolbar settings
-ENABLE_DJANGO_DEBUG_TOOLBAR = False
+ENABLE_DJANGO_DEBUG_TOOLBAR = True
 if ENABLE_DJANGO_DEBUG_TOOLBAR:
     MIDDLEWARE = ['debug_toolbar.middleware.DebugToolbarMiddleware'] + MIDDLEWARE
     INSTALLED_APPS = ['debug_toolbar'] + INSTALLED_APPS

--- a/ui/pages/Project/components/ProjectOverview.jsx
+++ b/ui/pages/Project/components/ProjectOverview.jsx
@@ -257,7 +257,7 @@ MatchmakerOverview.propTypes = {
 class DatasetSection extends React.PureComponent {
 
   static propTypes = {
-    loadedSampleCounts: PropTypes.object.isRequired,
+    loadedSampleCounts: PropTypes.arrayOf(PropTypes.object).isRequired,
   }
 
   state = { showAll: false }
@@ -269,9 +269,9 @@ class DatasetSection extends React.PureComponent {
   render() {
     const { loadedSampleCounts } = this.props
     const { showAll } = this.state
-    const allLoads = Object.keys(loadedSampleCounts).sort().map(loadedDate => (
+    const allLoads = loadedSampleCounts.map(({ loadedDate, count }) => (
       <div key={loadedDate}>
-        {`${new Date(loadedDate).toLocaleDateString()} - ${loadedSampleCounts[loadedDate]} samples`}
+        {`${new Date(loadedDate).toLocaleDateString()} - ${count} samples`}
       </div>
     ))
 
@@ -290,7 +290,7 @@ class DatasetSection extends React.PureComponent {
 }
 
 const Dataset = React.memo(({ showLoadWorkspaceData, hasAnvil, samplesByType, user, elasticsearchEnabled }) => {
-  const datasetSections = Object.entries(samplesByType).map(([sampleTypeKey, loadedSampleCounts]) => {
+  const datasetSections = samplesByType.map(([sampleTypeKey, loadedSampleCounts]) => {
     const [sampleType, datasetType] = sampleTypeKey.split('__')
     return {
       key: sampleTypeKey,

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -55,8 +55,11 @@ export const loadMmeSubmissions = () => loadCurrentProjectChildEntities('mme sub
 
 const loadFamilyNotes = () => loadCurrentProjectChildEntities('family notes', REQUEST_FAMILIES, RECEIVE_FAMILIES)
 
+const loadSamples = () => loadCurrentProjectChildEntities('samples', REQUEST_INDIVIDUALS)
+
 export const loadProjectExportData = () => (dispatch, getState) => Promise.all([
   loadIndividuals()(dispatch, getState),
+  loadSamples()(dispatch, getState),
   loadFamilyNotes()(dispatch, getState),
 ])
 

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -552,7 +552,6 @@ const getIndividualsExportData = createSelector(
     }))], []),
 )
 
-// TODO - fetch samples for export
 const getSamplesExportData = createSelector(
   getVisibleFamiliesInSortedOrder,
   getIndividualsByGuid,

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -21,7 +21,7 @@ import {
   getAnalysisGroupsGroupedByProjectGuid, getSavedVariantsByGuid, getSortedIndividualsByFamily,
   getMmeResultsByGuid, getMmeSubmissionsByGuid, getHasActiveSearchableSampleByFamily, getSelectableTagTypesByProject,
   getVariantTagsByGuid, getUserOptionsByUsername, getSamplesByFamily, getNotesByFamilyType,
-  getSamplesGroupedByProjectGuid, getVariantTagNotesByFamilyVariants, getPhenotypeGeneScoresByIndividual,
+  getVariantTagNotesByFamilyVariants, getPhenotypeGeneScoresByIndividual,
   getRnaSeqDataByIndividual,
 } from 'redux/selectors'
 
@@ -78,9 +78,6 @@ export const getProjectFamiliesByGuid = createSelector(
 export const getProjectAnalysisGroupsByGuid = createSelector(
   getAnalysisGroupsGroupedByProjectGuid, getProjectGuid, selectEntitiesForProjectGuid,
 )
-const getProjectSamplesByGuid = createSelector(
-  getSamplesGroupedByProjectGuid, getProjectGuid, selectEntitiesForProjectGuid,
-)
 
 const getAnalysisGroupGuid = (state, props) => (
   (props || {}).match ? props.match.params.analysisGroupGuid : (props || {}).analysisGroupGuid
@@ -119,7 +116,9 @@ export const getProjectAnalysisGroupDataLoadedFamilyIndividualCounts = createSel
   getProjectAnalysisGroupFamiliesByGuid,
   getSamplesByFamily,
   (familiesByGuid, samplesByFamily) => Object.values(familiesByGuid).map(((family) => {
-    const sampleIndividuals = new Set((samplesByFamily[family.familyGuid] || []).map(sample => sample.individualGuid))
+    const sampleIndividuals = new Set((samplesByFamily[family.familyGuid] || []).filter(
+      sample => sample.isActive,
+    ).map(sample => sample.individualGuid))
     const hasSampleParentCounts = (family.parents || []).map(
       ({ maternalGuid, paternalGuid }) => [maternalGuid, paternalGuid].filter(guid => sampleIndividuals.has(guid)),
     ).filter(parents => parents.length > 0)
@@ -142,20 +141,16 @@ export const getProjectAnalysisGroupIndividualsByGuid = createSelector(
 )
 
 export const getProjectAnalysisGroupSamplesByTypes = createSelector(
-  getProjectSamplesByGuid,
-  getSamplesByFamily,
+  getCurrentProject,
   getCurrentAnalysisGroup,
-  (projectSamplesByGuid, samplesByFamily, analysisGroup) => (analysisGroup ? analysisGroup.familyGuids.reduce(
-    (acc, familyGuid) => ([...acc, ...(samplesByFamily[familyGuid] || [])]), [],
-  ) : Object.values(projectSamplesByGuid)).reduce((acc, sample) => {
-    const loadedDate = (sample.loadedDate).split('T')[0]
-    const typeKey = `${sample.sampleType}__${sample.datasetType}`
-    if (!acc[typeKey]) {
-      acc[typeKey] = {}
-    }
-    acc[typeKey][loadedDate] = (acc[typeKey][loadedDate] || 0) + 1
-    return acc
-  }, {}),
+  (project, analysisGroup) => Object.entries(project.sampleCounts || {}).map(
+    ([key, typeCounts]) => ([key, typeCounts.map(({ familyCounts, ...data }) => ({
+      ...data,
+      count: Object.entries(familyCounts).reduce((total, [familyGuid, count]) => (
+        (!analysisGroup || analysisGroup.familyGuids.includes(familyGuid)) ? total + count : total
+      ), 0),
+    })).filter(({ count }) => count > 0)]),
+  ),
 )
 
 export const getProjectAnalysisGroupMmeSubmissionDetails = createSelector(
@@ -557,6 +552,7 @@ const getIndividualsExportData = createSelector(
     }))], []),
 )
 
+// TODO - fetch samples for export
 const getSamplesExportData = createSelector(
   getVisibleFamiliesInSortedOrder,
   getIndividualsByGuid,


### PR DESCRIPTION
Addresses a longstanding issue with slow loading for the RGP project page(~9 seconds). The major change is to stop returning all Samples as part of the project overview.

RGP currently has ~3500 active samples and ~50,000 inactive samples. On the project page, we use samples for the following:
- **All samples** to show the "Datasets" summary section, which shows all the samples/dataset types broken down by the number of samples loaded on each date
- Active samples to show the "Families/Individuals With Data" summary section (was using all samples but that was a bug, it should always have been active only)
- **All samples** for data export
- The first samples loaded for each family, to show on the family table an to sort it
- Active samples to display/sort/filter the family table

Returning the full samples data for ~50,000 samples was giving both the server side endpoint and client side rendering a performance hit, and for  no real advantage as for most project page renders the details of inactive samples are not important.  This changes the logic to only return active samples and the first loaded sample per family which covers most of the use cases for samples on the project page. For the 2 use cases that currently require all the samples data, this makes the following updates:
- Returns project-level summary statistics to use for the Datasets section so that the full summary can be shown without access to all the inactive samples
- Fetches all the samples when the user goes to export data. We were already fetching the individual data at that point and since the requests run in parallel this does not change the performance for download, and means that in the >99% of cases where a user is on the project page and not downloading anything, we do not need to have all the data ready

The final performance enhancement is an improvement to how we query the number of variant notes in a project- it turns out the query django was constructing was wildly inefficient and took over a second