### PR TITLE
UI snv indel loading

### DIFF
--- a/seqr/fixtures/users.json
+++ b/seqr/fixtures/users.json
@@ -161,7 +161,7 @@
         "username": "test_data_manager",
         "first_name": "Test Data Manager",
         "last_name": "",
-        "email": "test_data_manager@test.com",
+        "email": "test_data_manager@broadinstitute.org",
         "is_staff": true,
         "is_active": true,
         "date_joined": "2017-03-12T23:09:54.180Z",

--- a/seqr/management/tests/detect_inactive_priveleged_users_tests.py
+++ b/seqr/management/tests/detect_inactive_priveleged_users_tests.py
@@ -31,17 +31,17 @@ class DetectInactivePrivilegedUsersTest(TestCase):
         call_command('detect_inactive_privileged_users')
 
         self.assertFalse(User.objects.get(email='test_superuser@test.com').is_active)
-        self.assertTrue(User.objects.get(email='test_data_manager@test.com').is_active)
+        self.assertTrue(User.objects.get(email='test_data_manager@broadinstitute.org').is_active)
 
         mock_send_mail.assert_has_calls([
-            mock.call('Warning: seqr account deactivation', WARNING_EMAIL, None, ['test_data_manager@test.com']),
+            mock.call('Warning: seqr account deactivation', WARNING_EMAIL, None, ['test_data_manager@broadinstitute.org']),
             mock.call('Warning: seqr account deactivated', DEACTIVATED_EMAIL, None, ['test_superuser@test.com']),
         ])
 
         mock_logger.error.assert_called_with('Unable to send email: Connection error')
         mock_logger.info.assert_has_calls([
             mock.call('Checking for inactive users'),
-            mock.call('Warning test_data_manager@test.com of impending account inactivation'),
+            mock.call('Warning test_data_manager@broadinstitute.org of impending account inactivation'),
             mock.call('Inactivating account for test_superuser@test.com'),
             mock.call('Inactive user check complete'),
         ])

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -446,14 +446,14 @@ def get_loaded_projects(request, sample_type, dataset_type):
 
     if project_samples:
         for project in projects:
-            project['sampleIds'] = project_samples[project['projectGuid']]
+            project['sampleIds'] = sorted(project_samples[project['projectGuid']])
 
     return create_json_response({'projects': list(projects)})
 
 
 def _fetch_airtable_loadable_project_samples(user):
     pdos = AirtableSession(user).fetch_records(
-        'PDO', fields=['PassingCollaboratorSampleIDs', 'SeqrIDs', 'PDOName', 'PDOStatus', 'SeqrProjectURL'],
+        'PDO', fields=['PassingCollaboratorSampleIDs', 'SeqrIDs', 'SeqrProjectURL'],
         or_filters={'PDOStatus': LOADABLE_PDO_STATUSES}
     )
     project_samples = defaultdict(set)

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -436,6 +436,7 @@ def get_loaded_projects(request, sample_type, dataset_type):
         project_samples = _fetch_airtable_loadable_project_samples(request.user)
         projects = projects.filter(guid__in=project_samples.keys())
         exclude_sample_type = Sample.SAMPLE_TYPE_WES if sample_type == Sample.SAMPLE_TYPE_WGS else Sample.SAMPLE_TYPE_WGS
+        # Include projects with either the matched sample type OR with no loaded data
         projects = projects.exclude(family__individual__sample__sample_type=exclude_sample_type)
     else:
         projects = projects.filter(family__individual__sample__sample_type=sample_type)

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -20,6 +20,7 @@ from seqr.utils.logging_utils import SeqrLogger
 from seqr.utils.vcf_utils import validate_vcf_exists
 
 from seqr.views.utils.airflow_utils import trigger_data_loading, write_data_loading_pedigree
+from seqr.views.utils.airtable_utils import AirtableSession
 from seqr.views.utils.dataset_utils import load_rna_seq, load_phenotype_prioritization_data_file, RNA_DATA_TYPE_CONFIGS, \
     post_process_rna_data
 from seqr.views.utils.file_utils import parse_file, get_temp_upload_directory, load_uploaded_file
@@ -412,6 +413,11 @@ DATA_TYPE_FILE_EXTS = {
     Sample.DATASET_TYPE_SV_CALLS: ('.bed',),
 }
 
