### PR TITLE
Reload saved variants after new samples loaded

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -88,4 +88,12 @@ class Command(BaseCommand):
                 project, dataset_type, sample_type, inactivated_sample_guids,
                 updated_samples=project_updated_samples, num_samples=len(sample_ids),
             )
+
+        # Reload saved variant JSON
+        projects = Sample.objects.filter(
+            is_active=True, sample_type=sample_type, dataset_type=dataset_type,
+        ).values_list('individual__family__project').distinct()
+        # TODO only update variants with correct dataset_type
+        update_projects_saved_variant_json(projects, user_email='manage_command')
+
         logger.info('DONE')

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.management.base import BaseCommand, CommandError
 import json
 import logging
 
 from reference_data.models import GENOME_VERSION_LOOKUP
-from seqr.models import Family, Sample, Project
+from seqr.models import Family, Sample
 from seqr.utils.file_utils import file_iter, does_file_exist
 from seqr.utils.search.add_data_utils import notify_search_data_loaded
 from seqr.views.utils.dataset_utils import match_and_update_search_samples
@@ -93,7 +94,11 @@ class Command(BaseCommand):
         updated_annotation_samples = Sample.objects.filter(is_active=True, dataset_type=dataset_type)
         if dataset_type == Sample.DATASET_TYPE_SV_CALLS:
             updated_annotation_samples = updated_annotation_samples.filter(sample_type=sample_type)
-        projects = Project.objects.filter(family__individual__sample__in=updated_annotation_samples).distinct()
+        projects = Family.objects.filter(
+            individual__sample__in=updated_annotation_samples,
+        ).values('project').annotate(family_ids=ArrayAgg('family_id', distinct=True)).values_list(
+            'project__id', 'project__name', 'family_ids',
+        )
         update_projects_saved_variant_json(projects, user_email='manage_command', dataset_type=dataset_type)
 
         logger.info('DONE')

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -99,6 +99,7 @@ class Command(BaseCommand):
         ).order_by('id').values('project').annotate(family_ids=ArrayAgg('family_id', distinct=True)).values_list(
             'project__id', 'project__name', 'family_ids',
         )
+        import pdb; pdb.set_trace()
         update_projects_saved_variant_json(projects, user_email='manage_command', dataset_type=dataset_type)
 
         logger.info('DONE')

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -95,8 +95,8 @@ class Command(BaseCommand):
         if dataset_type == Sample.DATASET_TYPE_SV_CALLS:
             updated_annotation_samples = updated_annotation_samples.filter(sample_type=sample_type)
         projects = Family.objects.filter(
-            individual__sample__in=updated_annotation_samples,
-        ).values('project').annotate(family_ids=ArrayAgg('family_id', distinct=True)).values_list(
+            project__genome_version=genome_version.replace('GRCh', ''), individual__sample__in=updated_annotation_samples,
+        ).order_by('id').values('project').annotate(family_ids=ArrayAgg('family_id', distinct=True)).values_list(
             'project__id', 'project__name', 'family_ids',
         )
         update_projects_saved_variant_json(projects, user_email='manage_command', dataset_type=dataset_type)

--- a/seqr/management/commands/reload_saved_variant_json.py
+++ b/seqr/management/commands/reload_saved_variant_json.py
@@ -27,5 +27,7 @@ class Command(BaseCommand):
             projects = Project.objects.all()
             logging.info("Processing all %s projects" % len(projects))
 
-        update_projects_saved_variant_json(projects, user_email='manage_command', family_id=family_id)
+        family_ids = [family_id] if family_id else None
+        project_list = [(*project, family_ids) for project in projects.values_list('id', 'name')]
+        update_projects_saved_variant_json(project_list, user_email='manage_command')
         logger.info("Done")

--- a/seqr/management/commands/reload_saved_variant_json.py
+++ b/seqr/management/commands/reload_saved_variant_json.py
@@ -2,9 +2,8 @@ import logging
 from django.core.management.base import BaseCommand
 from django.db.models.query_utils import Q
 from tqdm import tqdm
