### PR TITLE
better error handling when rna temp file missing

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -320,7 +320,11 @@ def load_rna_seq_sample_data(request, sample_guid):
     config = RNA_DATA_TYPE_CONFIGS[data_type]
 
     data_rows = _load_saved_sample_data(file_name, sample_guid)
-    data_rows, error = post_process_rna_data(sample_guid, data_rows, **config.get('post_process_kwargs', {}))
+    if data_rows:
+        data_rows, error = post_process_rna_data(sample_guid, data_rows, **config.get('post_process_kwargs', {}))
+    else:
+        logger.error(f'No saved temp data found for {sample_guid} with file prefix {file_name}', request.user)
+        error = f'Data for this sample was not properly parsed. Please re-upload the data'
     if error:
         return create_json_response({'error': error}, status=400)
 

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -324,7 +324,7 @@ def load_rna_seq_sample_data(request, sample_guid):
         data_rows, error = post_process_rna_data(sample_guid, data_rows, **config.get('post_process_kwargs', {}))
     else:
         logger.error(f'No saved temp data found for {sample_guid} with file prefix {file_name}', request.user)
-        error = f'Data for this sample was not properly parsed. Please re-upload the data'
+        error = 'Data for this sample was not properly parsed. Please re-upload the data'
     if error:
         return create_json_response({'error': error}, status=400)
 


### PR DESCRIPTION
There should never be a case where the load_data endpoint fails to find the file. However, it is currently happening, and while I still do not know why I do know that when it does happen it should return a human readable error and log an informative error to alert the seqr engineers, instead of returning an incomprehensible unhandled error