### PR TITLE
Recessive search split tables

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -311,7 +311,6 @@ class BaseHailTableQuery(object):
                     )
                 num_families += num_project_families
 
-        #  TODO add pre-processing for annotations so do not even read in tables if not going to have vaild annotations
         if comp_het_families_ht is not None:
             comp_het_ht = self._query_table_annotations(comp_het_families_ht, self._get_table_path('annotations.ht'))
             self._comp_het_ht = self._filter_annotated_table(comp_het_ht, is_comp_het=True, **kwargs)
@@ -576,7 +575,6 @@ class BaseHailTableQuery(object):
         return True
 
     def _filter_by_frequency(self, ht, frequencies, pathogenicity):
-        # TODO do not filter if af == 1
         frequencies = {k: v for k, v in (frequencies or {}).items() if k in self.POPULATIONS}
         if not frequencies:
             return ht
@@ -652,10 +650,6 @@ class BaseHailTableQuery(object):
         annotations = annotations or {}
         annotation_override_filters = self._get_annotation_override_filters(ht, annotations, pathogenicity=pathogenicity)
 
-        # TODO confirm primary and secondary annotations are actually different before annotating etc -
-        #  ignore empty arrays and data-type specific fields from other data types and different sorts
-        #  Run _get_allowed_consequence_ids on both before loading to determine if different
-        #  also check diff overrides somehow
         annotation_exprs, _ = self._get_allowed_consequences_annotations(ht, annotations, annotation_override_filters)
         if is_comp_het or (self._has_comp_het_search and not annotation_exprs):
             secondary_exprs, allowed_secondary_consequences = self._get_allowed_consequences_annotations(
@@ -709,7 +703,6 @@ class BaseHailTableQuery(object):
 
     @staticmethod
     def _get_annotation_filters(ht, is_secondary=False):
-        # TODO not needed for anything except comp het search, just directly filter for everything else
         suffix = '_secondary' if is_secondary else ''
         annotation_filters = []
 

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -432,10 +432,13 @@ class BaseHailTableQuery(object):
                 ht, COMPOUND_HET, inheritance_filter, sorted_family_sample_data,
             )
 
-        if (inheritance_filter or inheritance_mode) and not is_any_affected:
-            ht = None if inheritance_mode == COMPOUND_HET else self._filter_families_inheritance(
-                ht, inheritance_mode, inheritance_filter, sorted_family_sample_data,
-            )
+        if is_any_affected or not (inheritance_filter and inheritance_mode):
+            # No sample-specific inheritance filtering needed
+            sorted_family_sample_data = []
+
+        ht = None if inheritance_mode == COMPOUND_HET else self._filter_families_inheritance(
+            ht, inheritance_mode, inheritance_filter, sorted_family_sample_data,
+        )
 
         return ht, comp_het_ht
 
@@ -650,7 +653,9 @@ class BaseHailTableQuery(object):
         annotation_override_filters = self._get_annotation_override_filters(ht, annotations, pathogenicity=pathogenicity)
 
         # TODO confirm primary and secondary annotations are actually different before annotating etc -