-import traceback
 from seqr.models import Project
-from seqr.views.utils.variant_utils import update_project_saved_variant_json
+from seqr.views.utils.variant_utils import update_projects_saved_variant_json
 
 logger = logging.getLogger(__name__)
 
@@ -28,27 +27,5 @@ class Command(BaseCommand):
             projects = Project.objects.all()
             logging.info("Processing all %s projects" % len(projects))
 
-        success = {}
-        error = {}
-        for project in tqdm(projects, unit=" projects"):
-            logger.info("Project: " + project.name)
-            try:
-                updated_saved_variant_guids = update_project_saved_variant_json(project, family_id=family_id)
-                success[project.name] = len(updated_saved_variant_guids)
-                logger.info('Updated {0} variants for project {1}'.format(len(updated_saved_variant_guids), project.name))
-            except Exception as e:
-                traceback_message = traceback.format_exc()
-                logger.error(traceback_message)
-                logger.error('Error in project {0}: {1}'.format(project.name, e))
-                error[project.name] = e
-
+        update_projects_saved_variant_json(projects, user_email='manage_command', family_id=family_id)
         logger.info("Done")
-        logger.info("Summary: ")
-        for k, v in success.items():
-            if v > 0:
-                logger.info("  {0}: Updated {1} variants".format(k, v))
-        if len(error):
-            logger.info("{0} failed projects".format(len(error)))
-        for k, v in error.items():
-            logger.info("  {0}: {1}".format(k, v))
-

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -97,7 +97,7 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         self.mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*')
         self.mock_utils_logger.info.assert_has_calls([
             mock.call('Reset 2 cached results'),
-            mock.call(f'Reloading saved variants in {len(reload_calls) + 1} projects'),
+            mock.call('Reloading saved variants in 2 projects'),
         ])
 
         # Test reload saved variants
@@ -248,7 +248,6 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
             mock.call('Updated 1 variants for project Non-Analyst Project'),
             mock.call('Reload Summary: '),
             mock.call('  Non-Analyst Project: Updated 1 variants'),
-            mock.call('Skipped the following 1 project with no saved variants: Test Reprocessed Project')
         ])
 
         # Test notifications

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -96,6 +96,7 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
 
         self.mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*')
         self.mock_utils_logger.info.assert_has_calls([mock.call('Reset 2 cached results')])
+        import pdb; pdb.set_trace()
         # TODO actually test correct summary
 
         # Test reload saved variants

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -72,6 +72,10 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         self.mock_redis = patcher.start()
         self.mock_redis.return_value.keys.side_effect = lambda pattern: [pattern]
         self.addCleanup(patcher.stop)
+        # TODO actually test correct search being executed, to test email header being set
+        patcher = mock.patch('seqr.views.utils.variant_utils.get_variants_for_variant_ids')
+        self.mock_get_variants = patcher.start()
+        self.addCleanup(patcher.stop)
         super().setUp()
 
     def _test_success(self, path, metadata, dataset_type, sample_guids, num_projects=1):
@@ -93,7 +97,8 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         self.mock_logger.warining.assert_not_called()
 
         self.mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*')
