### PR TITLE
load all phenotpye priorities after viewing variant page

### DIFF
--- a/ui/pages/Project/components/PhenotypePrioritizedGenes.jsx
+++ b/ui/pages/Project/components/PhenotypePrioritizedGenes.jsx
@@ -24,6 +24,7 @@ const PHENOTYPE_GENE_INFO_COLUMNS = [
         compact
         showInlineDetails
         noExpand
+        hideLocusLists
       />
     ),
   },

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -330,7 +330,16 @@ export const loadRnaSeqData = individualGuid => (dispatch, getState) => {
 export const loadPhenotypeGeneScores = individualGuid => (dispatch, getState) => {
   const state = getState()
   const { familyGuid } = state.individualsByGuid[individualGuid]
-  if (!state.phenotypeGeneScoresByIndividual[individualGuid]) {
+  const loadedToolCounts = Object.values(state.phenotypeGeneScoresByIndividual[individualGuid] || {}).reduce(
+    (acc, dataByTool) => (
+      Object.entries(dataByTool).reduce((acc2, [tool, data]) => ({
+        ...acc2,
+        [tool]: (acc2[tool] || 0) + data.length,
+      }), acc)
+    ), {},
+  )
+  // Data can be loaded for only a subset of genes if previously loaded variant information
+  if (!Object.values(loadedToolCounts).some(val => val >= 10)) {
     dispatch({ type: REQUEST_PHENOTYPE_GENE_SCORES })
     new HttpRequestHelper(`/api/family/${familyGuid}/phenotype_gene_scores`,
       (responseJson) => {

--- a/ui/pages/Project/reducers.js
+++ b/ui/pages/Project/reducers.js
@@ -327,6 +327,8 @@ export const loadRnaSeqData = individualGuid => (dispatch, getState) => {
   }
 }
 
+const MAX_EXPECTED_PHENOTYPE_PRIORITY_RANK = 10
+
 export const loadPhenotypeGeneScores = individualGuid => (dispatch, getState) => {
   const state = getState()
   const { familyGuid } = state.individualsByGuid[individualGuid]
@@ -339,7 +341,8 @@ export const loadPhenotypeGeneScores = individualGuid => (dispatch, getState) =>
     ), {},
   )
   // Data can be loaded for only a subset of genes if previously loaded variant information
-  if (!Object.values(loadedToolCounts).some(val => val >= 10)) {
+  // The top 10 genes are expected to be loaded per tool, so load data if fewer than that are available
+  if (!Object.values(loadedToolCounts).some(val => val >= MAX_EXPECTED_PHENOTYPE_PRIORITY_RANK)) {
     dispatch({ type: REQUEST_PHENOTYPE_GENE_SCORES })
     new HttpRequestHelper(`/api/family/${familyGuid}/phenotype_gene_scores`,
       (responseJson) => {

--- a/ui/shared/components/panel/variants/VariantGene.jsx
+++ b/ui/shared/components/panel/variants/VariantGene.jsx
@@ -579,7 +579,7 @@ const getGeneConsequence = (geneId, variant) => {
 
 export const BaseVariantGene = React.memo(({
   geneId, gene, variant, compact, showInlineDetails, compoundHetToggle, tpmGenes, individualGeneData, geneModalId,
-  noExpand, geneSearchFamily,
+  noExpand, geneSearchFamily, hideLocusLists,
 }) => {
   const geneConsequence = variant && getGeneConsequence(geneId, variant)
 
@@ -598,7 +598,7 @@ export const BaseVariantGene = React.memo(({
       margin={showInlineDetails ? '1em .5em 0px 0px' : null}
       horizontal={showInlineDetails}
       individualGeneData={individualGeneData}
-      showLocusLists
+      showLocusLists={!hideLocusLists}
     />
   )
 
@@ -684,6 +684,7 @@ BaseVariantGene.propTypes = {
   geneModalId: PropTypes.string,
   noExpand: PropTypes.bool,
   geneSearchFamily: PropTypes.string,
+  hideLocusLists: PropTypes.bool,
   ...RNA_SEQ_PROP_TYPES,
 }
 


### PR DESCRIPTION
If a user goes to the saved variants/ variant search page and then goes to the family page and views phenotype prioritized data, the data has been loaded just for the genes in the search page which was causing it to not load all the data and instead only show a subset. This updates the code to check and ensure all the data is loaded and fetch if not. 

Once this issue was fixed, the genes for the laoded data had all the locus list info loaded but the other genes did not which was making the table look weird, so I also updated the display to explicitly not show locus lists in the prioritized phenotype table