### PR TITLE
Better data type restrictions for searches

### DIFF
--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -1395,7 +1395,7 @@ class EsUtilsTest(TestCase):
         get_variants_for_variant_ids(self.families, ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL'])
         self.assertExecutedSearch(
             filters=[{'terms': {'variantId': ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL']}}],
-            size=9, index=','.join([INDEX_NAME, MITO_WGS_INDEX_NAME, SV_INDEX_NAME]),
+            size=6, index=','.join([INDEX_NAME, SV_INDEX_NAME]),
         )
 
     @urllib3_responses.activate

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -177,6 +177,11 @@ def _parse_location_search(search):
             {field: gene[f'{field}{search["genome_version"].title()}'] for field in ['chrom', 'start', 'end']}
             for gene in genes.values()
         ]
+        chromosomes = {gene['chrom'] for gene in gene_coords}
+        if 'M' not in chromosomes:
+            search['sample_data'].pop(Sample.DATASET_TYPE_MITO_CALLS, None)
+        elif chromosomes == {'M'} and Sample.DATASET_TYPE_MITO_CALLS in search['sample_data']:
+            search['sample_data'] = {Sample.DATASET_TYPE_MITO_CALLS: search['sample_data'][Sample.DATASET_TYPE_MITO_CALLS]}
         parsed_intervals = [_format_interval(**interval) for interval in intervals or []] + [
             '{chrom}:{start}-{end}'.format(**gene) for gene in gene_coords]
 

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -168,6 +168,7 @@ def _get_sort_metadata(sort, samples):
 def _parse_location_search(search):
     locus = search.pop('locus', None) or {}
     parsed_locus = search.pop('parsedLocus')
+    exclude_locations = locus.get('excludeLocations')
 
     genes = parsed_locus.get('genes') or {}
     intervals = parsed_locus.get('intervals')
@@ -177,15 +178,14 @@ def _parse_location_search(search):
             {field: gene[f'{field}{search["genome_version"].title()}'] for field in ['chrom', 'start', 'end']}
             for gene in genes.values()
         ]
-        chromosomes = {gene['chrom'] for gene in gene_coords}
-        if 'M' not in chromosomes:
-            search['sample_data'].pop(Sample.DATASET_TYPE_MITO_CALLS, None)
-        elif chromosomes == {'M'} and Sample.DATASET_TYPE_MITO_CALLS in search['sample_data']:
-            search['sample_data'] = {Sample.DATASET_TYPE_MITO_CALLS: search['sample_data'][Sample.DATASET_TYPE_MITO_CALLS]}
         parsed_intervals = [_format_interval(**interval) for interval in intervals or []] + [
             '{chrom}:{start}-{end}'.format(**gene) for gene in gene_coords]
-
-    exclude_locations = locus.get('excludeLocations')
+        if Sample.DATASET_TYPE_MITO_CALLS in search['sample_data'] and not exclude_locations:
+            chromosomes = {gene['chrom'] for gene in gene_coords + (intervals or [])}
+            if 'M' not in chromosomes:
+                search['sample_data'].pop(Sample.DATASET_TYPE_MITO_CALLS)
+            elif chromosomes == {'M'}:
+                search['sample_data'] = {Sample.DATASET_TYPE_MITO_CALLS: search['sample_data'][Sample.DATASET_TYPE_MITO_CALLS]}
 
     search.update({
         'intervals': parsed_intervals,

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -329,14 +329,15 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
     def test_get_variants_for_variant_ids(self):
         variant_ids = ['2-103343353-GAGA-G', '1-248367227-TC-T', 'prefix-938_DEL']
         get_variants_for_variant_ids(self.families, variant_ids, user=self.user)
-        # Follow up: should not query MITO variants
+        expected_sample_data = {k: ALL_AFFECTED_SAMPLE_DATA[k] for k in ['SNV_INDEL', 'SV_WES']}
         self._test_minimal_search_call(
             variant_ids=[['2', 103343353, 'GAGA', 'G'], ['1', 248367227, 'TC', 'T']],
             variant_keys=['prefix-938_DEL'],
-            num_results=3, sample_data={**ALL_AFFECTED_SAMPLE_DATA, **EXPECTED_MITO_SAMPLE_DATA})
+            num_results=3, sample_data=expected_sample_data)
 
+        del expected_sample_data['SV_WES']
         get_variants_for_variant_ids(self.families, variant_ids, user=self.user, dataset_type='SNV_INDEL')
         self._test_minimal_search_call(
             variant_ids=[['2', 103343353, 'GAGA', 'G'], ['1', 248367227, 'TC', 'T']],
             variant_keys=[],
-            num_results=2, sample_data={'SNV_INDEL': ALL_AFFECTED_SAMPLE_DATA['SNV_INDEL']})
+            num_results=2, sample_data=expected_sample_data)

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -123,7 +123,17 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
         )
 
         self.search_model.search['inheritance']['filter'] = {}
-        self.search_model.search['annotations_secondary'] = {'structural_consequence': ['LOF']}
+        self.search_model.search['annotations_secondary'] = self.search_model.search['annotations']
+        sv_annotations = {'structural_consequence': ['LOF']}
+        self.search_model.search['annotations'] = sv_annotations
+        query_variants(self.results_model, user=self.user)
+        self._test_expected_search_call(
+            inheritance_mode='recessive', dataset_type='SV', secondary_dataset_type='SNV_INDEL',
+            search_fields=['annotations', 'annotations_secondary'], sample_data=EXPECTED_SAMPLE_DATA,
+        )
+
+        self.search_model.search['annotations'] = self.search_model.search['annotations_secondary']
+        self.search_model.search['annotations_secondary'] = sv_annotations
         query_variants(self.results_model, user=self.user)
         self._test_expected_search_call(
             inheritance_mode='recessive', dataset_type='SNV_INDEL', secondary_dataset_type='SV',

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -23,8 +23,6 @@ SV_WGS_SAMPLE_DATA = [{
 
 EXPECTED_MITO_SAMPLE_DATA = deepcopy(FAMILY_2_MITO_SAMPLE_DATA)
 EXPECTED_MITO_SAMPLE_DATA['MITO'][0].update({'individual_guid': 'I000004_hg00731', 'sample_id': 'HG00731', 'affected': 'A'})
-EXPECTED_MITO_SAMPLE_DATA_WITH_SEX = deepcopy(EXPECTED_MITO_SAMPLE_DATA)
-EXPECTED_MITO_SAMPLE_DATA_WITH_SEX['MITO'][0].update({'sex': 'F'})
 
 ALL_EXPECTED_SAMPLE_DATA = {**EXPECTED_SAMPLE_DATA, **EXPECTED_MITO_SAMPLE_DATA}
 
@@ -150,8 +148,7 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
         query_variants(self.results_model, user=self.user)
         self._test_expected_search_call(
             inheritance_mode='x_linked_recessive', dataset_type='SNV_INDEL', secondary_dataset_type='SNV_INDEL',
-            # Follow up: can't have x-linked MITO variants
-            search_fields=['annotations', 'annotations_secondary'], sample_data={**EXPECTED_SAMPLE_DATA_WITH_SEX, **EXPECTED_MITO_SAMPLE_DATA_WITH_SEX},
+            search_fields=['annotations', 'annotations_secondary'], sample_data=EXPECTED_SAMPLE_DATA_WITH_SEX,
             omit_sample_type='SV_WES',
         )
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -6,7 +6,7 @@ from reference_data.models import GENOME_VERSION_LOOKUP, GENOME_VERSION_GRCh38
 from seqr.models import Sample, Individual, Project
 from seqr.utils.redis_utils import safe_redis_get_json, safe_redis_set_json
 from seqr.utils.search.constants import XPOS_SORT_KEY, PRIORITIZED_GENE_SORT, RECESSIVE, COMPOUND_HET, \
-    MAX_NO_LOCATION_COMP_HET_FAMILIES, SV_ANNOTATION_TYPES, ALL_DATA_TYPES, MAX_EXPORT_VARIANTS
+    MAX_NO_LOCATION_COMP_HET_FAMILIES, SV_ANNOTATION_TYPES, ALL_DATA_TYPES, MAX_EXPORT_VARIANTS, X_LINKED_RECESSIVE
 from seqr.utils.search.elasticsearch.constants import MAX_VARIANTS
 from seqr.utils.search.elasticsearch.es_utils import ping_elasticsearch, delete_es_index, get_elasticsearch_status, \
     get_es_variants, get_es_variants_for_variant_ids, process_es_previously_loaded_results, process_es_previously_loaded_gene_aggs, \
@@ -391,6 +391,9 @@ def _parse_inheritance(search, samples):
 
     if not inheritance_mode and list(inheritance_filter.keys()) == ['affected']:
         raise InvalidSearchException('Inheritance must be specified if custom affected status is set')
+
+    if inheritance_mode == X_LINKED_RECESSIVE:
+        samples = samples.exclude(dataset_type=Sample.DATASET_TYPE_MITO_CALLS)
 
     samples = samples.select_related('individual')
     skipped_samples = _filter_inheritance_family_samples(samples, inheritance_filter)

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -91,7 +91,7 @@ def _get_families_search_data(families, dataset_type=None):
         if not samples:
             raise InvalidSearchException(f'Unable to search against dataset type "{dataset_type}"')
 
-    projects = Project.objects.filter(family__individual__sample__in=samples).values_list('genome_version', 'name')
+    projects = Project.objects.filter(family__individual__sample__in=samples).values_list('genome_version', 'name').distinct()
     project_versions = defaultdict(set)
     for genome_version, project_name in projects:
         project_versions[genome_version].add(project_name)

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -251,8 +251,11 @@ def _query_variants(search_model, user, previous_search_results, sort=None, num_
     dataset_type, secondary_dataset_type, lookup_dataset_type = _search_dataset_type(parsed_search)
     parsed_search.update({'dataset_type': dataset_type, 'secondary_dataset_type': secondary_dataset_type})
     search_dataset_type = None
-    if dataset_type and dataset_type != ALL_DATA_TYPES and (secondary_dataset_type is None or secondary_dataset_type == dataset_type):
-        search_dataset_type = lookup_dataset_type or dataset_type
+    if dataset_type and dataset_type != ALL_DATA_TYPES:
+        if secondary_dataset_type is None or secondary_dataset_type == dataset_type:
+            search_dataset_type = lookup_dataset_type or dataset_type
+        elif dataset_type == Sample.DATASET_TYPE_SV_CALLS:
+            search_dataset_type = DATASET_TYPE_NO_MITO
 
     samples, genome_version = _get_families_search_data(families, dataset_type=search_dataset_type)
     if parsed_search.get('inheritance'):


### PR DESCRIPTION
Improves search performance by adding additional prefiltering for which data types can be included in search. In particular, removes mito search from several places where no mito variants are possible