-        self.mock_utils_logger.info.assert_called_with('Reset 2 cached results')
+        self.mock_utils_logger.info.assert_has_calls([mock.call('Reset 2 cached results')])
+        # TODO actually test correct summary
 
         # Tests Sample models created/updated
         updated_sample_models = Sample.objects.filter(guid__in=sample_guids)

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -32,7 +32,7 @@ class ReloadSavedVariantJsonTest(TestCase):
         logger_info_calls = [
             mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call('Updated 3 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call('Summary: '),
+            mock.call('Reload Summary: '),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Updated 3 variants')
         ]
         mock_logger.info.assert_has_calls(logger_info_calls)
@@ -61,7 +61,7 @@ class ReloadSavedVariantJsonTest(TestCase):
             mock.call('Updated 2 variants for project Test Reprocessed Project'),
             mock.call('Project: Non-Analyst Project'),
             mock.call('Updated 1 variants for project Non-Analyst Project'),
-            mock.call('Summary: '),
+            mock.call('Reload Summary: '),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Updated 4 variants'),
             mock.call('  Test Reprocessed Project: Updated 2 variants'),
             mock.call('  Non-Analyst Project: Updated 1 variants'),
@@ -80,7 +80,7 @@ class ReloadSavedVariantJsonTest(TestCase):
 
         logger_info_calls = [
             mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call('Summary: '),
+            mock.call('Reload Summary: '),
             mock.call('1 failed projects'),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Database error.')
         ]

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -13,13 +13,12 @@ FAMILY_ID = '1'
 class ReloadSavedVariantJsonTest(TestCase):
     fixtures = ['users', '1kg_project']
 
-    @mock.patch('logging.getLogger')
+    @mock.patch('seqr.views.utils.variant_utils.logger')
     @mock.patch('seqr.views.utils.variant_utils.get_variants_for_variant_ids')
-    def test_with_param_command(self, mock_get_variants, mock_get_logger):
+    def test_with_param_command(self, mock_get_variants, mock_logger):
         mock_get_variants.side_effect = lambda families, variant_ids, **kwargs: \
             [{'variantId': variant_id, 'familyGuids': [family.guid for family in families]}
              for variant_id in variant_ids]
-        mock_logger = mock_get_logger.return_value
 
         # Test with a specific project and a family id.
         call_command('reload_saved_variant_json',
@@ -28,12 +27,11 @@ class ReloadSavedVariantJsonTest(TestCase):
 
         family_1 = Family.objects.get(id=1)
         mock_get_variants.assert_called_with(
-            [family_1], ['1-1562437-G-C', '1-46859832-G-A','21-3343353-GAGA-G'], user=None)
+            [family_1], ['1-1562437-G-C', '1-46859832-G-A','21-3343353-GAGA-G'], user=None, user_email='manage_command')
 
         logger_info_calls = [
             mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call('Updated 3 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call('Done'),
             mock.call('Summary: '),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Updated 3 variants')
         ]
@@ -48,10 +46,10 @@ class ReloadSavedVariantJsonTest(TestCase):
         family_2 = Family.objects.get(id=2)
         mock_get_variants.assert_has_calls([
             mock.call(
-                [family_1, family_2], ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T', '21-3343353-GAGA-G'], user=None,
+                [family_1, family_2], ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T', '21-3343353-GAGA-G'], user=None, user_email='manage_command',
             ),
-            mock.call([Family.objects.get(id=12)], ['12-48367227-TC-T', 'prefix_19107_DEL'], user=None),
-            mock.call([Family.objects.get(id=14)], ['12-48367227-TC-T'], user=None)
+            mock.call([Family.objects.get(id=12)], ['12-48367227-TC-T', 'prefix_19107_DEL'], user=None, user_email='manage_command'),
+            mock.call([Family.objects.get(id=14)], ['12-48367227-TC-T'], user=None, user_email='manage_command')
         ], any_order=True)
 
         logger_info_calls = [
@@ -63,7 +61,6 @@ class ReloadSavedVariantJsonTest(TestCase):
             mock.call('Updated 2 variants for project Test Reprocessed Project'),
             mock.call('Project: Non-Analyst Project'),
             mock.call('Updated 1 variants for project Non-Analyst Project'),
-            mock.call('Done'),
             mock.call('Summary: '),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Updated 4 variants'),
             mock.call('  Test Reprocessed Project: Updated 2 variants'),
@@ -79,11 +76,10 @@ class ReloadSavedVariantJsonTest(TestCase):
                      PROJECT_GUID,
                      '--family-id={}'.format(FAMILY_ID))
 
-        mock_get_variants.assert_called_with([family_1], ['1-1562437-G-C', '1-46859832-G-A', '21-3343353-GAGA-G'], user=None)
+        mock_get_variants.assert_called_with([family_1], ['1-1562437-G-C', '1-46859832-G-A', '21-3343353-GAGA-G'], user=None, user_email='manage_command')
 
         logger_info_calls = [
             mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call('Done'),
             mock.call('Summary: '),
             mock.call('1 failed projects'),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Database error.')

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -30,7 +30,6 @@ class ReloadSavedVariantJsonTest(TestCase):
             [family_1], ['1-1562437-G-C', '1-46859832-G-A','21-3343353-GAGA-G'], user=None, user_email='manage_command')
 
         logger_info_calls = [
-            mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call('Updated 3 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call('Reload Summary: '),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Updated 3 variants')
@@ -53,18 +52,15 @@ class ReloadSavedVariantJsonTest(TestCase):
         ], any_order=True)
 
         logger_info_calls = [
-            mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
+            mock.call('Reloading saved variants in 4 projects'),
             mock.call('Updated 4 variants for project 1kg project n\xe5me with uni\xe7\xf8de'),
-            mock.call('Project: Empty Project'),
-            mock.call('Updated 0 variants for project Empty Project'),
-            mock.call('Project: Test Reprocessed Project'),
             mock.call('Updated 2 variants for project Test Reprocessed Project'),
-            mock.call('Project: Non-Analyst Project'),
             mock.call('Updated 1 variants for project Non-Analyst Project'),
             mock.call('Reload Summary: '),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Updated 4 variants'),
             mock.call('  Test Reprocessed Project: Updated 2 variants'),
             mock.call('  Non-Analyst Project: Updated 1 variants'),
+            mock.call('Skipped the following 1 project with no saved variants: Empty Project'),
         ]
         mock_logger.info.assert_has_calls(logger_info_calls)
         mock_get_variants.reset_mock()
@@ -79,7 +75,6 @@ class ReloadSavedVariantJsonTest(TestCase):
         mock_get_variants.assert_called_with([family_1], ['1-1562437-G-C', '1-46859832-G-A', '21-3343353-GAGA-G'], user=None, user_email='manage_command')
 
         logger_info_calls = [
-            mock.call('Project: 1kg project n\xe5me with uni\xe7\xf8de'),
             mock.call('Reload Summary: '),
             mock.call('1 failed projects'),
             mock.call('  1kg project n\xe5me with uni\xe7\xf8de: Database error.')

--- a/seqr/utils/search/elasticsearch/es_utils.py
+++ b/seqr/utils/search/elasticsearch/es_utils.py
@@ -263,7 +263,7 @@ def _get_es_indices(client):
     return indices, seqr_index_projects
 
 
-def get_es_variants_for_variant_ids(samples, genome_version, variants_by_id, user, return_all_queried_families=False):
+def get_es_variants_for_variant_ids(samples, genome_version, variants_by_id, user, return_all_queried_families=False, **kwargs):
     variants = EsSearch(
         samples, genome_version, user=user, return_all_queried_families=return_all_queried_families, sort=XPOS_SORT_KEY,
     ).filter_by_variant_ids(list(variants_by_id.keys()))

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -14,8 +14,8 @@ def _hail_backend_url(path):
     return f'{HAIL_BACKEND_SERVICE_HOSTNAME}:{HAIL_BACKEND_SERVICE_PORT}/{path}'
 
 
-def _execute_search(search_body, user, path='search', exception_map=None):
-    response = requests.post(_hail_backend_url(path), json=search_body, headers={'From': user.email}, timeout=300)
+def _execute_search(search_body, user, path='search', exception_map=None, user_email=None):
+    response = requests.post(_hail_backend_url(path), json=search_body, headers={'From': user_email or user.email}, timeout=300)
 
     if response.status_code >= 400:
         error = (exception_map or {}).get(response.status_code) or response.text or response.reason
@@ -62,13 +62,13 @@ def get_hail_variants(samples, search, user, previous_search_results, genome_ver
     return response_json['results'][end_offset - num_results:end_offset]
 
 
-def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_ids, user, return_all_queried_families=False):
+def get_hail_variants_for_variant_ids(samples, genome_version, parsed_variant_ids, user, user_email=None, return_all_queried_families=False):
     search = {
         'variant_ids': [parsed_id for parsed_id in parsed_variant_ids.values() if parsed_id],
         'variant_keys': [variant_id for variant_id, parsed_id in parsed_variant_ids.items() if not parsed_id],
     }
     search_body = _format_search_body(samples, genome_version, len(parsed_variant_ids), search)
-    response_json = _execute_search(search_body, user)
+    response_json = _execute_search(search_body, user, user_email=user_email)
 
     if return_all_queried_families:
         expected_family_guids = set(samples.values_list('individual__family__guid', flat=True))

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -81,6 +81,7 @@ class SearchUtilsTests(SearchTestHelper):
         self.assertDictEqual(variant, PARSED_VARIANTS[0])
         mock_get_variants_for_ids.assert_called_with(
             mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, self.user, return_all_queried_families=False,
+            user_email=None,
         )
         expected_samples = {s for s in self.search_samples if s.guid not in NON_SNP_INDEL_SAMPLES}
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
@@ -88,12 +89,13 @@ class SearchUtilsTests(SearchTestHelper):
         get_single_variant(self.families, '2-103343353-GAGA-G', user=self.user, return_all_queried_families=True)
         mock_get_variants_for_ids.assert_called_with(
             mock.ANY, '37', {'2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G')}, self.user, return_all_queried_families=True,
+            user_email=None,
         )
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
 
         get_single_variant(self.families, 'prefix_19107_DEL', user=self.user)
         mock_get_variants_for_ids.assert_called_with(
-            mock.ANY, '37', {'prefix_19107_DEL': None}, self.user, return_all_queried_families=False,
+            mock.ANY, '37', {'prefix_19107_DEL': None}, self.user, return_all_queried_families=False, user_email=None,
         )
         expected_samples = {
             s for s in self.search_samples if s.guid in ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
@@ -113,7 +115,7 @@ class SearchUtilsTests(SearchTestHelper):
             '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
             'M-10195-C-A': ('M', 10195, 'C', 'A'),
             'prefix-938_DEL': None,
-        }, self.user)
+        }, self.user, user_email=None)
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), set(self.search_samples))
 
         get_variants_for_variant_ids(
@@ -122,7 +124,7 @@ class SearchUtilsTests(SearchTestHelper):
             '2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G'),
             '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
             'M-10195-C-A': ('M', 10195, 'C', 'A'),
