### PR TITLE
Update indeterministic assertion in test_json_for_saved_variants_with_tags

### DIFF
--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -155,7 +155,7 @@ class JSONUtilsTest(object):
         self.assertSetEqual(set(var_2['noteGuids']), set(v2_note_guids))
 
         self.assertSetEqual(set(json['variantTagsByGuid'].keys()), v1_tag_guids | v2_tag_guids)
-        self.assertSetEqual(set(next(iter(json['variantTagsByGuid'].values())).keys()), TAG_FIELDS)
+        self.assertSetEqual(set(json['variantTagsByGuid']['VT1726961_2103343353_r0390_100'].keys()), TAG_FIELDS)
         for tag_guid in v1_tag_guids:
             self.assertListEqual(json['variantTagsByGuid'][tag_guid]['variantGuids'], [variant_guid_1])
         for tag_guid in v2_tag_guids:


### PR DESCRIPTION
Hi! There's an assertion in the `test_json_for_saved_variants_with_tags` test that performs a `next(iter(<dictionary>))`, which for a dictionary has an indeterministic order. In our CI, sometimes this fails. One of the variants here contains the variantTag for an AIP variant, which gets formatted with `metadata → apiMetadata` causing this test to intermittently fail. 

https://github.com/broadinstitute/seqr/blob/2e0a222705369b2967464c54f131ed4965a1f6c5/seqr/views/utils/orm_to_json_utils.py#L441-L445

For this reason, I propose selecting the tag `VT1726961_2103343353_r0390_100` to look at the keys for.

Here are the keys by tag ID for the `variantTagsByGuid`:

```json
{
    "VT1726961_2103343353_r0390_100": [
        "metadata",
        "createdBy",
        "lastModifiedDate",
        "searchHash",
        "tagGuid",
        "name",
        "category",
        "color",
        "variantGuids"
    ],
    "VT1708633_2103343353_r0390_100": [
        "metadata",
        "createdBy",
        "lastModifiedDate",
        "searchHash",
        "tagGuid",
        "name",
        "category",
        "color",
        "variantGuids"
    ],
    "VT1726945_2103343353_r0390_100": [
        "metadata",
        "createdBy",
        "lastModifiedDate",
        "searchHash",
        "tagGuid",
        "name",
        "category",
        "color",
        "variantGuids"
    ],
    "VT1726970_2103343353_r0004_tes": [
        "metadata",
        "createdBy",
        "lastModifiedDate",
        "searchHash",
        "tagGuid",
        "name",
        "category",
        "color",
        "variantGuids"
    ],
    "VT1726985_2103343353_r0390_100": [
        "createdBy",
        "lastModifiedDate",
        "searchHash",
        "tagGuid",
        "name",
        "category",
        "color",
        "aipMetadata",
        "variantGuids"
    ]
}
```