-        #  ignore empty arrays and data-type specific fields
+        #  ignore empty arrays and data-type specific fields from other data types and different sorts
+        # Run _get_allowed_consequence_ids on both before loading to determine if different
+        # also check diff overrides somehow
         annotation_exprs, _ = self._get_allowed_consequences_annotations(ht, annotations, annotation_override_filters)
         if is_comp_het or (self._has_comp_het_search and not annotation_exprs):
             secondary_exprs, allowed_secondary_consequences = self._get_allowed_consequences_annotations(

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -213,10 +213,6 @@ class BaseHailTableQuery(object):
             self._load_filtered_table(sample_data, inheritance_mode=inheritance_mode, **kwargs)
 
     @property
-    def _is_recessive_search(self):
-        return self._inheritance_mode == RECESSIVE
-
-    @property
     def _has_comp_het_search(self):
         return self._inheritance_mode in {RECESSIVE, COMPOUND_HET}
 
@@ -306,9 +302,9 @@ class BaseHailTableQuery(object):
             entry_type = main_ht.family_entries.dtype.element_type
             for project_ht, comp_het_project_ht, num_project_families in filtered_project_hts[1:]:
                 if families_ht is not None:
-                    families_ht = _add_project_ht(self, families_ht, project_ht, entry_type)
+                    families_ht = self._add_project_ht(self, families_ht, project_ht, entry_type)
                 if comp_het_families_ht is not None:
-                    comp_het_families_ht = _add_project_ht(self, comp_het_families_ht, comp_het_project_ht, entry_type)
+                    comp_het_families_ht = self._add_project_ht(self, comp_het_families_ht, comp_het_project_ht, entry_type)
                 num_families += num_project_families
 
         #  TODO add pre-processing for annotations so do not even read in tables if not going to have vaild annotations
@@ -718,7 +714,7 @@ class BaseHailTableQuery(object):
         ch_ht = self._comp_het_ht
 
         # Get possible pairs of variants within the same gene
-        ch_ht = ch_ht.annotate(gene_ids=self._gene_ids_expr(ch_ht, comp_het=True))
+        ch_ht = ch_ht.annotate(gene_ids=self._gene_ids_expr(ch_ht))
         ch_ht = ch_ht.explode(ch_ht.gene_ids)
 
         # Filter allowed transcripts to the grouped gene
@@ -822,7 +818,7 @@ class BaseHailTableQuery(object):
         )
 
     @classmethod
-    def _gene_ids_expr(cls, ht, comp_het=False):
+    def _gene_ids_expr(cls, ht):
         return hl.set(ht[cls.TRANSCRIPTS_FIELD].map(lambda t: t.gene_id))
 
     def _is_valid_comp_het_family(self, ch_ht, entries_1, entries_2):

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -432,7 +432,7 @@ class BaseHailTableQuery(object):
                 ht, COMPOUND_HET, inheritance_filter, sorted_family_sample_data,
             )
 
-        if is_any_affected or not (inheritance_filter and inheritance_mode):
+        if is_any_affected or not (inheritance_filter or inheritance_mode):
             # No sample-specific inheritance filtering needed
             sorted_family_sample_data = []
 
@@ -654,8 +654,8 @@ class BaseHailTableQuery(object):
 
         # TODO confirm primary and secondary annotations are actually different before annotating etc -
         #  ignore empty arrays and data-type specific fields from other data types and different sorts
-        # Run _get_allowed_consequence_ids on both before loading to determine if different
-        # also check diff overrides somehow
+        #  Run _get_allowed_consequence_ids on both before loading to determine if different
+        #  also check diff overrides somehow
         annotation_exprs, _ = self._get_allowed_consequences_annotations(ht, annotations, annotation_override_filters)
         if is_comp_het or (self._has_comp_het_search and not annotation_exprs):
             secondary_exprs, allowed_secondary_consequences = self._get_allowed_consequences_annotations(

--- a/hail_search/queries/gcnv.py
+++ b/hail_search/queries/gcnv.py
@@ -62,10 +62,10 @@ class GcnvHailTableQuery(SvHailTableQuery):
     POPULATIONS = {k: v for k, v in SvHailTableQuery.POPULATIONS.items() if k != 'gnomad_svs'}
 
     @classmethod
-    def _get_genotype_override_field(cls, r, field, family_entries_field=None):
+    def _get_genotype_override_field(cls, r, field):
         agg, get_default = cls.GENOTYPE_OVERRIDE_FIELDS[field]
         sample_field = f'sample_{field}'
-        entries = r[family_entries_field or 'family_entries'].flatmap(lambda x: x)
+        entries = r.family_entries.flatmap(lambda x: x)
         return hl.if_else(
             entries.any(lambda g: hl.is_defined(g.GT) & hl.is_missing(g[sample_field])),
             get_default(r), agg(entries.map(lambda g: g[sample_field]))
@@ -85,10 +85,9 @@ class GcnvHailTableQuery(SvHailTableQuery):
         ])
 
     @classmethod
