### PR TITLE
only show update transcript button to users with edit permission

### DIFF
--- a/ui/shared/components/panel/variants/Transcripts.jsx
+++ b/ui/shared/components/panel/variants/Transcripts.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { connect } from 'react-redux'
 import { Label, Header, Table, Segment } from 'semantic-ui-react'
 
-import { getGenesById, getTranscriptsById } from 'redux/selectors'
+import { getGenesById, getTranscriptsById, getFamiliesByGuid, getProjectsByGuid } from 'redux/selectors'
 import { updateVariantMainTranscript } from 'redux/rootReducer'
 import { VerticalSpacer } from '../../Spacers'
 import DispatchRequestButton from '../../buttons/DispatchRequestButton'
@@ -42,7 +42,7 @@ const TRANSCRIPT_LABELS = [
   },
 ]
 
-const Transcripts = React.memo(({ variant, genesById, transcriptsById, updateMainTranscript }) => (
+const Transcripts = React.memo(({ variant, genesById, transcriptsById, updateMainTranscript, project }) => (
   variant.transcripts && Object.entries(variant.transcripts).sort((transcriptsA, transcriptsB) => (
     Math.min(...transcriptsA[1].map(t => t.transcriptRank)) - Math.min(...transcriptsB[1].map(t => t.transcriptRank))
   )).map(([geneId, geneTranscripts]) => (
@@ -79,7 +79,7 @@ const Transcripts = React.memo(({ variant, genesById, transcriptsById, updateMai
                       )
                     ))}
                     {
-                      variant.variantGuid && (
+                      variant.variantGuid && project?.canEdit && (
                         <span>
                           <VerticalSpacer height={5} />
                           {
@@ -142,11 +142,13 @@ Transcripts.propTypes = {
   genesById: PropTypes.object.isRequired,
   transcriptsById: PropTypes.object.isRequired,
   updateMainTranscript: PropTypes.func.isRequired,
+  project: PropTypes.object,
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
   genesById: getGenesById(state),
   transcriptsById: getTranscriptsById(state),
+  project: getProjectsByGuid(state)[getFamiliesByGuid(state)[ownProps.variant.familyGuids[0]]?.projectGuid],
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({

--- a/ui/shared/components/panel/variants/Transcripts.test.js
+++ b/ui/shared/components/panel/variants/Transcripts.test.js
@@ -4,12 +4,12 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import configureStore from 'redux-mock-store'
 import Transcripts from './Transcripts'
 
-import { STATE1, GENE } from '../fixtures'
+import { STATE1, GENE, VARIANT } from '../fixtures'
 
 configure({ adapter: new Adapter() })
 
 test('shallow-render without crashing', () => {
   const store = configureStore()(STATE1)
 
-  shallow(<Transcripts store={store} gene={GENE} />)
+  shallow(<Transcripts store={store} gene={GENE} variant={VARIANT} />)
 })


### PR DESCRIPTION
The api endpoint associated with this button checks that users have edit permission on the project, but the button is shown to all users. This updates behavior so only users with permission see the button