### PR TITLE
include invalid sample id once per error message

### DIFF
--- a/seqr/management/tests/load_rna_seq_tests.py
+++ b/seqr/management/tests/load_rna_seq_tests.py
@@ -66,6 +66,7 @@ class LoadRnaSeqTest(AuthenticationTestCase):
             file_data=[
                 'sample_id\tproject\tindividual_id\tgene_id\tTPM\ttissue\n',
                 'NA19675_D2\t1kg project nåme with uniçøde\t\tENSG00000240361\t12.6\t\n',
+                'NA19675_D2\t1kg project nåme with uniçøde\t\tENSG00000233750\t1.26\t\n',
                 'NA19678_D1\t1kg project nåme with uniçøde\t\tENSG00000233750\t 6.04\twhole_blood\n',
                 'GTEX-001\t1kg project nåme with uniçøde\t\tENSG00000240361\t3.1\tinvalid\n',
                 'NA19677\t1kg project nåme with uniçøde\t\tENSG00000233750\t5.31\tmuscle\n',
@@ -79,7 +80,7 @@ class LoadRnaSeqTest(AuthenticationTestCase):
         self.mock_gzip_file_iter.return_value = [
             self.mock_gzip_file_iter.return_value[0],
             'NA19678_D1\t1kg project nåme with uniçøde\tNA19678\tENSG00000233750\t 6.04\twhole_blood\n',
-        ] + self.mock_gzip_file_iter.return_value[2:]
+        ] + self.mock_gzip_file_iter.return_value[3:]
         call_command('load_rna_seq', 'tpm', RNA_FILE_ID, '--ignore-extra-samples')
 
         # Existing outlier data should be unchanged

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -347,7 +347,7 @@ def _load_rna_seq_file(
 
     loaded_samples = set()
     unmatched_samples = set()
-    missing_required_fields = defaultdict(list)
+    missing_required_fields = defaultdict(set)
     gene_ids = set()
     current_sample = None
     for line in tqdm(parsed_f, unit=' rows'):
@@ -365,7 +365,7 @@ def _load_rna_seq_file(
         sample_id = row_dict.pop(SAMPLE_ID_COL) if SAMPLE_ID_COL in row_dict else row[SAMPLE_ID_COL]
         if missing_cols:
             for col in missing_cols:
-                missing_required_fields[col].append(sample_id)
+                missing_required_fields[col].add(sample_id)
         if missing_cols:
             continue
 


### PR DESCRIPTION
See logs here for example of why deduplicating is necessary for usability: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22seqr-cluster-prod%22%0Aresource.labels.container_name%3D%22seqr-pod%22;cursorTimestamp=2024-03-12T20:58:07.794717634Z;startTime=2024-03-12T20:58:07.244Z;endTime=2024-03-12T20:58:08.636Z?project=seqr-project