-    def _gene_ids_expr(cls, ht, comp_het=False):
-        family_entries_field = 'comp_het_family_entries' if comp_het else None
+    def _gene_ids_expr(cls, ht):
         return hl.or_else(
-            cls._get_genotype_override_field(ht, 'gene_ids', family_entries_field=family_entries_field),
+            cls._get_genotype_override_field(ht, 'gene_ids'),
             super()._gene_ids_expr(ht),
         )
 

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -219,19 +219,19 @@ class MitoHailTableQuery(BaseHailTableQuery):
              if canonical_consequences else allowed_consequence_ids
         ).contains)
 
-    def _get_annotation_override_filters(self, annotations, pathogenicity=None, **kwargs):
+    def _get_annotation_override_filters(self, ht, annotations, pathogenicity=None, **kwargs):
         annotation_filters = []
 
         for key in self.PATHOGENICITY_FILTERS.keys():
             path_terms = (pathogenicity or {}).get(key)
             if path_terms:
-                annotation_filters.append(self._has_path_expr(path_terms, key))
+                annotation_filters.append(self._has_path_expr(ht,path_terms, key))
 
         return annotation_filters
 
-    def _frequency_override_filter(self, pathogenicity):
+    def _frequency_override_filter(self, ht, pathogenicity):
         path_terms = self._get_clinvar_path_filters(pathogenicity)
-        return self._has_path_expr(path_terms, CLINVAR_KEY) if path_terms else None
+        return self._has_path_expr(ht, path_terms, CLINVAR_KEY) if path_terms else None
 
     @staticmethod
     def _get_clinvar_path_filters(pathogenicity):
@@ -239,7 +239,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
             f for f in (pathogenicity or {}).get(CLINVAR_KEY) or [] if f in CLINVAR_PATH_SIGNIFICANCES
         }
 
-    def _has_path_expr(self, terms, field):
+    def _has_path_expr(self, ht, terms, field):
         subfield, range_configs = self.PATHOGENICITY_FILTERS[field]
         field_name = self.PATHOGENICITY_FIELD_MAP.get(field, field)
         enum_lookup = self._get_enum_lookup(field_name, subfield)
@@ -254,7 +254,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
                 ranges.append([None, None])
 
         ranges = [r for r in ranges if r[0] is not None]
-        value = self._ht[field_name][f'{subfield}_id']
+        value = ht[field_name][f'{subfield}_id']
         return hl.any(lambda r: (value >= r[0]) & (value <= r[1]), ranges)
 
     def _format_results(self, ht, *args, **kwargs):

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -71,7 +71,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
     @staticmethod
     def _family_filtered_ch_ht(ht, overlapped_families, families, key):
         family_indices = hl.array([families.index(family_guid) for family_guid in overlapped_families])
-        ht = ht.annotate(comp_het_family_entries=family_indices.map(lambda i: ht.comp_het_family_entries[i]))
+        ht = ht.annotate(family_entries=family_indices.map(lambda i: ht.family_entries[i]))
         return ht.group_by('gene_ids').aggregate(**{key: hl.agg.collect(ht.row)})
 
     def _is_valid_comp_het_family(self, ch_ht, entries_1, entries_2):
@@ -93,6 +93,9 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
 
     def format_search_ht(self):
         hts = []
+        import logging
+        import time
+        logger = logging.getLogger(__name__)
         for data_type, query in self._data_type_queries.items():
             dt_ht = query.format_search_ht()
             if dt_ht is None:
@@ -101,6 +104,28 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
             if merged_sort_expr is not None:
                 dt_ht = dt_ht.annotate(_sort=merged_sort_expr)
             hts.append(dt_ht.select('_sort', **{data_type: dt_ht.row}))
