### PR TITLE
Better saved variant datset type filtering

### DIFF
--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -102,10 +102,13 @@ def update_project_saved_variant_json(project_id, family_guids=None, dataset_typ
 
 def saved_variants_dataset_type_filter(dataset_type):
     xpos_filter_key = 'xpos__gte' if dataset_type == Sample.DATASET_TYPE_MITO_CALLS else 'xpos__lt'
-    return {
-        'alt__isnull': dataset_type == Sample.DATASET_TYPE_SV_CALLS,
-        xpos_filter_key: get_xpos('M', 1),
-    }
+    dataset_filter = {xpos_filter_key: get_xpos('M', 1)}
+    if dataset_type == Sample.DATASET_TYPE_SV_CALLS:
+        dataset_filter['alt__isnull'] = True
+    else:
+        # Filter out manual variants with invalid characters, such as those used for STRs
+        dataset_filter['alt__regex'] = '^[ACGT]$'
+    return dataset_filter
 
 
 def parse_saved_variant_json(variant_json, family):


### PR DESCRIPTION
Adds better filtration for reloading saved variant json, to prevent errors such as this one that was triggered over the weekend: https://console.cloud.google.com/logs/query;query=error_groups.id%3D%22CPyKxOuL3qCBLA%22%0AlogName:%22stderr%22%0Aresource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22seqr-project%22%0Aresource.labels.location%3D%22us-central1-b%22%0Aresource.labels.pod_name%3D%22seqr-check-new-samples-job-grch38-snv-indel-fvqzf%22%0Aresource.labels.container_name%3D%22seqr-check-new-samples-job-pod-grch38-snv-indel%22%0Aresource.labels.cluster_name%3D%22seqr-cluster-prod%22%0Aresource.labels.namespace_name%3D%22default%22;cursorTimestamp=2024-03-16T02:54:12.061140841Z;startTime=2024-03-16T02:24:42.061Z;endTime=2024-03-16T03:24:42.061Z?project=seqr-project