### PR TITLE
feat: Show more details on hover over data point of RNASeq Outliers plot

### DIFF
--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -990,7 +990,6 @@ def get_individual_rna_seq_data(request, individual_guid):
 
     genes_to_show = get_genes({
         gene_id for rna_data in outlier_data.get(individual_guid, {}).values() for gene_id, data in rna_data.items()
-        if any([d['isSignificant'] for d in (data if isinstance(data, list) else [data])])
     })
 
     return create_json_response({

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -1293,7 +1293,7 @@ class IndividualAPITest(object):
             },
             outliers_by_pos[132885746]
         )
-        self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953', 'ENSG00000268903'})
+        self.assertSetEqual(set(response_json['genesById'].keys()), {'ENSG00000135953', 'ENSG00000268903', 'ENSG00000240361'})
 
     def test_get_individual_rna_seq_data_is_significant(self):
         url = reverse(get_individual_rna_seq_data, args=[INDIVIDUAL_GUID])

--- a/ui/pages/Project/components/RnaSeqOutliers.jsx
+++ b/ui/pages/Project/components/RnaSeqOutliers.jsx
@@ -52,12 +52,16 @@ class RnaSeqOutliersGraph extends React.PureComponent {
     const dataPoints = svg.append('g').selectAll('dot').data(dataArray).enter()
       .append('g')
 
+    console.debug('genesById', genesById)
+
     dataPoints.append('circle')
-      .attr('cx', d => x(d[xField]))
-      .attr('cy', d => y(d[yField]))
-      .attr('r', 3)
-      .style('fill', 'None')
+      .attr('cx', d => x(d.zScore))
+      .attr('cy', d => y(d.pValue))
+      .attr('r', d => (d.deltaPsi === undefined ? 3 : r(Math.abs(d.deltaPsi))))
+      .style('fill-opacity', '0%')
       .style('stroke', d => (d.isSignificant ? 'red' : 'lightgrey'))
+      .append('svg:title')
+      .text(d => `${genesById[d.geneId] ? genesById[d.geneId].geneSymbol : d.geneId}\nZ = ${d.zScore.toPrecision(2)}\n${'P-value = 10^-'}${(-Math.log10(d.pValue)).toPrecision(2)}`)
 
     dataPoints.append('text')
       .text(d => (d.isSignificant ? (genesById[d.geneId] || {}).geneSymbol : null))

--- a/ui/pages/Project/components/RnaSeqOutliers.jsx
+++ b/ui/pages/Project/components/RnaSeqOutliers.jsx
@@ -52,8 +52,6 @@ class RnaSeqOutliersGraph extends React.PureComponent {
     const dataPoints = svg.append('g').selectAll('dot').data(dataArray).enter()
       .append('g')
 
-    console.debug('genesById', genesById)
-
     dataPoints.append('circle')
       .attr('cx', d => x(d.zScore))
       .attr('cy', d => y(d.pValue))


### PR DESCRIPTION
Hi,

We made some small improvements to the RNASeq Outliers plot so that each data point shows extra details on hover.  See screenshot below.

In order to show the gene symbols, it meant the `isSignificant` genes filter had to be removed from the `get_individual_rna_seq_data()` API call.  This increased the API call time by around 20% on our instance.  However, since this plot already has a long delay to get the rest of the data, we didn't think it would make the experience much worse.

<img width="806" alt="ScreenShot 2024-03-19 at 1 12 17 PM" src="https://github.com/broadinstitute/seqr/assets/117335/c4403290-8884-4405-bc6d-46edd8471a6e">

A question I had was any future plans around RNASeq in Seqr.  Will there be much more significant changes to how Seqr supports RNASeq?  We're asking because we have other improvements to this plot that have more involved changes and if this plot is not going to stay around then we may not bother.  The improvement is to add a new drop down for gene lists selection such that on drop down change, the data points in the selected gene list gets a darker shade.  Would this feature be useful for your team?
