### PR TITLE
Revert "Multi project gene search redesign"

### DIFF
--- a/hail_search/queries/snv_indel.py
+++ b/hail_search/queries/snv_indel.py
@@ -73,9 +73,9 @@ class SnvIndelHailTableQuery(MitoHailTableQuery):
         PATHOGENICTY_HGMD_SORT_KEY: lambda r: [MitoHailTableQuery.CLINVAR_SORT(CLINVAR_KEY, r), r.hgmd.class_id],
     }
 
-    def _prefilter_entries_table(self, ht, *args, **kwargs):
+    def _prefilter_entries_table(self, ht, *args, num_projects=1, **kwargs):
         ht = super()._prefilter_entries_table(ht, *args, **kwargs)
-        if 'variant_ht' not in self._load_table_kwargs and not self._load_table_kwargs.get('_filter_intervals'):
+        if num_projects > 1 or not self._load_table_kwargs.get('_filter_intervals'):
             af_ht = self._get_loaded_filter_ht(
                 GNOMAD_GENOMES_FIELD, 'high_af_variants.ht', self._get_gnomad_af_prefilter, **kwargs)
             if af_ht:

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -56,6 +56,17 @@ class SvHailTableQuery(BaseHailTableQuery):
     def _get_sample_type(cls, *args):
         return cls.DATA_TYPE.split('_')[-1]
 
+    def import_filtered_table(self, project_samples, *args, parsed_intervals=None, padded_interval=None, **kwargs):
+        if len(project_samples) > 1 and (parsed_intervals or padded_interval):
+            # For multi-project interval search, faster to first read and filter the annotation table and then add entries
+            ht = self._read_table('annotations.ht')
+            ht = self._filter_annotated_table(ht, parsed_intervals=parsed_intervals, padded_interval=padded_interval)
+            self._load_table_kwargs['variant_ht'] = ht.select()
+            parsed_intervals = None
+            padded_interval = None
+
+        return super().import_filtered_table(project_samples, *args, parsed_intervals=parsed_intervals, padded_interval=padded_interval, **kwargs)
+
     def _filter_annotated_table(self, ht, *args, parsed_intervals=None, exclude_intervals=False, padded_interval=None, **kwargs):
         if parsed_intervals:
             interval_filter = hl.array(parsed_intervals).any(lambda interval: hl.if_else(


### PR DESCRIPTION
Reverts broadinstitute/seqr#3936
Having tested this in dev, even reading in just the single gene from the annotations table is too much for SNV_INDEL data