### PR TITLE
configure max partitions in seqr app

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -205,7 +205,7 @@ class BaseHailTableQuery(object):
         return value
 
     def __init__(self, sample_data, sort=XPOS, sort_metadata=None, num_results=100, inheritance_mode=None,
-                 override_comp_het_alt=False, **kwargs):
+                 override_comp_het_alt=False, max_partitions=100, **kwargs):
         self.unfiltered_comp_het_ht = None
         self._sort = sort
         self._sort_metadata = sort_metadata
@@ -217,7 +217,7 @@ class BaseHailTableQuery(object):
         self._has_secondary_annotations = False
         self._is_multi_data_type_comp_het = False
         self.max_unaffected_samples = None
-        self._load_table_kwargs = {'_n_partitions': (os.cpu_count() or 2)-1}
+        self._load_table_kwargs = {'_n_partitions': min(max_partitions, (os.cpu_count() or 2)-1)}
         self.entry_samples_by_family_guid = {}
 
         if sample_data:

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -45,6 +45,7 @@ def get_hail_variants(samples, search, user, previous_search_results, genome_ver
         'frequencies': frequencies,
         'quality_filter': search_body.pop('qualityFilter', None),
         'custom_query': search_body.pop('customQuery', None),
+        'max_partitions': 24,
     })
     search_body.pop('skipped_samples', None)
 

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -53,6 +53,7 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
                                    quality_filter=None, sort='xpos', sort_metadata=None, **kwargs):
 
         expected_search = {
+            'max_partitions': 24,
             'sort': sort,
             'sort_metadata': sort_metadata,
             'inheritance_mode': inheritance_mode,


### PR DESCRIPTION
Allows the seqr app to set the max partitions in hail backend, so we can quickly iterate in dev and experimentally determine the optimal partition count