+LOADABLE_PDO_STATUSES = [
+    'On hold for phenotips, but ready to load',
+    'Methods (Loading)',
+]
+
 
 @pm_or_data_manager_required
 def validate_callset(request):
@@ -425,16 +431,40 @@ def validate_callset(request):
 @pm_or_data_manager_required
 def get_loaded_projects(request, sample_type, dataset_type):
     projects = get_internal_projects().filter(is_demo=False)
+    project_samples = None
     if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
+        project_samples = _fetch_airtable_loadable_project_samples(request.user)
+        projects = projects.filter(guid__in=project_samples.keys())
         exclude_sample_type = Sample.SAMPLE_TYPE_WES if sample_type == Sample.SAMPLE_TYPE_WGS else Sample.SAMPLE_TYPE_WGS
         projects = projects.exclude(family__individual__sample__sample_type=exclude_sample_type)
-        # TODO filter for loadable projects from airtable
     else:
         projects = projects.filter(family__individual__sample__sample_type=sample_type)
+
     projects = projects.distinct().order_by('name').values('name', projectGuid=F('guid'), dataTypeLastLoaded=Max(
         'family__individual__sample__loaded_date', filter=Q(family__individual__sample__dataset_type=dataset_type),
     ))
+
+    if project_samples:
+        for project in projects:
+            project['sampleIds'] = project_samples[project['projectGuid']]
+
     return create_json_response({'projects': list(projects)})
+
+
+def _fetch_airtable_loadable_project_samples(user):
+    pdos = AirtableSession(user).fetch_records(
+        'PDO', fields=['PassingCollaboratorSampleIDs', 'SeqrIDs', 'PDOName', 'PDOStatus', 'SeqrProjectURL'],
+        or_filters={'PDOStatus': LOADABLE_PDO_STATUSES}
+    )
+    project_samples = defaultdict(set)
+    for pdo in pdos.values():
+        project_guid = re.match(
+            'https://seqr.broadinstitute.org/project/([^/]+)/project_page', pdo['SeqrProjectURL'],
+        ).group(1)
+        project_samples[project_guid].update([
+            sample_id for sample_id in pdo['PassingCollaboratorSampleIDs'] + pdo['SeqrIDs'] if sample_id
+        ])
+    return project_samples
 
 
 @pm_or_data_manager_required

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -442,9 +442,9 @@ def load_data(request):
     request_json = json.loads(request.body)
     sample_type = request_json['sampleType']
     dataset_type = request_json['datasetType']
-    projects = request_json['projects']
+    projects = [json.loads(project) for project in request_json['projects']]
 
-    project_models = Project.objects.filter(guid__in=projects)
+    project_models = Project.objects.filter(guid__in=[p['projectGuid'] for p in projects])
     if len(project_models) < len(projects):
         missing = sorted(set(projects) - {p.guid for p in project_models})
         return create_json_response({'error': f'The following projects are invalid: {", ".join(missing)}'}, status=400)

--- a/seqr/views/utils/airflow_utils.py
+++ b/seqr/views/utils/airflow_utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, OrderedDict
 from django.contrib.auth.models import User
-from django.db.models import F
+from django.db.models import F, Q, Count
 import google.auth
 from google.auth.transport.requests import AuthorizedSession
 import itertools
@@ -12,6 +12,7 @@ from seqr.models import Individual, Sample, Project
 from seqr.utils.communication_utils import safe_post_to_slack
 from seqr.utils.file_utils import does_file_exist
 from seqr.utils.logging_utils import SeqrLogger
+from seqr.utils.middleware import ErrorsWarningsException
 from seqr.views.utils.export_utils import write_multiple_files_to_gs
 from settings import AIRFLOW_WEBSERVER_URL, SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL
 
@@ -27,7 +28,7 @@ class DagRunningException(Exception):
 
 def trigger_data_loading(projects: list[Project], sample_type: str, dataset_type: str, data_path: str, user: User,
                          success_message: str, success_slack_channel: str, error_message: str,
-                         genome_version: str = GENOME_VERSION_GRCh38, is_internal: bool = False):
+                         genome_version: str = GENOME_VERSION_GRCh38, is_internal: bool = False, project_samples: dict = None):
 
     success = True
     dag_name = f'v03_pipeline-{_dag_dataset_type(sample_type, dataset_type)}'
@@ -40,7 +41,8 @@ def trigger_data_loading(projects: list[Project], sample_type: str, dataset_type
         'reference_genome': GENOME_VERSION_LOOKUP[genome_version],
     }
 
