### PR TITLE
Disable project delete UI

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -5,7 +5,7 @@
     "fields": {
         "guid": "R0001_1kg",
         "created_date": "2017-03-12T19:27:08.156Z",
-        "created_by": null,
+        "created_by": 10,
         "last_modified_date": "2017-03-13T09:07:49.582Z",
         "name": "1kg project n\u00e5me with uni\u00e7\u00f8de",
         "description": "1000 genomes project description with uni\u00e7\u00f8de",
@@ -29,7 +29,7 @@
     "fields": {
         "guid": "R0002_empty",
         "created_date": "2017-03-12T19:27:08.156Z",
-        "created_by": null,
+        "created_by": 10,
         "last_modified_date": "2017-03-13T09:07:49.582Z",
         "name": "Empty Project",
         "description": "",
@@ -50,7 +50,7 @@
     "fields": {
         "guid": "R0003_test",
         "created_date": "2017-03-12T19:27:08.156Z",
-        "created_by": null,
+        "created_by": 10,
         "last_modified_date": "2017-03-13T09:07:49.582Z",
         "name": "Test Reprocessed Project",
         "description": "",

--- a/seqr/views/apis/dashboard_api.py
+++ b/seqr/views/apis/dashboard_api.py
@@ -4,6 +4,7 @@ APIs used by the main seqr dashboard page
 from django.db import models
 
 from seqr.models import ProjectCategory, Sample, Family, Project
+from seqr.views.utils.individual_utils import check_project_individuals_deletable
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_projects
 from seqr.views.utils.permissions_utils import get_project_guids_user_can_view, login_and_policies_required
@@ -46,6 +47,9 @@ def _get_projects_json(user):
         projects_by_guid[project.guid]['numFamilies'] = project.family__count
         projects_by_guid[project.guid]['numIndividuals'] = project.family__individual__count
         projects_by_guid[project.guid]['numVariantTags'] = project.family__savedvariant__count
+        if projects_by_guid[project.guid]['userIsCreator']:
+            errors, _ = check_project_individuals_deletable(project)
+            projects_by_guid[project.guid]['userCanDelete'] = not errors
 
     analysis_status_counts = Family.objects.filter(project__in=projects).values(
         'project__guid', 'analysis_status').annotate(count=models.Count('*'))

--- a/seqr/views/apis/dashboard_api_tests.py
+++ b/seqr/views/apis/dashboard_api_tests.py
@@ -40,6 +40,8 @@ class DashboardPageTest(object):
         self.assertSetEqual(
             set(next(iter(response_json['projectsByGuid'].values())).keys()), DASHBOARD_PROJECT_FIELDS
         )
+        self.assertSetEqual({p['userIsCreator'] for p in response_json['projectsByGuid'].values()}, {False})
+        self.assertFalse(any('userCanDelete' in p for p in response_json['projectsByGuid'].values()))
         mock_get_redis.assert_called_with('projects__test_user_collaborator')
         mock_set_redis.assert_called_with(
             'projects__test_user_collaborator', list(response_json['projectsByGuid'].keys()), expire=300)
@@ -49,6 +51,10 @@ class DashboardPageTest(object):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertEqual(len(response_json['projectsByGuid']), 3)
+        self.assertSetEqual({p['userIsCreator'] for p in response_json['projectsByGuid'].values()}, {True})
+        self.assertTrue(response_json['projectsByGuid']['R0002_empty']['userCanDelete'])
+        self.assertFalse(response_json['projectsByGuid']['R0001_1kg']['userCanDelete'])
+        self.assertFalse(response_json['projectsByGuid']['R0003_test']['userCanDelete'])
         mock_get_redis.assert_called_with('projects__test_user')
         mock_set_redis.assert_called_with('projects__test_user', list(response_json['projectsByGuid'].keys()), expire=300)
 

--- a/seqr/views/utils/individual_utils.py
+++ b/seqr/views/utils/individual_utils.py
@@ -173,7 +173,7 @@ def delete_individuals(project, individual_guids, user):
     Returns:
         list: Family objects for families with deleted individuals
     """
-    errors, individuals_to_delete = check_project_individuals_deletable(project.guid, individual_guids=individual_guids)
+    errors, individuals_to_delete = check_project_individuals_deletable(project, individual_guids=individual_guids)
     if errors:
         raise ErrorsWarningsException(errors)
 
@@ -192,8 +192,8 @@ def delete_individuals(project, individual_guids, user):
     return families_with_deleted_individuals
 
 
-def check_project_individuals_deletable(project_guid, individual_guids=None):
-    individuals_to_delete = Individual.objects.filter(family__project__guid=project_guid)
+def check_project_individuals_deletable(project, individual_guids=None):
+    individuals_to_delete = Individual.objects.filter(family__project=project)
     if individual_guids is not None:
         individuals_to_delete = individuals_to_delete.filter(guid__in=individual_guids)
 

--- a/ui/pages/Dashboard/components/ProjectEllipsisMenu.jsx
+++ b/ui/pages/Dashboard/components/ProjectEllipsisMenu.jsx
@@ -55,7 +55,7 @@ const ProjectEllipsisMenu = React.memo((props) => {
       <Dropdown.Divider key="divider1" />,
     )
   }
-  if (props.project.userIsCreator) {
+  if (props.project.userCanDelete) {
     menuItems.push(
       <Dropdown.Divider key="divider2" />,
       <DeleteButton


### PR DESCRIPTION
Current behavior in seqr is to show users the delete button and then throw an error when they try to delete the project. This changes the behavior to not show the button in the UI in the first place