### PR TITLE
do not use remapped sample ids for hail backend

### DIFF
--- a/hail_search/test_search.py
+++ b/hail_search/test_search.py
@@ -867,13 +867,13 @@ class HailSearchTestCase(AioHTTPTestCase):
         async with self.client.request('POST', '/search', json=search_body) as resp:
             self.assertEqual(resp.status, 400)
             reason = resp.reason
-        self.assertEqual(reason, 'The following samples are available in seqr but missing the loaded data: NA19675, NA19678')
+        self.assertEqual(reason, 'The following samples are available in seqr but missing the loaded data: NA19675_1, NA19678')
 
         search_body = get_hail_search_body(sample_data=MULTI_PROJECT_MISSING_SAMPLE_DATA)
         async with self.client.request('POST', '/search', json=search_body) as resp:
             self.assertEqual(resp.status, 400)
             reason = resp.reason
-        self.assertEqual(reason, 'The following samples are available in seqr but missing the loaded data: NA19675, NA19678')
+        self.assertEqual(reason, 'The following samples are available in seqr but missing the loaded data: NA19675_1, NA19678')
 
         search_body = get_hail_search_body(
             intervals=LOCATION_SEARCH['intervals'] + ['1:1-99999999999'], omit_sample_type='SV_WES',

--- a/hail_search/test_utils.py
+++ b/hail_search/test_utils.py
@@ -36,7 +36,7 @@ CUSTOM_AFFECTED_SAMPLE_DATA['SNV_INDEL'][2]['affected'] = 'U'
 
 FAMILY_1_SAMPLE_DATA = {
     'SNV_INDEL': [
-        {'sample_id': 'NA19675', 'individual_guid': 'I000001_na19675', 'family_guid': 'F000001_1', 'project_guid': 'R0001_1kg', 'affected': 'A'},
+        {'sample_id': 'NA19675_1', 'individual_guid': 'I000001_na19675', 'family_guid': 'F000001_1', 'project_guid': 'R0001_1kg', 'affected': 'A'},
         {'sample_id': 'NA19678', 'individual_guid': 'I000002_na19678', 'family_guid': 'F000001_1', 'project_guid': 'R0001_1kg', 'affected': 'N'},
     ],
 }

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -101,7 +101,7 @@ def _get_sample_data(samples, inheritance_filter=None, inheritance_mode=None, **
     )
     if inheritance_mode == X_LINKED_RECESSIVE:
         sample_values['sex'] = F('individual__sex')
-    sample_data = samples.order_by('id').values('sample_id', 'dataset_type', 'sample_type', **sample_values)
+    sample_data = samples.order_by('id').values('individual__individual_id', 'dataset_type', 'sample_type', **sample_values)
 
     custom_affected = (inheritance_filter or {}).pop('affected', None)
     if custom_affected:
@@ -112,6 +112,7 @@ def _get_sample_data(samples, inheritance_filter=None, inheritance_mode=None, **
     for s in sample_data:
         dataset_type = s.pop('dataset_type')
         sample_type = s.pop('sample_type')
+        s['sample_id'] = s.pop('individual__individual_id')
         data_type_key = f'{dataset_type}_{sample_type}' if dataset_type == Sample.DATASET_TYPE_SV_CALLS else dataset_type
         sample_data_by_data_type[data_type_key].append(s)
 


### PR DESCRIPTION
In the hail backend, the sample_id is taken from the individual_id field in the pedigree and is never different from the individual_id. Some v2 samples were not remapped in the pipeline itself and therefore the individual_id and sample_id are different, but this is not possible in v3 so we should not use those differing sample_ids