-        }, self.user)
+        }, self.user, user_email=None)
         skipped_samples = ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
         expected_samples = {s for s in self.search_samples if s.guid not in skipped_samples}
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)
@@ -132,7 +134,7 @@ class SearchUtilsTests(SearchTestHelper):
         mock_get_variants_for_ids.assert_called_with(mock.ANY, '37', {
             '2-103343353-GAGA-G': ('2', 103343353, 'GAGA', 'G'),
             '1-248367227-TC-T': ('1', 248367227, 'TC', 'T'),
-        }, self.user)
+        }, self.user, user_email=None)
         skipped_samples.append('S000149_hg00733')
         expected_samples = {s for s in self.search_samples if s.guid not in skipped_samples}
         self.assertSetEqual(set(mock_get_variants_for_ids.call_args.args[0]), expected_samples)

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -127,11 +127,11 @@ def get_single_variant(families, variant_id, return_all_queried_families=False, 
     return variants[0]
 
 
-def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None):
-    return _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=dataset_type)
+def get_variants_for_variant_ids(families, variant_ids, dataset_type=None, user=None, user_email=None):
+    return _get_variants_for_variant_ids(families, variant_ids, user, user_email, dataset_type=dataset_type)
 
 
-def _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=None, **kwargs):
+def _get_variants_for_variant_ids(families, variant_ids, user, user_email=None, dataset_type=None, **kwargs):
     parsed_variant_ids = {}
     for variant_id in variant_ids:
         parsed_variant_ids[variant_id] = _parse_variant_id(variant_id)
