### PR TITLE
Remove phenotips json support

### DIFF
--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -963,29 +963,6 @@ class IndividualAPITest(object):
         response = self.client.post(url, data={'f': f})
         self._is_expected_individuals_metadata_upload(response, expected_families=True, has_non_hpo_update=True)
 
-    def test_individuals_metadata_json_table_handler(self):
-        url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])
-        self.check_collaborator_login(url)
-
-        f = SimpleUploadedFile('updates.json', json.dumps([
-            {'external_id': 'NA19675_1', 'sex': 'F', 'date_of_birth': '2000-01-01', 'features': [
-                {'id': 'HP:0002017', 'observed': 'yes'},
-                {'id': 'HP:0002017', 'observed': 'yes'},
-                {'id': 'HP:0012469', 'observed': 'no'},
-                {'id': 'HP:0004322', 'observed': 'no'},
-            ], 'family_history': {'affectedRelatives': True}, 'global_age_of_onset': [{'label': 'Juvenile onset'}],
-             'global_mode_of_inheritance': [{'label': 'Autosomal dominant inheritance'}, {'label': 'Sporadic'}],
-             'ethnicity': {'maternal_ethnicity': ['Finnish', 'Irish']}, 'genes': [
-                 {'gene': 'IKBKAP', 'comments': 'multiple panels, no confirm'}, {'gene': 'EHBP1L1'},
-             ]},
-            {'external_id': 'NA19678', 'features': [], 'notes': {'family_history': 'history note'}},
-            {'external_id': 'NA19679', 'features': [{'id': 'HP:0100258', 'observed': 'yes'}]},
-            {'family_id': '1', 'external_id': 'HG00731', 'features': [
-                {'id': 'HP:0002017', 'observed': 'yes'}, {'id': 'HP:0011675', 'observed': 'no'}]},
-        ]).encode('utf-8'))
-        response = self.client.post(url, data={'f': f})
-        self._is_expected_individuals_metadata_upload(response)
-
     def test_individuals_metadata_hpo_term_number_table_handler(self):
         url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])
         self.check_collaborator_login(url)

--- a/ui/pages/Project/components/edit-families-and-individuals/BulkEditForm.jsx
+++ b/ui/pages/Project/components/edit-families-and-individuals/BulkEditForm.jsx
@@ -24,9 +24,6 @@ import {
   getProjectAnalysisGroupIndividualsByGuid,
 } from '../../selectors'
 
-const ALL_UPLOAD_FORMATS = FILE_FORMATS.concat([
-  { title: 'Phenotips Export', formatLinks: [{ href: 'https://phenotips.org/', linkExt: 'json' }] },
-])
 const FAM_UPLOAD_FORMATS = [].concat(FILE_FORMATS)
 FAM_UPLOAD_FORMATS[1] = { ...FAM_UPLOAD_FORMATS[1], formatLinks: [...FAM_UPLOAD_FORMATS[1].formatLinks, { href: 'https://www.cog-genomics.org/plink2/formats#fam', linkExt: 'fam' }] }
 
@@ -153,7 +150,7 @@ const IndividualMetadataBulkForm = React.memo(({ load, loading, ...props }) => (
       details="Alternately, the table can have a single row per HPO term"
       requiredFields={INDIVIDUAL_ID_EXPORT_DATA}
       optionalFields={INDIVIDUAL_DETAIL_EXPORT_DATA}
-      uploadFormats={ALL_UPLOAD_FORMATS}
+      uploadFormats={FILE_FORMATS}
       {...props}
     />
   </DataLoader>


### PR DESCRIPTION
Removes the description form the UI saying we support phenotips json upload, and updates behavior for uploading files to default to not support json, as almost everywhere that function is called it will break if json is uploaded.