### PR TITLE
update fixture data variant IDs

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1768,7 +1768,7 @@
         "xpos_end": 1248367228,
         "ref": "TC",
         "alt": "T",
-        "variant_id": "12-48367227-TC-T",
+        "variant_id": "1-248367227-TC-T",
         "saved_variant_json": {
             "clinvar": {
                 "clinicalSignificance": "",
@@ -2002,7 +2002,7 @@
         "xpos_end": 1248367228,
         "ref": "TC",
         "alt": "T",
-        "variant_id": "12-48367227-TC-T",
+        "variant_id": "1-248367227-TC-T",
         "saved_variant_json": {
             "clinvar": {"clinicalSignificance": "", "alleleId": null, "variationId": null, "goldStars": null},
             "liftedOverGenomeVersion": "38",  "liftedOverPos": "", "genotypeFilters": "pass",
@@ -2082,7 +2082,7 @@
         "xpos_end": 1248367228,
         "ref": "TC",
         "alt": "T",
-        "variant_id": "12-48367227-TC-T",
+        "variant_id": "1-248367227-TC-T",
         "saved_variant_json": {
             "liftedOverGenomeVersion": "37",  "liftedOverPos": "", "genomeVersion": "38", "pos": 248367227,
             "transcripts": {}, "chrom": "1", "genotypes": {

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -131,7 +131,7 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
             "http://testairtable/appUelDNM3BnWaR7M/AnVIL%20Seqr%20Loading%20Requests%20Tracking?fields[]=Status&pageSize=2&filterByFormula=AND({AnVIL Project URL}='https://seqr.broadinstitute.org/project/R0004_non_analyst_project/project_page',OR(Status='Loading',Status='Loading Requested'))",
             json={'records': [{'id': 'rec12345', 'fields': {}}, {'id': 'rec67890', 'fields': {}}]})
         responses.add(responses.POST, f'{MOCK_HAIL_HOST}:5000/search', status=200, json={
-            'results': [{'variantId': '12-48367227-TC-T', 'familyGuids': ['F000014_14'], 'updated_field': 'updated_value'}],
+            'results': [{'variantId': '1-248367227-TC-T', 'familyGuids': ['F000014_14'], 'updated_field': 'updated_value'}],
             'total': 1,
         })
         responses.add(responses.POST, f'{MOCK_HAIL_HOST}:5000/multi_lookup', status=200, json={
@@ -190,7 +190,7 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         self.mock_logger.reset_mock()
         self.mock_subprocess.reset_mock()
         search_body = {
-            'genome_version': 'GRCh38', 'num_results': 1, 'variant_ids': [['12', 48367227, 'TC', 'T']], 'variant_keys': [],
+            'genome_version': 'GRCh38', 'num_results': 1, 'variant_ids': [['1', 248367227, 'TC', 'T']], 'variant_keys': [],
         }
         self._test_success('GRCh38/SNV_INDEL', metadata, dataset_type='SNV_INDEL', sample_guids={
             EXISTING_SAMPLE_GUID, REPLACED_SAMPLE_GUID, NEW_SAMPLE_GUID_P3, NEW_SAMPLE_GUID_P4,

--- a/seqr/management/tests/reload_saved_variant_json_tests.py
+++ b/seqr/management/tests/reload_saved_variant_json_tests.py
@@ -45,10 +45,10 @@ class ReloadSavedVariantJsonTest(TestCase):
         family_2 = Family.objects.get(id=2)
         mock_get_variants.assert_has_calls([
             mock.call(
-                [family_1, family_2], ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T', '21-3343353-GAGA-G'], user=None, user_email='manage_command',
+                [family_1, family_2], ['1-1562437-G-C', '1-248367227-TC-T', '1-46859832-G-A', '21-3343353-GAGA-G'], user=None, user_email='manage_command',
             ),
-            mock.call([Family.objects.get(id=12)], ['12-48367227-TC-T', 'prefix_19107_DEL'], user=None, user_email='manage_command'),
-            mock.call([Family.objects.get(id=14)], ['12-48367227-TC-T'], user=None, user_email='manage_command')
+            mock.call([Family.objects.get(id=12)], ['1-248367227-TC-T', 'prefix_19107_DEL'], user=None, user_email='manage_command'),
+            mock.call([Family.objects.get(id=14)], ['1-248367227-TC-T'], user=None, user_email='manage_command')
         ], any_order=True)
 
         logger_info_calls = [

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -928,7 +928,7 @@ class SavedVariantAPITest(object):
 
         families = [Family.objects.get(guid='F000001_1'), Family.objects.get(guid='F000002_2')]
         mock_get_variants.assert_has_calls([
-            mock.call(families, ['1-1562437-G-C', '1-46859832-G-A', '12-48367227-TC-T'], user=self.manager_user, user_email=None),
+            mock.call(families, ['1-1562437-G-C', '1-248367227-TC-T', '1-46859832-G-A'], user=self.manager_user, user_email=None),
             mock.call(families, ['21-3343353-GAGA-G'], user=self.manager_user, user_email=None),
         ])
         mock_logger.error.assert_not_called()

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -479,11 +479,11 @@ class SummaryDataAPITest(AirtableTest):
             },
             'results': {
                 'HG00731': {
-                    '12-48367227-TC-T': {'categories': ['3', '4'], 'support_vars': ['2-103343353-GAGA-G']},
-                    '1-248367227-TC-T': {'categories': ['1'], 'support_vars': ['12-48367227-TC-T']},
+                    '1-248367227-TC-T': {'categories': ['3', '4'], 'support_vars': ['2-103343353-GAGA-G']},
+                    '12-48367227-TC-T': {'categories': ['1'], 'support_vars': ['1-248367227-TC-T']},
                 },
                 'SAM_123': {
-                    '12-48367227-TC-T': {'categories': ['4', 'support'], 'support_vars': []},
+                    '1-248367227-TC-T': {'categories': ['4', 'support'], 'support_vars': []},
                 },
             }
         }
@@ -498,10 +498,10 @@ class SummaryDataAPITest(AirtableTest):
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['errors'], [
-            "Unable to find the following family's AIP variants in the search backend: 2 (1-248367227-TC-T)",
+            "Unable to find the following family's AIP variants in the search backend: 2 (12-48367227-TC-T)",
         ])
 
-        aip_upload['results']['HG00731']['2-103343353-GAGA-G'] = aip_upload['results']['HG00731'].pop('1-248367227-TC-T')
+        aip_upload['results']['HG00731']['2-103343353-GAGA-G'] = aip_upload['results']['HG00731'].pop('12-48367227-TC-T')
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'info': ['Loaded 2 new and 1 updated AIP tags for 2 families']})

--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -150,7 +150,7 @@ class JSONUtilsTest(object):
         self.assertSetEqual(set(var_1['tagGuids']), v1_tag_guids)
         self.assertSetEqual(set(var_1['functionalDataGuids']), v1_functional_guids)
         var_2 = json['savedVariantsByGuid'][variant_guid_2]
-        self.assertEqual(var_2['variantId'], '12-48367227-TC-T')
+        self.assertEqual(var_2['variantId'], '1-248367227-TC-T')
         self.assertSetEqual(set(var_2['tagGuids']), v2_tag_guids)
         self.assertSetEqual(set(var_2['noteGuids']), set(v2_note_guids))
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -948,7 +948,7 @@ VARIANTS = [
         'xpos': 1248367227,
         'genomeVersion': '37',
         'liftedOverGenomeVersion': '',
-        'variantId': '12-48367227-TC-T',
+        'variantId': '1-248367227-TC-T',
         'transcripts': {'ENSG00000233653': {}},
         'familyGuids': ['F000002_2'],
         'genotypes': {}


### PR DESCRIPTION
The test fixture data has been messed up a for some time where the chrom/pos/xpos do not actually map to the variant ID due to an old typo. This has propagated across a lot of tests at this point, but makes testing things difficult as. you get a different variant ID depending on how you compute it, which can't actually happen with real data