@@ -145,7 +145,7 @@ def _get_variants_for_variant_ids(families, variant_ids, user, dataset_type=None
     dataset_type = _variant_ids_dataset_type(parsed_variant_ids.values())
 
     return backend_specific_call(get_es_variants_for_variant_ids, get_hail_variants_for_variant_ids)(
-        *_get_families_search_data(families, dataset_type=dataset_type), parsed_variant_ids, user, **kwargs
+        *_get_families_search_data(families, dataset_type=dataset_type), parsed_variant_ids, user, user_email=user_email, **kwargs
     )
 
 

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -298,6 +298,7 @@ def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=Vari
 
 @login_and_policies_required
 def update_saved_variant_json(request, project_guid):
+    # TODO endpoint not used in hail backend, should be disabled
     project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
     reset_cached_search_results(project)
     try:

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -4,6 +4,7 @@ from django.db.models import Q
 
 from seqr.models import SavedVariant, VariantTagType, VariantTag, VariantNote, VariantFunctionalData,\
     Family, GeneNote, Project
+from seqr.utils.search.utils import backend_specific_call
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_create_model_from_json, \
     create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
@@ -298,7 +299,7 @@ def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=Vari
 
 @login_and_policies_required
 def update_saved_variant_json(request, project_guid):
-    # TODO endpoint not used in hail backend, should be disabled
+    backend_specific_call(lambda: True, _hail_backend_error)()
     project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
     reset_cached_search_results(project)
     try:
@@ -308,6 +309,10 @@ def update_saved_variant_json(request, project_guid):
         updated_saved_variant_guids = []
 
     return create_json_response({variant_guid: None for variant_guid in updated_saved_variant_guids})
+
+
+def _hail_backend_error(*args, **kwargs):
+    raise ValueError('Endpoint is disabled for the hail backend')
 
 
 @login_and_policies_required

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -303,12 +303,12 @@ def update_saved_variant_json(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
     reset_cached_search_results(project)
     try:
-        updated_saved_variant_guids = update_project_saved_variant_json(project, user=request.user)
+        updated_saved_variant_guids = update_project_saved_variant_json(project.id, user=request.user)
     except Exception as e:
         logger.error('Unable to reset saved variant json for {}: {}'.format(project_guid, e))
         updated_saved_variant_guids = []
 
-    return create_json_response({variant_guid: None for variant_guid in updated_saved_variant_guids})
+    return create_json_response({variant_guid: None for variant_guid in updated_saved_variant_guids or []})
 
 
 def _hail_backend_error(*args, **kwargs):

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -905,9 +905,11 @@ class SavedVariantAPITest(object):
         self.assertDictEqual(response.json(), {'error': 'Unable to find the following variant(s): not_variant'})
 
     @mock.patch('seqr.views.utils.variant_utils.MAX_VARIANTS_FETCH', 3)
+    @mock.patch('seqr.utils.search.utils.es_backend_enabled')
     @mock.patch('seqr.views.apis.saved_variant_api.logger')
     @mock.patch('seqr.views.utils.variant_utils.get_variants_for_variant_ids')
-    def test_update_saved_variant_json(self, mock_get_variants, mock_logger):
+    def test_update_saved_variant_json(self, mock_get_variants, mock_logger, mock_es_enabled):
+        mock_es_enabled.return_value = True
         mock_get_variants.side_effect = lambda families, variant_ids, **kwargs: \
             [{'variantId': variant_id, 'familyGuids': [family.guid for family in families]}
              for variant_id in variant_ids]
@@ -926,8 +928,8 @@ class SavedVariantAPITest(object):
 
         families = [Family.objects.get(guid='F000001_1'), Family.objects.get(guid='F000002_2')]
         mock_get_variants.assert_has_calls([
-            mock.call(families, ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T'], user=self.manager_user),
-            mock.call(families, ['21-3343353-GAGA-G'], user=self.manager_user),
+            mock.call(families, ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T'], user=self.manager_user, user_email=None),
+            mock.call(families, ['21-3343353-GAGA-G'], user=self.manager_user, user_email=None),
         ])
         mock_logger.error.assert_not_called()
 
@@ -936,6 +938,10 @@ class SavedVariantAPITest(object):
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
         mock_logger.error.assert_called_with('Unable to reset saved variant json for R0001_1kg: Unable to fetch variants')
+
+        mock_es_enabled.return_value = False
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 500)
 
     def test_update_variant_main_transcript(self):
         transcript_id = 'ENST00000438943'

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -88,7 +88,7 @@ def update_project_saved_variant_json(project_id, family_ids=None, dataset_type=
     variant_ids = sorted(variant_ids)
     families = sorted(families, key=lambda f: f.guid)
     variants_json = []
-    for sub_var_ids in [variant_ids[i:i+MAX_VARIANTS_FETCH] for i in range(0, len(variant_ids), MAX_VARIANTS_FETCH)]:
+    for sub_var_ids in [varixant_ids[i:i+MAX_VARIANTS_FETCH] for i in range(0, len(variant_ids), MAX_VARIANTS_FETCH)]:
         variants_json += get_variants_for_variant_ids(families, sub_var_ids, user=user, user_email=user_email)
 
     updated_saved_variant_guids = []

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -65,15 +65,14 @@ def update_project_saved_variant_json(project_id, family_ids=None, dataset_type=
     saved_variants = SavedVariant.objects.filter(family__project_id=project_id).select_related('family')
     if family_ids:
         saved_variants = saved_variants.filter(family__family_id__in=family_ids)
-    if dataset_type == Sample.DATASET_TYPE_SV_CALLS:
-        saved_variants = saved_variants.filter(alt__isnull=True)
-    elif dataset_type:
-        mito_xpos = get_xpos('M', 1)
-        saved_variants = saved_variants.filter(alt__isnull=False)
-        if dataset_type == Sample.DATASET_TYPE_MITO_CALLS:
-            saved_variants = saved_variants.filter(xpos__gte=mito_xpos)
-        else:
-            saved_variants = saved_variants.filter(xpos__lt=mito_xpos)
+
+    if dataset_type:
+        xpos_filter_key = 'xpos__gte' if dataset_type == Sample.DATASET_TYPE_MITO_CALLS else 'xpos__lt'
+        dataset_filter = {
+            'alt__isnull': dataset_type == Sample.DATASET_TYPE_SV_CALLS,
+            xpos_filter_key: get_xpos('M', 1),
+        }
+        saved_variants = saved_variants.filter(**dataset_filter)
 
     if not saved_variants:
         return None

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -88,7 +88,7 @@ def update_project_saved_variant_json(project_id, family_ids=None, dataset_type=
     variant_ids = sorted(variant_ids)
     families = sorted(families, key=lambda f: f.guid)
     variants_json = []
-    for sub_var_ids in [varixant_ids[i:i+MAX_VARIANTS_FETCH] for i in range(0, len(variant_ids), MAX_VARIANTS_FETCH)]:
+    for sub_var_ids in [variant_ids[i:i+MAX_VARIANTS_FETCH] for i in range(0, len(variant_ids), MAX_VARIANTS_FETCH)]:
         variants_json += get_variants_for_variant_ids(families, sub_var_ids, user=user, user_email=user_email)
 
     updated_saved_variant_guids = []


### PR DESCRIPTION
After new data is loaded, seqr allele frequencies (plus possibly other annotations) will be updated for all variants of the data type. This will cause the saved variants to be updated to stay in sync with the latest annotations