-    upload_info = _upload_data_loading_files(projects, is_internal, user, genome_version, sample_type)
+    upload_info = _upload_data_loading_files(
+        projects, is_internal, user, genome_version, sample_type, project_samples=project_samples)
 
     try:
         _check_dag_running_state(dag_name)
@@ -106,7 +108,8 @@ def _dag_dataset_type(sample_type: str, dataset_type: str):
 
 
 def _upload_data_loading_files(projects: list[Project], is_internal: bool,
-                               user: User, genome_version: str, sample_type: str, callset: str = 'Internal'):
+                               user: User, genome_version: str, sample_type: str, callset: str = 'Internal',
+                               project_samples: dict = None):
     file_annotations = OrderedDict({
         'Project_GUID': F('family__project__guid'), 'Family_GUID': F('family__guid'),
         'Family_ID': F('family__family_id'),
@@ -114,6 +117,8 @@ def _upload_data_loading_files(projects: list[Project], is_internal: bool,
         'Paternal_ID': F('father__individual_id'), 'Maternal_ID': F('mother__individual_id'), 'Sex': F('sex'),
     })
     annotations = {'project': F('family__project__guid'), **file_annotations}
+    if project_samples:
+        annotations['sampleCount'] = Count('sample', filter=Q(sample__is_active=True) & Q(sample__sample_type=sample_type))
     data = Individual.objects.filter(family__project__in=projects).order_by('family_id', 'individual_id').values(
         **dict(annotations))
 
@@ -122,16 +127,59 @@ def _upload_data_loading_files(projects: list[Project], is_internal: bool,
         data_by_project[row.pop('project')].append(row)
 
     info = []
+    errors = []
     for project_guid, rows in data_by_project.items():
         gs_path = _get_dag_project_gs_path(project_guid, genome_version, sample_type, is_internal, callset)
         try:
-            write_multiple_files_to_gs(
-                [(f'{project_guid}_pedigree', file_annotations.keys(), rows)], gs_path, user, file_format='tsv')
+            files, file_suffixes = _parse_project_upload_files(project_guid, rows, file_annotations.keys(), project_samples)
+            write_multiple_files_to_gs(files, gs_path, user, file_format='tsv', file_suffixes=file_suffixes)
+        except ValueError as e:
+            errors.append(str(e))
         except Exception as e:
             logger.error(f'Uploading Pedigree to Google Storage failed. Errors: {e}', user, detail=rows)
         info.append(f'Pedigree file has been uploaded to {gs_path}')
 
+    if errors:
+        raise ErrorsWarningsException(errors)
+
     return info
+
+
+def _parse_project_upload_files(project_guid, rows, header, project_samples):
+    files = [(f'{project_guid}_pedigree', header, rows)]
+    file_suffixes = None
+    if project_samples and project_guid in project_samples:
+        _validate_project_samples(project_samples[project_guid], rows)
+        file_name = f'{project_guid}_ids'
+        files.append((file_name, ['s'], [{'s': sample_id} for sample_id in project_samples[project_guid]]))
+        file_suffixes = {file_name: 'txt'}
+    return files, file_suffixes
+
+
+def _validate_project_samples(sample_ids, pedigree_rows):
+    individual_families = {}
+    loaded_family_individuals = defaultdict(set)
+    for row in pedigree_rows:
+        individual_id = row['Individual_ID']
+        family_id = row['Family_ID']
+        individual_families[individual_id] = family_id
+        if row['sampleCount']:
+            loaded_family_individuals[family_id].add(individual_id)
+
+    missing_samples = sorted(set(sample_ids) - set(individual_families.keys()))
+    if missing_samples:
+        raise ValueError(f'The following samples are included in airtable but missing from seqr: {", ".join(missing_samples)}')
+
+    airtable_families = defaultdict(set)
+    for sample_id in sample_ids:
+        airtable_families[individual_families[sample_id]].add(sample_id)
+    family_errors = []
+    for family_id, family_samples in airtable_families.items():
+        missing_family_samples = sorted(loaded_family_individuals[family_id] - family_samples)
+        if missing_family_samples:
+            family_errors.append(f'{family_id} ({", ".join(missing_family_samples)})')
+    if family_errors:
+        raise ValueError(f'The following families have previously loaded samples absent from airtable: {"; ".join(family_errors)}')
 
 
 def _get_dag_project_gs_path(project: str, genome_version: str, sample_type: str, is_internal: bool, callset: str):

--- a/ui/pages/DataManagement/components/LoadData.jsx
+++ b/ui/pages/DataManagement/components/LoadData.jsx
@@ -5,7 +5,13 @@ import { validators } from 'shared/components/form/FormHelpers'
 import FormWizard from 'shared/components/form/FormWizard'
 import { ButtonRadioGroup } from 'shared/components/form/Inputs'
 import LoadOptionsSelect from 'shared/components/form/LoadOptionsSelect'
-import { SAMPLE_TYPE_EXOME, SAMPLE_TYPE_GENOME, DATASET_TYPE_SV_CALLS, DATASET_TYPE_MITO_CALLS } from 'shared/utils/constants'
+import {
+  SAMPLE_TYPE_EXOME,
+  SAMPLE_TYPE_GENOME,
+  DATASET_TYPE_SV_CALLS,
+  DATASET_TYPE_MITO_CALLS,
+  DATASET_TYPE_SNV_INDEL_CALLS,
+} from 'shared/utils/constants'
 
 const formatProjectOption = ({ name, projectGuid, dataTypeLastLoaded }) => ({
   value: projectGuid,
@@ -54,7 +60,11 @@ const LOAD_DATA_PAGES = [
         name: 'datasetType',
         label: 'Dataset Type',
         component: ButtonRadioGroup,
-        options: [DATASET_TYPE_SV_CALLS, DATASET_TYPE_MITO_CALLS].map(value => ({ value, text: value })),
+        options: [
+          DATASET_TYPE_SNV_INDEL_CALLS,
+          DATASET_TYPE_SV_CALLS,
+          DATASET_TYPE_MITO_CALLS,
+        ].map(value => ({ value, text: value.replace('_', '/') })),
         validate: validators.required,
       },
     ],

--- a/ui/pages/DataManagement/components/LoadData.jsx
+++ b/ui/pages/DataManagement/components/LoadData.jsx
@@ -13,11 +13,11 @@ import {
   DATASET_TYPE_SNV_INDEL_CALLS,
 } from 'shared/utils/constants'
 
-const formatProjectOption = ({ name, projectGuid, dataTypeLastLoaded }) => ({
-  value: projectGuid,
-  text: name,
-  description: dataTypeLastLoaded && `Last Loaded: ${new Date(dataTypeLastLoaded).toLocaleDateString()}`,
-  color: dataTypeLastLoaded ? 'teal' : 'orange',
+const formatProjectOption = opt => ({
+  value: JSON.stringify(opt),
+  text: opt.name,
+  description: opt.dataTypeLastLoaded && `Last Loaded: ${new Date(opt.dataTypeLastLoaded).toLocaleDateString()}`,
+  color: opt.dataTypeLastLoaded ? 'teal' : 'orange',
 })
 
 const renderLabel = ({ color, text }) => ({ color, content: text })

--- a/ui/pages/DataManagement/components/LoadData.jsx
+++ b/ui/pages/DataManagement/components/LoadData.jsx
@@ -16,7 +16,10 @@ import {
 const formatProjectOption = opt => ({
   value: JSON.stringify(opt),
   text: opt.name,
-  description: opt.dataTypeLastLoaded && `Last Loaded: ${new Date(opt.dataTypeLastLoaded).toLocaleDateString()}`,
+  description: [
+    opt.sampleIds && `${opt.sampleIds.length} Samples to Load`,
+    opt.dataTypeLastLoaded && `Last Loaded: ${new Date(opt.dataTypeLastLoaded).toLocaleDateString()}`,
+  ].filter(val => val).join('; '),
   color: opt.dataTypeLastLoaded ? 'teal' : 'orange',
 })
 


### PR DESCRIPTION
Ads the option to load SNV/INDEL data from the UI, and adds a check with airtable to only load projects that are ready for loading in airtable, and only load the subset of families that are actually updated. When this goes live it should work redundantly with the current airtable checks in airflow (so no issues should arise) and then after this is live those can be safely removed

Project dropdown UI:
<img width="1351" alt="Screenshot 2024-04-26 at 5 05 18 PM" src="https://github.com/broadinstitute/seqr/assets/24598672/746afb79-a93e-4877-ac8a-11c3a92ae6b5">