### PR TITLE
Additional prefiltering for multi rpoject search

### DIFF
--- a/deploy/kubectl_helpers/logs.sh
+++ b/deploy/kubectl_helpers/logs.sh
@@ -6,4 +6,10 @@ set -x -e
 
 POD_NAME=$("${DIR}"/utils/get_pod_name.sh "$@")
 
-kubectl logs -f "${POD_NAME}" --all-containers
+COMPONENT=$2
+case ${COMPONENT} in
+  hail-search) CONTAINER="-c seqr-hail-search-pod" ;;
+  *) CONTAINER="--all-containers" ;;
+esac
+
+kubectl logs -f "${POD_NAME}" ${CONTAINER}

--- a/deploy/kubectl_helpers/logs.sh
+++ b/deploy/kubectl_helpers/logs.sh
@@ -12,4 +12,4 @@ case ${COMPONENT} in
   *) CONTAINER="--all-containers" ;;
 esac
 
-kubectl logs -f "${POD_NAME}" ${CONTAINER}
+kubectl logs -f "${POD_NAME}" "${CONTAINER}"

--- a/deploy/kubectl_helpers/port_forward.sh
+++ b/deploy/kubectl_helpers/port_forward.sh
@@ -7,15 +7,9 @@ set -x -e
 COMPONENT=$2
 
 case ${COMPONENT} in
-  elasticsearch)
-    PORT=9200
-    NAME='service/elasticsearch-es-http'
-    OPEN_BROWSER=true
-    ;;
-  kibana)
-    PORT=5601
-    NAME='service/kibana-kb-http'
-    OPEN_BROWSER=true
+  hail-search)
+    PORT=5000
+    NAME='service/seqr-hail-search'
     ;;
   redis)
     PORT=6379

--- a/deploy/kubectl_helpers/set_env.sh
+++ b/deploy/kubectl_helpers/set_env.sh
@@ -10,11 +10,9 @@ DEPLOYMENT_TARGET=$1
 case ${DEPLOYMENT_TARGET} in
   dev)
     CLUSTER_NAME=seqr-cluster-dev
-    NAMESPACE=gcloud-dev
     ;;
   prod)
     CLUSTER_NAME=seqr-cluster-prod
-    NAMESPACE=default
     ;;
   *)
     echo "Invalid deployment target '${DEPLOYMENT_TARGET}'"
@@ -26,4 +24,4 @@ gcloud config set core/project ${GCLOUD_PROJECT}
 gcloud config set compute/zone ${GCLOUD_ZONE}
 gcloud container clusters get-credentials --zone=${GCLOUD_ZONE} ${CLUSTER_NAME}
 
-kubectl config set-context $(kubectl config current-context) --namespace=${NAMESPACE}
+kubectl config set-context $(kubectl config current-context) --namespace=default

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -276,6 +276,7 @@ class BaseHailTableQuery(object):
     def _load_filtered_project_hts(self, project_samples, skip_all_missing=False, **kwargs):
         filtered_project_hts = []
         exception_messages = set()
+        num_projects = len(project_samples)
         for i, (project_guid, project_sample_data) in enumerate(project_samples.items()):
             project_ht = self._read_table(
                 f'projects/{project_guid}.ht',
@@ -286,7 +287,7 @@ class BaseHailTableQuery(object):
                 continue
             try:
                 filtered_project_hts.append(
-                    (*self._filter_entries_table(project_ht, project_sample_data, **kwargs), len(project_sample_data))
+                    (*self._filter_entries_table(project_ht, project_sample_data, num_projects=num_projects, **kwargs), len(project_sample_data))
                 )
             except HTTPBadRequest as e:
                 exception_messages.add(e.reason)
@@ -361,8 +362,7 @@ class BaseHailTableQuery(object):
         ), True
 
     def _filter_entries_table(self, ht, sample_data, inheritance_filter=None, quality_filter=None, **kwargs):
-        if not self._load_table_kwargs:
-            ht = self._prefilter_entries_table(ht, **kwargs)
+        ht = self._prefilter_entries_table(ht, **kwargs)
 
         ht, sorted_family_sample_data = self._add_entry_sample_families(ht, sample_data)
 

--- a/hail_search/queries/snv_indel.py
+++ b/hail_search/queries/snv_indel.py
@@ -73,12 +73,13 @@ class SnvIndelHailTableQuery(MitoHailTableQuery):
         PATHOGENICTY_HGMD_SORT_KEY: lambda r: [MitoHailTableQuery.CLINVAR_SORT(CLINVAR_KEY, r), r.hgmd.class_id],
     }
 
-    def _prefilter_entries_table(self, ht, *args, **kwargs):
+    def _prefilter_entries_table(self, ht, *args, num_projects=1, **kwargs):
         ht = super()._prefilter_entries_table(ht, *args, **kwargs)
-        af_ht = self._get_loaded_filter_ht(
-            GNOMAD_GENOMES_FIELD, 'high_af_variants.ht', self._get_gnomad_af_prefilter, **kwargs)
-        if af_ht:
-            ht = ht.filter(hl.is_missing(af_ht[ht.key]))
+        if num_projects > 1 or not self._load_table_kwargs:
+            af_ht = self._get_loaded_filter_ht(
+                GNOMAD_GENOMES_FIELD, 'high_af_variants.ht', self._get_gnomad_af_prefilter, **kwargs)
+            if af_ht:
+                ht = ht.filter(hl.is_missing(af_ht[ht.key]))
         return ht
 
     def _get_gnomad_af_prefilter(self, frequencies=None, pathogenicity=None, **kwargs):


### PR DESCRIPTION
This adds additional up-front prefiltering to improve performance for multi-project search. It also updates some of the `kubect_helper` scripts to make proxying to the hail backend locally easier