+            # start = time.perf_counter()
+            # logger.info(f'{data_type}: {dt_ht.count()} ({time.perf_counter() - start:0.4f}s)')
+            """
+            Hom-recessive only:
+            SV_WGS: 0 (5.9890s)
+            MITO: 0 (2.4309s)
+            SNV_INDEL: 3 (16.8396s)
+
+            All recessive (with comp het)
+            SV_WGS: 0 (14.6799s)
+            MITO: 0 (8.7807s)
+            SNV_INDEL: 11 (170.8936s)
+            comp het SV_WGS: 0 (86.7876s)
+            Actual total: ~304s
+            
+            With updates:
+            SV_WGS: 0 (20.0788s)
+            MITO: 0 (9.6441s)
+            SNV_INDEL: 11 (106.1276s)
+            SV_WGS: 0 (82.6384s)
+            Actual total: ~217s
+            """
 
         for data_type, ch_ht in self._comp_het_hts.items():
             ch_ht = ch_ht.annotate(
@@ -111,6 +136,8 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
                 _sort=hl.sorted([ch_ht.v1._sort, ch_ht.v2._sort])[0],
                 **{f'comp_het_{data_type}': ch_ht.row},
             ))
+            # start = time.perf_counter()
+            # logger.info(f'comp het {data_type}: {ch_ht.count()} ({time.perf_counter() - start:0.4f}s)')
 
         ht = hts[0]
         for sub_ht in hts[1:]:

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -101,6 +101,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
             if merged_sort_expr is not None:
                 dt_ht = dt_ht.annotate(_sort=merged_sort_expr)
             hts.append(dt_ht.select('_sort', **{data_type: dt_ht.row}))
