### PR TITLE
Multi project gene search redesign

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -276,7 +276,6 @@ class BaseHailTableQuery(object):
     def _load_filtered_project_hts(self, project_samples, skip_all_missing=False, **kwargs):
         filtered_project_hts = []
         exception_messages = set()
-        num_projects = len(project_samples)
         for i, (project_guid, project_sample_data) in enumerate(project_samples.items()):
             project_ht = self._read_table(
                 f'projects/{project_guid}.ht',
@@ -287,7 +286,7 @@ class BaseHailTableQuery(object):
                 continue
             try:
                 filtered_project_hts.append(
-                    (*self._filter_entries_table(project_ht, project_sample_data, num_projects=num_projects, **kwargs), len(project_sample_data))
+                    (*self._filter_entries_table(project_ht, project_sample_data, **kwargs), len(project_sample_data))
                 )
             except HTTPBadRequest as e:
                 exception_messages.add(e.reason)

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -300,6 +300,15 @@ class BaseHailTableQuery(object):
         return filtered_project_hts
 
     def import_filtered_table(self, project_samples, num_families, intervals=None, **kwargs):
+        if len(project_samples) > 1 and (kwargs.get('parsed_intervals') or kwargs.get('padded_interval')):
+            # For multi-project interval search, faster to first read and filter the annotation table and then add entries
+            ht = self._read_table('annotations.ht')
+            ht = self._filter_annotated_table(
+                ht, parsed_intervals=kwargs.get('parsed_intervals'), padded_interval=kwargs.get('padded_interval'),
+            )
+            self._load_table_kwargs['variant_ht'] = ht.select()
+            kwargs.update({'parsed_intervals': None, 'padded_interval': None})
+
         if num_families == 1:
             family_sample_data = list(project_samples.values())[0]
             family_guid = list(family_sample_data.keys())[0]

--- a/hail_search/queries/snv_indel.py
+++ b/hail_search/queries/snv_indel.py
@@ -73,9 +73,9 @@ class SnvIndelHailTableQuery(MitoHailTableQuery):
         PATHOGENICTY_HGMD_SORT_KEY: lambda r: [MitoHailTableQuery.CLINVAR_SORT(CLINVAR_KEY, r), r.hgmd.class_id],
     }
 
-    def _prefilter_entries_table(self, ht, *args, num_projects=1, **kwargs):
+    def _prefilter_entries_table(self, ht, *args, **kwargs):
         ht = super()._prefilter_entries_table(ht, *args, **kwargs)
-        if num_projects > 1 or not self._load_table_kwargs.get('_filter_intervals'):
+        if not self._load_table_kwargs.get('_filter_intervals'):
             af_ht = self._get_loaded_filter_ht(
                 GNOMAD_GENOMES_FIELD, 'high_af_variants.ht', self._get_gnomad_af_prefilter, **kwargs)
             if af_ht:

--- a/hail_search/queries/snv_indel.py
+++ b/hail_search/queries/snv_indel.py
@@ -75,7 +75,7 @@ class SnvIndelHailTableQuery(MitoHailTableQuery):
 
     def _prefilter_entries_table(self, ht, *args, **kwargs):
         ht = super()._prefilter_entries_table(ht, *args, **kwargs)
-        if not self._load_table_kwargs.get('_filter_intervals'):
+        if 'variant_ht' not in self._load_table_kwargs and not self._load_table_kwargs.get('_filter_intervals'):
             af_ht = self._get_loaded_filter_ht(
                 GNOMAD_GENOMES_FIELD, 'high_af_variants.ht', self._get_gnomad_af_prefilter, **kwargs)
             if af_ht:

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -56,17 +56,6 @@ class SvHailTableQuery(BaseHailTableQuery):
     def _get_sample_type(cls, *args):
         return cls.DATA_TYPE.split('_')[-1]
 
-    def import_filtered_table(self, project_samples, *args, parsed_intervals=None, padded_interval=None, **kwargs):
-        if len(project_samples) > 1 and (parsed_intervals or padded_interval):
-            # For multi-project interval search, faster to first read and filter the annotation table and then add entries
-            ht = self._read_table('annotations.ht')
-            ht = self._filter_annotated_table(ht, parsed_intervals=parsed_intervals, padded_interval=padded_interval)
-            self._load_table_kwargs['variant_ht'] = ht.select()
-            parsed_intervals = None
-            padded_interval = None
-
-        return super().import_filtered_table(project_samples, *args, parsed_intervals=parsed_intervals, padded_interval=padded_interval, **kwargs)
-
     def _filter_annotated_table(self, ht, *args, parsed_intervals=None, exclude_intervals=False, padded_interval=None, **kwargs):
         if parsed_intervals:
             interval_filter = hl.array(parsed_intervals).any(lambda interval: hl.if_else(


### PR DESCRIPTION
For SVs we found that for multi-project search with a location filter, it was better to start with the annotations table and then join the project tables instead of the other way around. Since we are seeing issues with the search in SNV_INDEL data as well, we should try making this optimization available for all data types