### PR TITLE
Add temporary aggregation to time query_table

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -332,12 +332,16 @@ class BaseHailTableQuery(object):
                 logger.info(f'Found {num_projects_added} {self.DATA_TYPE} projects with matched entries')
 
         if comp_het_families_ht is not None:
+            logger.info(f'Found {comp_het_families_ht.count()} compound het {self.DATA_TYPE} rows')
             comp_het_ht = self._query_table_annotations(comp_het_families_ht, self._get_table_path('annotations.ht'))
+            logger.info(f'Found {comp_het_ht.count_where(hl.is_defined(comp_het_ht.variant_id))} annotated compound het {self.DATA_TYPE} rows')
             self._comp_het_ht = self._filter_annotated_table(comp_het_ht, is_comp_het=True, **kwargs)
             self._comp_het_ht = self._filter_compound_hets()
 
         if families_ht is not None:
+            logger.info(f'Found {families_ht.count()} {self.DATA_TYPE} rows')
             ht = self._query_table_annotations(families_ht, self._get_table_path('annotations.ht'))
+            logger.info(f'Found {ht.count_where(hl.is_defined(ht.variant_id))} annotated {self.DATA_TYPE} rows')
             self._ht = self._filter_annotated_table(ht, **kwargs)
 
     def _add_project_ht(self, families_ht, project_ht, default, default_1=None):


### PR DESCRIPTION
After some optimization on their end, the hail team is now seeing the `query_table` step as the main bottleneck for recessive search performance. However, the ~30 seconds they are seeing is not consistent with what we would expect for the performance on our dev and prod architecture, given the experimentation and optimization we did during the early configuration of the infrastructure, I would expect it to be more like ~5-10 seconds. This adds some aggregations and logs so we can see the rough time it takes to run the query table step in dev and see whether it looks more like what they are seeing locally or more like what I would expect. This willl never go to production, the idea is to run a couple searches in dev and then revert it
See https://hail.zulipchat.com/#narrow/stream/123011-Hail-Query-Dev/topic/SEQR for discussion