### PR TITLE
No phasing comp het

### DIFF
--- a/hail_search/constants.py
+++ b/hail_search/constants.py
@@ -19,7 +19,6 @@ CLINVAR_KEY = 'clinvar'
 CLINVAR_MITO_KEY = 'clinvar_mito'
 HGMD_KEY = 'hgmd'
 STRUCTURAL_ANNOTATION_FIELD = 'structural'
-STRUCTURAL_CONSEQUENCE_FIELD = 'structural_consequence'
 FAMILY_GUID_FIELD = 'familyGuids'
 GENOTYPES_FIELD = 'genotypes'
 

--- a/hail_search/constants.py
+++ b/hail_search/constants.py
@@ -19,6 +19,7 @@ CLINVAR_KEY = 'clinvar'
 CLINVAR_MITO_KEY = 'clinvar_mito'
 HGMD_KEY = 'hgmd'
 STRUCTURAL_ANNOTATION_FIELD = 'structural'
+STRUCTURAL_CONSEQUENCE_FIELD = 'structural_consequence'
 FAMILY_GUID_FIELD = 'familyGuids'
 GENOTYPES_FIELD = 'genotypes'
 

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -207,6 +207,8 @@ class BaseHailTableQuery(object):
         self._override_comp_het_alt = override_comp_het_alt
         self._ht = None
         self._comp_het_ht = None
+        self._comp_het_override_ht = None
+        self.unfiltered_override_ht = None
         self._inheritance_mode = inheritance_mode
         self._has_secondary_annotations = False
         self._is_multi_data_type_comp_het = False
@@ -317,13 +319,21 @@ class BaseHailTableQuery(object):
                 num_families += num_project_families
 
         if comp_het_families_ht is not None:
+            logger.info(f'comp het count: {comp_het_families_ht.count()}')
             comp_het_ht = self._query_table_annotations(comp_het_families_ht, self._get_table_path('annotations.ht'))
-            self._comp_het_ht = self._filter_annotated_table(comp_het_ht, is_comp_het=True, **kwargs)
-            self._comp_het_ht = self._filter_compound_hets()
+            comp_het_ht = self._filter_annotated_table(comp_het_ht, is_comp_het=True, **kwargs)
+            self._comp_het_ht = self._filter_compound_hets(
+                comp_het_ht, is_multi_data_type_comp_het=self._is_multi_data_type_comp_het,
+            )
 
         if families_ht is not None:
+            logger.info(f'recessive count: {families_ht.count()}')
             ht = self._query_table_annotations(families_ht, self._get_table_path('annotations.ht'))
             self._ht = self._filter_annotated_table(ht, **kwargs)
+            if self._comp_het_override_ht is not None:
+                self._filter_compound_hets(
+                    self._comp_het_override_ht, unfiltered_ht_name='unfiltered_override_ht', is_multi_data_type_comp_het=True,
+                )
 
     def _add_project_ht(self, families_ht, project_ht, default, default_1=None):
         if default_1 is None:
@@ -439,8 +449,12 @@ class BaseHailTableQuery(object):
             # No sample-specific inheritance filtering needed
             sorted_family_sample_data = []
 
