### PR TITLE
feat: Clearly show when variant transcript is not Canonical nor MANE

### DIFF
--- a/ui/shared/components/panel/variants/Annotations.test.js
+++ b/ui/shared/components/panel/variants/Annotations.test.js
@@ -1,13 +1,15 @@
 import React from 'react'
 import { shallow, configure } from 'enzyme'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
-import { getUser } from 'redux/selectors'
+import configureStore from 'redux-mock-store'
 import Annotations from './Annotations'
-import { VARIANT, SV_VARIANT } from '../fixtures'
+import { STATE1, VARIANT, SV_VARIANT } from '../fixtures'
 
 configure({ adapter: new Adapter() })
 
 test('shallow-render without crashing', () => {
-  shallow(<Annotations variant={VARIANT} />)
-  shallow(<Annotations variant={SV_VARIANT} />)
+  const store = configureStore()(STATE1)
+
+  shallow(<Annotations store={store} variant={VARIANT} />)
+  shallow(<Annotations store={store} variant={SV_VARIANT} />)
 })


### PR DESCRIPTION
Our analysts/curators were a little confused when the Seqr variant search results did not return the Canonical nor MANE transcripts.  We subsequently added logic to highlight this in the UI.  We've had a fair bit of discussion around this and @drtconway in our group could can provide better context and why it's useful.  I initially thought of raising a discussion first but I think a PR is easier, just reject it if your group doesn't find it useful.

<img width="658" alt="ScreenShot 2024-02-06 at 4 18 51 pm" src="https://github.com/broadinstitute/seqr/assets/117335/cab152d0-8b2b-4726-bdab-f080ec38e665">

<img width="1134" alt="ScreenShot 2024-02-06 at 4 19 16 pm" src="https://github.com/broadinstitute/seqr/assets/117335/6893dcae-cb33-4104-9df2-6c085f3f2c58">
