### PR TITLE
add caching for variant lookup

### DIFF
--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -116,8 +116,8 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         ])
         mock_logger.warining.assert_not_called()
 
-        mock_redis.return_value.delete.assert_called_with('search_results__*')
-        mock_utils_logger.info.assert_called_with('Reset 1 cached results')
+        mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*')
+        mock_utils_logger.info.assert_called_with('Reset 2 cached results')
 
         # Tests Sample models created/updated
         updated_sample_models = Sample.objects.filter(guid__in={

--- a/seqr/management/tests/reset_cached_search_results_tests.py
+++ b/seqr/management/tests/reset_cached_search_results_tests.py
@@ -23,7 +23,7 @@ class ResetCachedSearchResultsTest(TestCase):
     @mock.patch('seqr.views.utils.variant_utils.logger')
     @mock.patch('seqr.management.commands.reset_cached_search_results.logger')
     def test_command(self, mock_command_logger, mock_utils_logger, mock_redis):
-        mock_redis.return_value.keys.side_effect = lambda pattern: [pattern]
+        mock_redis.return_value.keys.side_effect = lambda pattern: [pattern] if pattern != 'variant_lookup_results__*' else []
 
         # Test command with a --project argument
         call_command('reset_cached_search_results', '--project={}'.format(PROJECT_NAME))
@@ -47,9 +47,10 @@ class ResetCachedSearchResultsTest(TestCase):
 
         # Test command for reset metadata
         mock_redis.reset_mock()
+        mock_redis.return_value.keys.side_effect = lambda pattern: [pattern]
         call_command('reset_cached_search_results', '--reset-index-metadata')
-        mock_redis.return_value.delete.assert_called_with('search_results__*', 'index_metadata__*')
-        mock_utils_logger.info.assert_called_with('Reset 2 cached results')
+        mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*', 'index_metadata__*')
+        mock_utils_logger.info.assert_called_with('Reset 3 cached results')
         mock_command_logger.info.assert_called_with('Reset cached search results for all projects')
 
         # Test with connection error

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from django.db.models import F, Min, Count
 
 import requests
-from reference_data.models import Omim, GeneConstraint, GENOME_VERSION_LOOKUP, GENOME_VERSION_GRCh38
+from reference_data.models import Omim, GeneConstraint, GENOME_VERSION_LOOKUP
 from seqr.models import Sample, PhenotypePrioritization
 from seqr.utils.search.constants import PRIORITIZED_GENE_SORT, X_LINKED_RECESSIVE
 from seqr.utils.xpos_utils import MIN_POS, MAX_POS
@@ -74,9 +74,8 @@ def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_id
     return response_json['results']
 
 
-def hail_variant_lookup(user, variant_id, genome_version=None, samples=None, **kwargs):
+def hail_variant_lookup(user, variant_id, samples=None, **kwargs):
     body = {
-        'genome_version': GENOME_VERSION_LOOKUP[genome_version or GENOME_VERSION_GRCh38],
         'variant_id': variant_id,
         **kwargs,
     }

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import timedelta
 
+from reference_data.models import GENOME_VERSION_LOOKUP, GENOME_VERSION_GRCh38
 from seqr.models import Sample, Individual, Project
 from seqr.utils.redis_utils import safe_redis_get_json, safe_redis_set_json
 from seqr.utils.search.constants import XPOS_SORT_KEY, PRIORITIZED_GENE_SORT, RECESSIVE, COMPOUND_HET, \
@@ -152,7 +153,13 @@ def _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=None
     )
 
 
-def variant_lookup(user, variant_id, families=None, **kwargs):
+def variant_lookup(user, variant_id, families=None, genome_version=None, **kwargs):
+    genome_version = genome_version or GENOME_VERSION_GRCh38
+    cache_key = f'variant_lookup_results__{variant_id}__{genome_version}__{user}'
+    variant = safe_redis_get_json(cache_key)
+    if variant:
+        return variant
+
     parsed_variant_id = _parse_variant_id(variant_id)
     if not parsed_variant_id:
         raise InvalidSearchException(f'Invalid variant {variant_id}')
@@ -162,7 +169,9 @@ def variant_lookup(user, variant_id, families=None, **kwargs):
         kwargs['samples'] = samples
 
     lookup_func = backend_specific_call(_raise_search_error('Hail backend is disabled'), hail_variant_lookup)
-    return lookup_func(user, parsed_variant_id, **kwargs)
+    variant = lookup_func(user, parsed_variant_id, genome_version=GENOME_VERSION_LOOKUP[genome_version], **kwargs)
+    safe_redis_set_json(cache_key, variant, expire=timedelta(weeks=2))
+    return variant
 
 
 def _get_search_cache_key(search_model, sort=None):

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -88,6 +88,7 @@ def reset_cached_search_results(project, reset_index_metadata=False):
                 keys_to_delete += redis_client.keys(pattern='search_results__{}*'.format(guid))
         else:
             keys_to_delete = redis_client.keys(pattern='search_results__*')
+        keys_to_delete += redis_client.keys(pattern='variant_lookup_results__*')
         if reset_index_metadata:
             keys_to_delete += redis_client.keys(pattern='index_metadata__*')
         if keys_to_delete:


### PR DESCRIPTION
The variant lookup endpoint now completes in less than the max time for running a search on the pod, but its intermittently taking longer than the browser/django is allowing before showing a 504. While not as good as just succeeding the first time, caching the result means that if the user refreshes the page after a request fails, the response will be in the cache and can be shown to them. This is behavior analysts are used to for long-running searches, and is consistent with how searches generally behave