-        ht = None if self._inheritance_mode == COMPOUND_HET else self._filter_families_inheritance(
-            ht, self._inheritance_mode, inheritance_filter, sorted_family_sample_data,
+        inheritance_mode = self._inheritance_mode
+        if self._override_comp_het_alt and self._inheritance_mode == COMPOUND_HET:
+            inheritance_mode = RECESSIVE
+
+        ht = None if inheritance_mode == COMPOUND_HET else self._filter_families_inheritance(
+            ht, inheritance_mode, inheritance_filter, sorted_family_sample_data,
         )
 
         return ht, comp_het_ht
@@ -455,8 +469,6 @@ class BaseHailTableQuery(object):
                     if individual_genotype_filter else INHERITANCE_FILTERS[inheritance_mode].get(s['affected_id'])
                 if inheritance_mode == X_LINKED_RECESSIVE and s['affected_id'] == UNAFFECTED_ID and s['is_male']:
                     genotype = REF_REF
-                if genotype == COMP_HET_ALT and self._override_comp_het_alt:
-                    genotype = HAS_ALT
                 if genotype:
                     entry_indices_by_gt[genotype][family_index].append(sample_index)
 
@@ -706,40 +718,54 @@ class BaseHailTableQuery(object):
     def _filter_by_annotations(self, ht, is_comp_het, consequence_ids=None, annotation_overrides=None,
                                secondary_consequence_ids=None, secondary_annotation_overrides=None, **kwargs):
 
+        annotation_filters = self._get_annotation_override_filters(ht, annotation_overrides)
+        annotation_exprs = self._get_annotation_filter_expressions(ht, consequence_ids, annotation_filters or None)
+
+        secondary_annotation_filters = None if secondary_annotation_overrides is None else \
+            self._get_annotation_override_filters(ht, secondary_annotation_overrides)
+        secondary_annotation_exprs = self._get_annotation_filter_expressions(
+            ht, secondary_consequence_ids, secondary_annotation_filters, suffix='_secondary',
+        )
+
+        if is_comp_het:
+            annotation_exprs.update(secondary_annotation_exprs)
+            return self._filter_computed_annotations(ht, annotation_exprs)
+
+        use_primary_override_ht = False
+        if self._override_comp_het_alt:
+            primary_override, secondary_override = self._override_comp_het_alt
+            if secondary_override:
+                # Cannot just use the recessive table, as need to include secondary annotations
+                override_exprs = {**annotation_exprs, **secondary_annotation_exprs} if primary_override else {
+                    k.replace('_secondary', ''): v for k, v in secondary_annotation_exprs.items()
+                }
+                if override_exprs:
+                    self._comp_het_override_ht = self._filter_computed_annotations(ht, override_exprs)
+            else:
+                use_primary_override_ht = True
+
+        ht = self._filter_computed_annotations(ht, annotation_exprs)
+        if use_primary_override_ht and annotation_exprs:
+            self._comp_het_override_ht = ht
+        if self._inheritance_mode == COMPOUND_HET:
+            # If not a full recessive search, skip recessive only results
+            return None
+        return ht
+
+    def _get_annotation_filter_expressions(self, ht, consequence_ids, annotation_overrides, suffix=''):
         annotation_exprs = {}
+        if annotation_overrides is not None:
+            annotation_exprs[f'{HAS_ANNOTATION_OVERRIDE}{suffix}'] = hl.any(annotation_overrides) if annotation_overrides else False
         if consequence_ids:
-            annotation_exprs[ALLOWED_TRANSCRIPTS] = self._get_allowed_transcripts(ht, consequence_ids)
-            ht = ht.annotate(**annotation_exprs)
-        annotation_filters = self._get_annotation_override_filters(ht, annotation_overrides or {})
+            annotation_exprs[f'{ALLOWED_TRANSCRIPTS}{suffix}'] = self._get_allowed_transcripts(ht, consequence_ids)
+        return annotation_exprs
 
-        if not is_comp_het:
-            if annotation_exprs:
-                annotation_filters.append(self._has_allowed_transcript_filter(ht, ALLOWED_TRANSCRIPTS))
-            if annotation_filters:
-                ht = ht.filter(hl.any(annotation_filters))
-            return ht
-
-        if annotation_filters:
-            annotation_exprs[HAS_ANNOTATION_OVERRIDE] = hl.any(annotation_filters)
-        if secondary_annotation_overrides is not None:
-            annotation_exprs[f'{HAS_ANNOTATION_OVERRIDE}_secondary'] = hl.any(
-                self._get_annotation_override_filters(ht, secondary_annotation_overrides)
-            ) if secondary_annotation_overrides else False
-        secondary_allowed_transcripts_field = f'{ALLOWED_TRANSCRIPTS}_secondary'
-        if secondary_consequence_ids:
-            annotation_exprs[secondary_allowed_transcripts_field] = self._get_allowed_transcripts(ht, secondary_consequence_ids)
-
-        filter_fields = list(annotation_exprs.keys())
-        transcript_filter_fields = [ALLOWED_TRANSCRIPTS, secondary_allowed_transcripts_field]
-        annotation_exprs.pop(ALLOWED_TRANSCRIPTS, None)
+    def _filter_computed_annotations(self, ht, annotation_exprs):
         if annotation_exprs:
             ht = ht.annotate(**annotation_exprs)
 
-        all_filters = [
-            self._has_allowed_transcript_filter(ht, field) if field in transcript_filter_fields else ht[field]
-            for field in filter_fields
-        ]
-        return ht.filter(hl.any(all_filters))
+        all_filters = self._get_annotation_filters(ht) + self._get_annotation_filters(ht, is_secondary=True)
+        return ht.filter(hl.any(all_filters)) if all_filters else ht
 
     def _get_allowed_consequence_ids(self, annotations):
         allowed_consequences = {
@@ -785,10 +811,7 @@ class BaseHailTableQuery(object):
     def _has_allowed_transcript_filter(ht, allowed_transcript_field):
         return hl.is_defined(ht[allowed_transcript_field].first())
 
-    def _filter_compound_hets(self):
-        # pylint: disable=pointless-string-statement
-        ch_ht = self._comp_het_ht
-
+    def _filter_compound_hets(self, ch_ht, unfiltered_ht_name='unfiltered_comp_het_ht', is_multi_data_type_comp_het=False):
         # Get possible pairs of variants within the same gene
         ch_ht = ch_ht.annotate(gene_ids=self._gene_ids_expr(ch_ht))
         ch_ht = ch_ht.explode(ch_ht.gene_ids)
@@ -801,14 +824,14 @@ class BaseHailTableQuery(object):
         if transcript_annotations:
             ch_ht = ch_ht.annotate(**transcript_annotations)
 
+        unfiltered_ht = ch_ht
         if transcript_annotations or self._has_secondary_annotations:
             primary_filters = self._get_annotation_filters(ch_ht)
             secondary_filters = self._get_annotation_filters(ch_ht, is_secondary=True) if self._has_secondary_annotations else []
-            self.unfiltered_comp_het_ht = ch_ht.filter(hl.any(primary_filters + secondary_filters))
-        else:
-            self.unfiltered_comp_het_ht = ch_ht
+            unfiltered_ht = ch_ht.filter(hl.any(primary_filters + secondary_filters))
+        setattr(self, unfiltered_ht_name, unfiltered_ht)
 
-        if self._is_multi_data_type_comp_het:
+        if is_multi_data_type_comp_het:
             # In cases where comp het pairs must have different data types, there are no single data type results
             return None
 
@@ -910,8 +933,6 @@ class BaseHailTableQuery(object):
             family_filters.append(hl.enumerate(entries_1).all(lambda x: hl.any([
                 (x[1].affected_id != UNAFFECTED_ID), *self._comp_het_entry_has_ref(x[1].GT, entries_2[x[0]].GT),
             ])))
-        if self._override_comp_het_alt:
-            family_filters.append(entries_1.extend(entries_2).all(lambda x: ~self.GENOTYPE_QUERY_MAP[ALT_ALT](x.GT)))
         return hl.all(family_filters)
 
     def _comp_het_entry_has_ref(self, gt1, gt2):

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -210,6 +210,7 @@ class BaseHailTableQuery(object):
         self._inheritance_mode = inheritance_mode
         self._has_secondary_annotations = False
         self._is_multi_data_type_comp_het = False
+        self.max_unaffected_samples = None
         self._load_table_kwargs = {}
 
         if sample_data:
@@ -464,10 +465,13 @@ class BaseHailTableQuery(object):
             family_unaffected_counts = [
                 len(i) for i in entry_indices_by_gt[INHERITANCE_FILTERS[COMPOUND_HET][UNAFFECTED_ID]].values()
             ]
-            if any(count > 1 for count in family_unaffected_counts):
+            self.max_unaffected_samples = max(family_unaffected_counts) if family_unaffected_counts else 0
+            if self.max_unaffected_samples > 1:
                 min_unaffected = min(family_unaffected_counts)
 
         for genotype, entry_indices in entry_indices_by_gt.items():
+            if not entry_indices:
+                continue
             entry_indices = hl.dict(entry_indices)
             ht = ht.annotate(family_entries=hl.enumerate(ht.family_entries).map(
                 lambda x: self._valid_genotype_family_entries(x[1], entry_indices.get(x[0]), genotype, min_unaffected)
@@ -901,12 +905,14 @@ class BaseHailTableQuery(object):
         return hl.set(ht[cls.TRANSCRIPTS_FIELD].map(lambda t: t.gene_id))
 
     def _is_valid_comp_het_family(self, ch_ht, entries_1, entries_2):
-        is_valid = hl.is_defined(entries_1) & hl.is_defined(entries_2) & hl.enumerate(entries_1).all(lambda x: hl.any([
-            (x[1].affected_id != UNAFFECTED_ID), *self._comp_het_entry_has_ref(x[1].GT, entries_2[x[0]].GT),
-        ]))
+        family_filters = [hl.is_defined(entries_1), hl.is_defined(entries_2)]
+        if self.max_unaffected_samples > 0:
+            family_filters.append(hl.enumerate(entries_1).all(lambda x: hl.any([
+                (x[1].affected_id != UNAFFECTED_ID), *self._comp_het_entry_has_ref(x[1].GT, entries_2[x[0]].GT),
+            ])))
         if self._override_comp_het_alt:
-            is_valid &= entries_1.extend(entries_2).all(lambda x: ~self.GENOTYPE_QUERY_MAP[ALT_ALT](x.GT))
-        return is_valid
+            family_filters.append(entries_1.extend(entries_2).all(lambda x: ~self.GENOTYPE_QUERY_MAP[ALT_ALT](x.GT)))
+        return hl.all(family_filters)
 
     def _comp_het_entry_has_ref(self, gt1, gt2):
         return [self.GENOTYPE_QUERY_MAP[REF_REF](gt1), self.GENOTYPE_QUERY_MAP[REF_REF](gt2)]

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -1,8 +1,7 @@
 import hail as hl
 import os
 
-from hail_search.constants import ALT_ALT, REF_REF, CONSEQUENCE_SORT, OMIM_SORT, GROUPED_VARIANTS_FIELD, GENOME_VERSION_GRCh38, \
-    STRUCTURAL_ANNOTATION_FIELD, STRUCTURAL_CONSEQUENCE_FIELD, NEW_SV_FIELD
+from hail_search.constants import ALT_ALT, REF_REF, CONSEQUENCE_SORT, OMIM_SORT, GROUPED_VARIANTS_FIELD, GENOME_VERSION_GRCh38
 from hail_search.queries.base import BaseHailTableQuery
 from hail_search.queries.mito import MitoHailTableQuery
 from hail_search.queries.snv_indel import SnvIndelHailTableQuery
@@ -18,74 +17,44 @@ if ONT_ENABLED:
     QUERY_CLASSES.append(OntSnvIndelHailTableQuery)
 QUERY_CLASS_MAP = {(cls.DATA_TYPE, cls.GENOME_VERSION): cls for cls in QUERY_CLASSES}
 SNV_INDEL_DATA_TYPE = SnvIndelHailTableQuery.DATA_TYPE
-SV_DATA_TYPES = [SvHailTableQuery.DATA_TYPE, GcnvHailTableQuery.DATA_TYPE]
 
 
 class MultiDataTypeHailTableQuery(BaseHailTableQuery):
 
     def __init__(self, sample_data, *args, **kwargs):
         self._data_type_queries = {
-            k: QUERY_CLASS_MAP[(k, GENOME_VERSION_GRCh38)](v, *args, override_comp_het_alt=self._include_comp_het_override(k, sample_data, **kwargs), **kwargs)
+            k: QUERY_CLASS_MAP[(k, GENOME_VERSION_GRCh38)](v, *args, override_comp_het_alt=k == SNV_INDEL_DATA_TYPE, **kwargs)
             for k, v in sample_data.items()
         }
         self._comp_het_hts = {}
-        self._require_overlap = False
+        self._sv_type_del_id = None
         self._current_sv_data_type = None
         super().__init__(sample_data, *args, **kwargs)
-
-    def _include_comp_het_override(self, data_type, sample_data, annotations=None, annotations_secondary=None, **kwargs):
-        if data_type != SNV_INDEL_DATA_TYPE or all(dt not in sample_data for dt in SV_DATA_TYPES):
-            return None
-
-        # SNPs overlapped by trans deletions may be incorrectly called as hom alt, so we will also call comp hets on
-        # the "recessive" results if it is possible to have them in trans with deletions
-        primary_del = self._allows_deletions(annotations)
-        secondary_del = self._allows_deletions(annotations_secondary)
-        return (secondary_del, primary_del) if primary_del or secondary_del else None
-
-    def _allows_deletions(self, annotations):
-        if not annotations:
-            return False
-        has_del_annotation = any(
-            del_csq in annotations.get(STRUCTURAL_ANNOTATION_FIELD, [])
-            for del_csq in ['DEL', f'{GcnvHailTableQuery.SV_TYPE_PREFIX}DEL']
-        )
-        return has_del_annotation or any(annotations.get(field) for field in [STRUCTURAL_CONSEQUENCE_FIELD, NEW_SV_FIELD])
 
     def _load_filtered_table(self, *args, **kwargs):
         variant_query = self._data_type_queries.get(SNV_INDEL_DATA_TYPE)
         sv_data_types = [
-            data_type for data_type in SV_DATA_TYPES
+            data_type for data_type in [SvHailTableQuery.DATA_TYPE, GcnvHailTableQuery.DATA_TYPE]
             if data_type in self._data_type_queries
         ]
         if not (self._has_comp_het_search and variant_query is not None and sv_data_types):
             return
 
         variant_ht = variant_query.unfiltered_comp_het_ht
-        variant_override_ht = variant_query.unfiltered_override_ht
         variant_families = hl.eval(variant_ht.family_guids)
         for data_type in sv_data_types:
-            self._require_overlap = False
             self._current_sv_data_type = data_type
             sv_query = self._data_type_queries[data_type]
-            sv_ht = sv_query.unfiltered_comp_het_ht
             self.max_unaffected_samples = max(variant_query.max_unaffected_samples, sv_query.max_unaffected_samples)
-            merged_ht = self._filter_data_type_comp_hets(variant_ht, variant_families, sv_ht)
+            merged_ht = self._filter_data_type_comp_hets(variant_ht, variant_families, sv_query)
             if merged_ht is not None:
                 self._comp_het_hts[data_type] = merged_ht.key_by()
 
-            # SNPs overlapped by trans deletions may be incorrectly called as hom alt, and should be
-            # considered comp hets with said deletions
-            if variant_override_ht is not None:
-                self._require_overlap = True
-                sv_type_del_ids = sv_query.get_allowed_sv_type_ids([f'{getattr(sv_query, "SV_TYPE_PREFIX", "")}DEL'])
-                del_id = list(sv_type_del_ids)[0]
-                sv_ht = sv_ht.filter(sv_ht.sv_type_id == del_id)
-                merged_ht = self._filter_data_type_comp_hets(variant_ht, variant_families, sv_ht)
-                if merged_ht is not None:
-                    self._comp_het_hts[f'{data_type}_override'] = merged_ht.key_by()
+    def _filter_data_type_comp_hets(self, variant_ht, variant_families, sv_query):
+        sv_ht = sv_query.unfiltered_comp_het_ht
+        sv_type_del_ids = sv_query.get_allowed_sv_type_ids([f'{getattr(sv_query, "SV_TYPE_PREFIX", "")}DEL'])
+        self._sv_type_del_id = list(sv_type_del_ids)[0] if sv_type_del_ids else None
 
-    def _filter_data_type_comp_hets(self, variant_ht, variant_families, sv_ht):
         sv_families = hl.eval(sv_ht.family_guids)
         overlapped_families = list(set(variant_families).intersection(sv_families))
         if not overlapped_families:
@@ -112,12 +81,14 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
     def _is_valid_comp_het_family(self, ch_ht, entries_1, entries_2):
         is_valid = super()._is_valid_comp_het_family(ch_ht, entries_1, entries_2)
 
-        if self._require_overlap:
-            is_valid &= hl.all([
-                ch_ht.v2.start_locus.position <= ch_ht.v1.locus.position,
-                ch_ht.v1.locus.position <= ch_ht.v2.end_locus.position,
-            ])
-        return is_valid
+        # SNPs overlapped by trans deletions may be incorrectly called as hom alt, and should be
+        # considered comp hets with said deletions. Any other hom alt variants are not valid comp hets
+        is_allowed_hom_alt = entries_1.all(lambda g: ~self.GENOTYPE_QUERY_MAP[ALT_ALT](g.GT)) | hl.all([
+            ch_ht.v2.sv_type_id == self._sv_type_del_id,
+            ch_ht.v2.start_locus.position <= ch_ht.v1.locus.position,
+            ch_ht.v1.locus.position <= ch_ht.v2.end_locus.position,
+        ])
+        return is_valid & is_allowed_hom_alt
 
     def _comp_het_entry_has_ref(self, gt1, gt2):
         variant_query = self._data_type_queries[SNV_INDEL_DATA_TYPE]
@@ -126,9 +97,6 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
 
     def format_search_ht(self):
         hts = []
-        import logging
-        import time
-        logger = logging.getLogger(__name__)
         for data_type, query in self._data_type_queries.items():
             dt_ht = query.format_search_ht()
             if dt_ht is None:
@@ -137,27 +105,16 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
             if merged_sort_expr is not None:
                 dt_ht = dt_ht.annotate(_sort=merged_sort_expr)
             hts.append(dt_ht.select('_sort', **{data_type: dt_ht.row}))
-            start = time.perf_counter()
-            logger.info(f'{data_type}: {dt_ht.count()} ({time.perf_counter() - start:0.4f}s)')
-            """
-            SV_WGS: 2 (15.3892s)
-            SNV_INDEL: 36 (178.4971s)
-            comp het SV_WGS: 2 (160.9323s)
-            """
 
         for data_type, ch_ht in self._comp_het_hts.items():
             ch_ht = ch_ht.annotate(
                 v1=self._format_comp_het_result(ch_ht.v1, SNV_INDEL_DATA_TYPE),
-                v2=self._format_comp_het_result(ch_ht.v2, data_type.replace('_override', '')),
+                v2=self._format_comp_het_result(ch_ht.v2, data_type),
             )
             hts.append(ch_ht.select(
                 _sort=hl.sorted([ch_ht.v1._sort, ch_ht.v2._sort])[0],
                 **{f'comp_het_{data_type}': ch_ht.row},
             ))
-            start = time.perf_counter()
-            logger.info(f'comp het {data_type}: {ch_ht.count()} ({time.perf_counter() - start:0.4f}s)')
-
-        raise Exception('WHYYYYY')
 
         ht = hts[0]
         for sub_ht in hts[1:]:

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -45,6 +45,7 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
         for data_type in sv_data_types:
             self._current_sv_data_type = data_type
             sv_query = self._data_type_queries[data_type]
+            self.max_unaffected_samples = max(variant_query.max_unaffected_samples, sv_query.max_unaffected_samples)
             merged_ht = self._filter_data_type_comp_hets(variant_ht, variant_families, sv_query)
             if merged_ht is not None:
                 self._comp_het_hts[data_type] = merged_ht.key_by()

--- a/hail_search/web_app.py
+++ b/hail_search/web_app.py
@@ -66,6 +66,7 @@ async def init_web_app():
     if JAVA_OPTS_XSS:
         spark_conf.update({f'spark.{field}.extraJavaOptions': f'-Xss{JAVA_OPTS_XSS}' for field in ['driver', 'executor']})
     hl.init(idempotent=True, spark_conf=spark_conf or None)
+    hl._set_flags(use_new_shuffle='1')
     load_globals()
     app = web.Application(middlewares=[error_middleware], client_max_size=(1024**2)*10)
     app.add_routes([

--- a/hail_search/web_app.py
+++ b/hail_search/web_app.py
@@ -66,7 +66,6 @@ async def init_web_app():
     if JAVA_OPTS_XSS:
         spark_conf.update({f'spark.{field}.extraJavaOptions': f'-Xss{JAVA_OPTS_XSS}' for field in ['driver', 'executor']})
     hl.init(idempotent=True, spark_conf=spark_conf or None)
-    hl._set_flags(use_new_shuffle='1')
     load_globals()
     app = web.Application(middlewares=[error_middleware], client_max_size=(1024**2)*10)
     app.add_routes([


### PR DESCRIPTION
This adds a few minor performance/control flow optimizations to avoid extra computations in proband only and duo families. However, the bulk of the performance savings come from setting the `use_new_shuffle` flag, which reduced the runtime of a problematic recessive search from 385 seconds to 230 seconds