+
         for data_type, ch_ht in self._comp_het_hts.items():
             ch_ht = ch_ht.annotate(
                 v1=self._format_comp_het_result(ch_ht.v1, SNV_INDEL_DATA_TYPE),

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -70,6 +70,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
 
     @staticmethod
     def _family_filtered_ch_ht(ht, overlapped_families, families, key):
+        # TODO only remap families if different
         family_indices = hl.array([families.index(family_guid) for family_guid in overlapped_families])
         ht = ht.annotate(family_entries=family_indices.map(lambda i: ht.family_entries[i]))
         return ht.group_by('gene_ids').aggregate(**{key: hl.agg.collect(ht.row)})
@@ -125,6 +126,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
             SNV_INDEL: 11 (106.1276s)
             SV_WGS: 0 (82.6384s)
             Actual total: ~217s
+            (actual-actual: 244.699374)
             """
 
         for data_type, ch_ht in self._comp_het_hts.items():

--- a/hail_search/queries/snv_indel.py
+++ b/hail_search/queries/snv_indel.py
@@ -93,14 +93,14 @@ class SnvIndelHailTableQuery(MitoHailTableQuery):
 
         return 'is_gt_10_percent' if af_cutoff > PREFILTER_FREQ_CUTOFF else True
 
-    def _get_annotation_override_filters(self, annotations, *args, **kwargs):
-        annotation_filters = super()._get_annotation_override_filters(annotations, *args, **kwargs)
+    def _get_annotation_override_filters(self, ht, annotations, *args, **kwargs):
+        annotation_filters = super()._get_annotation_override_filters(ht, annotations, *args, **kwargs)
 
         if annotations.get(SCREEN_KEY):
             allowed_consequences = hl.set(self._get_enum_terms_ids(SCREEN_KEY.lower(), 'region_type', annotations[SCREEN_KEY]))
-            annotation_filters.append(allowed_consequences.contains(self._ht.screen.region_type_ids.first()))
+            annotation_filters.append(allowed_consequences.contains(ht.screen.region_type_ids.first()))
         if annotations.get(SPLICE_AI_FIELD):
-            score_filter, _ = self._get_in_silico_filter(SPLICE_AI_FIELD, annotations[SPLICE_AI_FIELD])
+            score_filter, _ = self._get_in_silico_filter(ht, SPLICE_AI_FIELD, annotations[SPLICE_AI_FIELD])
             annotation_filters.append(score_filter)
 
         return annotation_filters

--- a/hail_search/queries/snv_indel_37.py
+++ b/hail_search/queries/snv_indel_37.py
@@ -11,6 +11,6 @@ class SnvIndelHailTableQuery37(SnvIndelHailTableQuery):
     def _should_add_chr_prefix(self):
         return False
 
-    def _get_annotation_override_filters(self, annotations, *args, **kwargs):
+    def _get_annotation_override_filters(self, ht, annotations, *args, **kwargs):
         annotations = {k: v for k, v in annotations.items() if k != SCREEN_KEY}
-        return super()._get_annotation_override_filters(annotations, *args, **kwargs)
+        return super()._get_annotation_override_filters(ht, annotations, *args, **kwargs)

--- a/hail_search/web_app.py
+++ b/hail_search/web_app.py
@@ -65,7 +65,7 @@ async def init_web_app():
         spark_conf['spark.driver.memory'] = f'{int((int(MACHINE_MEM)-11)*JVM_MEMORY_FRACTION)}g'
     if JAVA_OPTS_XSS:
         spark_conf.update({f'spark.{field}.extraJavaOptions': f'-Xss{JAVA_OPTS_XSS}' for field in ['driver', 'executor']})
-    hl.init(idempotent=True, spark_conf=spark_conf or None, backend='local')
+    hl.init(idempotent=True, spark_conf=spark_conf or None)
     load_globals()
     app = web.Application(middlewares=[error_middleware], client_max_size=(1024**2)*10)
     app.add_routes([

--- a/hail_search/web_app.py
+++ b/hail_search/web_app.py
@@ -65,7 +65,7 @@ async def init_web_app():
         spark_conf['spark.driver.memory'] = f'{int((int(MACHINE_MEM)-11)*JVM_MEMORY_FRACTION)}g'
     if JAVA_OPTS_XSS:
         spark_conf.update({f'spark.{field}.extraJavaOptions': f'-Xss{JAVA_OPTS_XSS}' for field in ['driver', 'executor']})
-    hl.init(idempotent=True, spark_conf=spark_conf or None)
+    hl.init(idempotent=True, spark_conf=spark_conf or None, backend='local')
     load_globals()
     app = web.Application(middlewares=[error_middleware], client_max_size=(1024**2)*10)
     app.add_routes([


### PR DESCRIPTION
This changes the control flow for recessive searches. In the search included in the linked ticket, this reduced the search time by over 60seconds on my local machine, from > 300 seconds that could not even complete on production to 245 seconds which can

Previously, we read in the entries table(s), filtered them to variants that were valid for either hom recessive or comp het, annotated and filtered them, and then at the end ran a filter for hom recessive only and a filter for comp het only to separate it out. What this instead does is that the entry table is initally filtered into 2 different tables, one for hom recessive and one for comp het, and then each table is independently annotated and filtered for the duration of the search.

 Originally I did not go this route because it involved calling `query_table` on the annotations table twice which intuitively seems slower. However, since `query_table` runs roughly linearly to the number of variants to query regardless of how many distinct calls its broken into, and because within a single family possible SNV_INDELs can only match one of the 2 modes of inheritance but not both, that means that the subsetted tables are non-overlapping so the `query_table` time stays essentially the same and then all the additional annotating to maintain the 2 possible inheritance modes and all the filtering at the end to seperate the tables back out is fully removed, saving a bunch of time.

Note that this does slightly slow down SV only comp het search, as the inheritance for those means a variant can both be hom recessive and comp het so we do double query some variants, but SV only search was always much faster to begin with (when testing this change the SV-only part of the search went from 15 to 20 seconds, while the SNV__INDEL portion went from 170 to 105. The SV slow down seems very reasonable in that context). Also, its possible that in a multi-family comp het search it could result in double querying some variants that are recessive in some families and comp het in others. However, multi family comp het search is required to be gene-restircted so its already much faster, and these single family searches are substantially more common than thse, so the treade off feels worth it