### PR TITLE
Revert "Make metadata reports available to local users"

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -124,10 +124,12 @@ from seqr.views.apis.data_manager_api import elasticsearch_status, upload_qc_pip
     validate_callset, get_loaded_projects, load_data
 from seqr.views.apis.report_api import \
     anvil_export, \
+    family_metadata, \
+    variant_metadata, \
     gregor_export, \
     seqr_stats
 from seqr.views.apis.summary_data_api import success_story, saved_variants_page, mme_details, hpo_summary_data, \
-    bulk_update_family_external_analysis, individual_metadata, family_metadata, variant_metadata
+    bulk_update_family_external_analysis, individual_metadata
 from seqr.views.apis.superuser_api import get_all_users
 
 from seqr.views.apis.awesomebar_api import awesomebar_autocomplete_handler
@@ -318,6 +320,8 @@ api_endpoints = {
     'upload_temp_file': save_temp_file,
 
     'report/anvil/(?P<project_guid>[^/]+)': anvil_export,
+    'report/family_metadata/(?P<project_guid>[^/]+)': family_metadata,
+    'report/variant_metadata/(?P<project_guid>[^/]+)': variant_metadata,
     'report/gregor': gregor_export,
     'report/seqr_stats': seqr_stats,
 
@@ -340,8 +344,6 @@ api_endpoints = {
     'summary_data/matchmaker': mme_details,
     'summary_data/update_external_analysis': bulk_update_family_external_analysis,
     'summary_data/individual_metadata/(?P<project_guid>[^/]+)': individual_metadata,
-    'summary_data/family_metadata/(?P<project_guid>[^/]+)': family_metadata,
-    'summary_data/variant_metadata/(?P<project_guid>[^/]+)': variant_metadata,
 
     'create_project_from_workspace/(?P<namespace>[^/]+)/(?P<name>[^/]+)/grant_access': grant_workspace_access,
     'create_project_from_workspace/(?P<namespace>[^/]+)/(?P<name>[^/]+)/validate_vcf': validate_anvil_vcf,

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -20,6 +20,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.permissions_utils import analyst_required, get_project_and_check_permissions, \
     get_project_guids_user_can_view, get_internal_projects
 from seqr.views.utils.terra_api_utils import anvil_enabled
+from seqr.views.utils.variant_utils import DISCOVERY_CATEGORY
 
 from seqr.models import Project, Family, Sample, Individual
 from settings import GREGOR_DATA_MODEL_URL
@@ -790,3 +791,130 @@ def _validate_column_data(column, file_name, data, column_validator, warnings, e
 def _get_row_id(row):
     id_col = next(col for col in ['genetic_findings_id', 'participant_id', 'experiment_sample_id', 'family_id'] if col in row)
     return row[id_col]
+
+
+@analyst_required
+def family_metadata(request, project_guid):
+    projects = _get_metadata_projects(project_guid, request.user)
+
+    families_by_id = {}
+    family_individuals = defaultdict(dict)
+
+    def _add_row(row, family_id, row_type):
+        if row_type == FAMILY_ROW_TYPE:
+            families_by_id[family_id] = row
+        elif row_type == SUBJECT_ROW_TYPE:
+            family_individuals[family_id][row['participant_id']] = row
+        elif row_type == SAMPLE_ROW_TYPE:
+            family_individuals[family_id][row['participant_id']].update(row)
+        elif row_type == DISCOVERY_ROW_TYPE:
+            family = families_by_id[family_id]
+            if 'inheritance_models' not in family:
+                family.update({'genes': set(), 'inheritance_models': set()})
+            family['genes'].update({v.get('gene') or v.get('sv_name') or v.get('gene_id') or '' for v in row})
+            family['inheritance_models'].update({v['variant_inheritance'] for v in row})
+
+    parse_anvil_metadata(
+        projects, user=request.user, add_row=_add_row, omit_airtable=True, include_metadata=True, include_no_individual_families=True)
+
+    for family_id, f in families_by_id.items():
+        individuals_by_id = family_individuals[family_id]
+        proband = next((i for i in individuals_by_id.values() if i['proband_relationship'] == 'Self'), None)
+        individuals_ids = set(individuals_by_id.keys())
+        known_ids = {}
+        if proband:
+            known_ids = {
+                'proband_id': proband['participant_id'],
+                'paternal_id': proband['paternal_id'],
+                'maternal_id': proband['maternal_id'],
+            }
+            f.update(known_ids)
+            individuals_ids -= set(known_ids.values())
+
+        sorted_samples = sorted(individuals_by_id.values(), key=lambda x: x.get('date_data_generation', ''))
+        earliest_sample = next((s for s in [proband or {}] + sorted_samples if s.get('date_data_generation')), {})
+
+        inheritance_models = f.pop('inheritance_models', [])
+        f.update({
+            'individual_count': len(individuals_by_id),
+            'other_individual_ids':  '; '.join(sorted(individuals_ids)),
+            'family_structure': _get_family_structure(len(individuals_by_id), sum(1 for id in known_ids.values() if id)),
+            'data_type': earliest_sample.get('data_type'),
+            'date_data_generation': earliest_sample.get('date_data_generation'),
+            'genes': '; '.join(sorted(f.get('genes', []))),
+            'actual_inheritance': 'unknown' if inheritance_models == {'unknown'} else ';'.join(
+                sorted([i for i in inheritance_models if i != 'unknown'])),
+        })
+
+    return create_json_response({'rows': list(families_by_id.values())})
+
+
+def _get_metadata_projects(project_guid, user):
+    if project_guid == 'all':
+        return get_internal_projects()
+    if project_guid == GREGOR_CATEGORY.lower():
+        return Project.objects.filter(projectcategory__name=GREGOR_CATEGORY)
+    return [get_project_and_check_permissions(project_guid, user)]
+
+
+FAMILY_STRUCTURES = {
+    1: 'singleton',
+    2: 'duo',
+    3: 'trio',
+    4: 'quad',
+}
+
+
+def _get_family_structure(num_individuals, num_known_individuals):
+    if (num_individuals and num_known_individuals == num_individuals) or (
+            num_known_individuals in {0, 3} and num_individuals == num_known_individuals + 1):
+        return FAMILY_STRUCTURES[num_individuals]
+    return 'other'
+
+
+@analyst_required
+def variant_metadata(request, project_guid):
+    projects = _get_metadata_projects(project_guid, request.user)
+
+    individuals = Individual.objects.filter(
+        family__project__in=projects, family__savedvariant__varianttag__variant_tag_type__category=DISCOVERY_CATEGORY,
+    ).distinct().annotate(
+        data_types=ArrayAgg('sample__sample_type', distinct=True, filter=Q(sample__isnull=False))
+    )
+
+    families_by_id = {}
+    participant_mme = {}
+    variant_rows = []
+
+    def _add_row(row, family_id, row_type):
+        if row_type == FAMILY_ROW_TYPE:
+            families_by_id[family_id] = row
+        elif row_type == SUBJECT_ROW_TYPE:
+            participant_mme[row['participant_id']] = row.get('MME', {})
+        elif row_type == DISCOVERY_ROW_TYPE:
+            family = families_by_id[family_id]
+            for variant in row:
+                del variant['gene_ids']
+                variant_rows.append({
+                    'MME': variant.pop('variantId') in participant_mme[variant['participant_id']].get('variant_ids', []),
+                    'phenotype_contribution': 'Full',
+                    **family,
+                    **variant,
+                })
+
+    parse_anvil_metadata(
+        projects,
+        user=request.user,
+        individual_samples={i: None for i in individuals},
+        individual_data_types={i.individual_id: i.data_types for i in individuals},
+        add_row=_add_row,
+        variant_json_fields=['clinvar', 'variantId'],
+        mme_values={'variant_ids': ArrayAgg('matchmakersubmissiongenes__saved_variant__saved_variant_json__variantId')},
+        include_metadata=True,
+        include_mondo=True,
+        omit_airtable=True,
+        proband_only_variants=True,
+        include_parent_mnvs=True,
+    )
+
+    return create_json_response({'rows': variant_rows})

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -5,7 +5,7 @@ import responses
 from settings import AIRTABLE_URL
 
 from seqr.models import Project, SavedVariant
-from seqr.views.apis.report_api import seqr_stats, anvil_export, gregor_export
+from seqr.views.apis.report_api import seqr_stats, anvil_export, gregor_export, family_metadata, variant_metadata
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, AirtableTest
 
 
@@ -484,6 +484,31 @@ MOCK_INVALID_DATA_MODEL = {
             'columns': [{'column': 'analyte_id', 'required': True}],
         },
     ] + INVALID_TABLES
+}
+
+BASE_VARIANT_METADATA_ROW = {
+    'MME': False,
+    'additional_family_members_with_variant': '',
+    'allele_balance_or_heteroplasmy_percentage': None,
+    'analysisStatus': 'Q',
+    'analysis_groups': '',
+    'clinvar': None,
+    'condition_id': None,
+    'consanguinity': 'Unknown',
+    'end': None,
+    'hgvsc': '',
+    'hgvsp': '',
+    'method_of_discovery': 'SR-ES',
+    'notes': None,
+    'phenotype_contribution': 'Full',
+    'phenotype_description': None,
+    'pmid_id': None,
+    'seqr_chosen_consequence': None,
+    'solve_status': 'Unsolved',
+    'svName': None,
+    'svType': None,
+    'sv_name': None,
+    'transcript': None,
 }
 
 PARTICIPANT_TABLE = [
@@ -1074,9 +1099,238 @@ class ReportAPITest(AirtableTest):
 
         self.assertEqual(responses.calls[len(mondo_ids) + 3].request.url, MOCK_DATA_MODEL_URL)
 
+    def test_family_metadata(self):
+        url = reverse(family_metadata, args=['R0003_test'])
+        self.check_analyst_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertListEqual(list(response_json.keys()), ['rows'])
+        self.assertListEqual(sorted([r['familyGuid'] for r in response_json['rows']]), ['F000011_11', 'F000012_12'])
+        test_row = next(r for r in response_json['rows'] if r['familyGuid'] == 'F000012_12')
+        self.assertDictEqual(test_row, {
+            'projectGuid': 'R0003_test',
+            'internal_project_id': 'Test Reprocessed Project',
+            'familyGuid': 'F000012_12',
+            'family_id': '12',
+            'displayName': '12',
+            'solve_status': 'Unsolved',
+            'actual_inheritance': 'unknown',
+            'date_data_generation': '2017-02-05',
+            'data_type': 'WES',
+            'proband_id': 'NA20889',
+            'maternal_id': '',
+            'paternal_id': '',
+            'other_individual_ids': 'NA20870; NA20888',
+            'individual_count': 3,
+            'family_structure': 'other',
+            'family_history': 'Yes',
+            'genes': 'DEL:chr1:249045487-249045898; OR4G11P',
+            'pmid_id': None,
+            'phenotype_description': None,
+            'analysisStatus': 'Q',
+            'analysis_groups': '',
+            'consanguinity': 'Unknown',
+        })
+
+        # Test all projects
+        all_projects_url = reverse(family_metadata, args=['all'])
+        response = self.client.get(all_projects_url)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertListEqual(list(response_json.keys()), ['rows'])
+        self.assertListEqual(sorted([r['familyGuid'] for r in response_json['rows']]), [
+            'F000001_1', 'F000002_2', 'F000003_3', 'F000004_4', 'F000005_5', 'F000006_6', 'F000007_7', 'F000008_8',
+            'F000009_9', 'F000010_10', 'F000011_11', 'F000012_12', 'F000013_13'] + self.ADDITIONAL_FAMILIES)
+        test_row = next(r for r in response_json['rows'] if r['familyGuid'] == 'F000003_3')
+        self.assertDictEqual(test_row, {
+            'projectGuid': 'R0001_1kg',
+            'internal_project_id': '1kg project nåme with uniçøde',
+            'familyGuid': 'F000003_3',
+            'family_id': '3',
+            'displayName': '3',
+            'solve_status': 'Unsolved',
+            'actual_inheritance': '',
+            'date_data_generation': '2017-02-05',
+            'data_type': 'WES',
+            'other_individual_ids': 'NA20870',
+            'individual_count': 1,
+            'family_structure': 'singleton',
+            'genes': '',
+            'pmid_id': None,
+            'phenotype_description': None,
+            'analysisStatus': 'Q',
+            'analysis_groups': 'Accepted; Test Group 1',
+            'consanguinity': 'Unknown',
+            'condition_id': 'OMIM:615123',
+            'known_condition_name': '',
+            'condition_inheritance': 'Unknown',
+        })
+
+        # Test empty project
+        empty_project_url = reverse(family_metadata, args=['R0002_empty'])
+        response = self.client.get(empty_project_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), {'rows': []})
+
+    def test_variant_metadata(self):
+        url = reverse(variant_metadata, args=[PROJECT_GUID])
+        self.check_analyst_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertListEqual(list(response_json.keys()), ['rows'])
+        row_ids = ['NA19675_1_21_3343353', 'HG00731_1_248367227', 'HG00731_19_1912634', 'HG00731_19_1912633', 'HG00731_19_1912632']
+        self.assertListEqual([r['genetic_findings_id'] for r in response_json['rows']], row_ids)
+        expected_row = {
+            **BASE_VARIANT_METADATA_ROW,
+            'additional_family_members_with_variant': 'HG00732',
+            'alt': 'T',
+            'chrom': '1',
+            'clinvar': {'alleleId': None, 'clinicalSignificance': '', 'goldStars': None, 'variationId': None},
+            'condition_id': 'MONDO:0044970',
+            'condition_inheritance': None,
+            'displayName': '2',
+            'familyGuid': 'F000002_2',
+            'family_id': '2',
+            'gene': 'RP11',
+            'gene_id': 'ENSG00000135953',
+            'gene_known_for_phenotype': 'Known',
+            'genetic_findings_id': 'HG00731_1_248367227',
+            'known_condition_name': 'mitochondrial disease',
+            'participant_id': 'HG00731',
+            'phenotype_contribution': 'Full',
+            'phenotype_description': 'microcephaly; seizures',
+            'pos': 248367227,
+            'projectGuid': 'R0001_1kg',
+            'internal_project_id': '1kg project nåme with uniçøde',
+            'ref': 'TC',
+            'tags': ['Known gene for phenotype'],
+            'variant_inheritance': 'paternal',
+            'variant_reference_assembly': 'GRCh37',
+            'zygosity': 'Homozygous',
+        }
+        self.assertDictEqual(response_json['rows'][1], expected_row)
+        expected_mnv = {
+            **BASE_VARIANT_METADATA_ROW,
+            'alt': 'T',
+            'chrom': '19',
+            'condition_id': 'MONDO:0044970',
+            'condition_inheritance': None,
+            'displayName': '2',
+            'end': 1912634,
+            'familyGuid': 'F000002_2',
+            'family_id': '2',
+            'gene': 'OR4G11P',
+            'gene_id': 'ENSG00000240361',
+            'gene_known_for_phenotype': 'Known',
+            'genetic_findings_id': 'HG00731_19_1912634',
+            'known_condition_name': 'mitochondrial disease',
+            'notes': 'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, p.Ala196Leu): 19-1912633-G-T, 19-1912634-C-T',
+            'participant_id': 'HG00731',
+            'phenotype_description': 'microcephaly; seizures',
+            'pos': 1912634,
+            'projectGuid': 'R0001_1kg',
+            'internal_project_id': '1kg project nåme with uniçøde',
+            'ref': 'C',
+            'tags': ['Known gene for phenotype'],
+            'transcript': 'ENST00000371839',
+            'variant_inheritance': 'unknown',
+            'variant_reference_assembly': 'GRCh38',
+            'zygosity': 'Heterozygous',
+        }
+        self.assertDictEqual(response_json['rows'][2], expected_mnv)
+
+        # Test gregor projects
+        gregor_projects_url = reverse(variant_metadata, args=['gregor'])
+        response = self.client.get(gregor_projects_url)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertListEqual(list(response_json.keys()), ['rows'])
+        row_ids += ['NA20889_1_248367227', 'NA20889_1_249045487']
+        self.assertListEqual([r['genetic_findings_id'] for r in response_json['rows']], row_ids)
+        self.assertDictEqual(response_json['rows'][1], expected_row)
+        self.assertDictEqual(response_json['rows'][2], expected_mnv)
+        self.assertDictEqual(response_json['rows'][5], {
+            **BASE_VARIANT_METADATA_ROW,
+            'MME': True,
+            'alt': 'T',
+            'chrom': '1',
+            'clinvar': {'alleleId': None, 'clinicalSignificance': '', 'goldStars': None, 'variationId': None},
+            'condition_id': 'MONDO:0008788',
+            'displayName': '12',
+            'familyGuid': 'F000012_12',
+            'family_id': '12',
+            'family_history': 'Yes',
+            'gene': 'OR4G11P',
+            'gene_id': 'ENSG00000240361',
+            'gene_known_for_phenotype': 'Candidate',
+            'genetic_findings_id': 'NA20889_1_248367227',
+            'hgvsc': 'c.3955G>A',
+            'hgvsp': 'c.1586-17C>G',
+            'participant_id': 'NA20889',
+            'pos': 248367227,
+            'projectGuid': 'R0003_test',
+            'internal_project_id': 'Test Reprocessed Project',
+            'ref': 'TC',
+            'seqr_chosen_consequence': 'intron_variant',
+            'tags': ['Tier 1 - Novel gene and phenotype'],
+            'transcript': 'ENST00000505820',
+            'variant_inheritance': 'unknown',
+            'variant_reference_assembly': 'GRCh37',
+            'zygosity': 'Heterozygous',
+        })
+        self.assertDictEqual(response_json['rows'][6], {
+            **BASE_VARIANT_METADATA_ROW,
+            'alt': None,
+            'chrom': '1',
+            'condition_id': 'MONDO:0008788',
+            'displayName': '12',
+            'end': 249045898,
+            'familyGuid': 'F000012_12',
+            'family_id': '12',
+            'family_history': 'Yes',
+            'gene': None,
+            'gene_id': None,
+            'gene_known_for_phenotype': 'Candidate',
+            'genetic_findings_id': 'NA20889_1_249045487',
+            'participant_id': 'NA20889',
+            'pos': 249045487,
+            'projectGuid': 'R0003_test',
+            'internal_project_id': 'Test Reprocessed Project',
+            'ref': None,
+            'svType': 'DEL',
+            'sv_name': 'DEL:chr1:249045487-249045898',
+            'tags': ['Tier 1 - Novel gene and phenotype'],
+            'variant_inheritance': 'unknown',
+            'variant_reference_assembly': 'GRCh37',
+            'zygosity': 'Heterozygous',
+        })
+
+        # Test all projects
+        all_projects_url = reverse(variant_metadata, args=['all'])
+        response = self.client.get(all_projects_url)
+        self.assertEqual(response.status_code, 200)
+        response_json = response.json()
+        self.assertListEqual(list(response_json.keys()), ['rows'])
+        row_ids += self.ADDITIONAL_FINDINGS
+        self.assertListEqual([r['genetic_findings_id'] for r in response_json['rows']], row_ids)
+        self.assertDictEqual(response_json['rows'][1], expected_row)
+        self.assertDictEqual(response_json['rows'][2], expected_mnv)
+
+        # Test empty project
+        empty_project_url = reverse(family_metadata, args=['R0002_empty'])
+        response = self.client.get(empty_project_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.json(), {'rows': []})
+
 
 class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
     fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
+    ADDITIONAL_FAMILIES = ['F000014_14']
+    ADDITIONAL_FINDINGS = ['NA21234_1_248367227']
     STATS_DATA = {
         'projectsCount': {'non_demo': 3, 'demo': 1},
         'familiesCount': {'non_demo': 12, 'demo': 2},
@@ -1093,6 +1347,8 @@ class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
 
 class AnvilReportAPITest(AnvilAuthenticationTestCase, ReportAPITest):
     fixtures = ['users', 'social_auth', '1kg_project', 'reference_data', 'report_variants']
+    ADDITIONAL_FAMILIES = []
+    ADDITIONAL_FINDINGS = []
     STATS_DATA = {
         'projectsCount': {'internal': 1, 'external': 1, 'no_anvil': 1, 'demo': 1},
         'familiesCount': {'internal': 11, 'external': 1, 'no_anvil': 0, 'demo': 2},

--- a/seqr/views/apis/summary_data_api.py
+++ b/seqr/views/apis/summary_data_api.py
@@ -2,8 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import User
-from django.contrib.postgres.aggregates import ArrayAgg
-from django.db.models import CharField, F, Q, Value
+from django.db.models import CharField, F, Value
 from django.db.models.functions import Coalesce, Concat, JSONObject, NullIf
 import json
 from random import randint
@@ -24,7 +23,7 @@ from seqr.views.utils.orm_to_json_utils import get_json_for_matchmaker_submissio
     add_individual_hpo_details, INDIVIDUAL_DISPLAY_NAME_EXPR, AIP_TAG_TYPE
 from seqr.views.utils.permissions_utils import analyst_required, user_is_analyst, get_project_guids_user_can_view, \
     login_and_policies_required, get_project_and_check_permissions, get_internal_projects
-from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, FAMILY_ROW_TYPE, SUBJECT_ROW_TYPE, SAMPLE_ROW_TYPE, DISCOVERY_ROW_TYPE
+from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, FAMILY_ROW_TYPE, SUBJECT_ROW_TYPE, DISCOVERY_ROW_TYPE
 from seqr.views.utils.variant_utils import get_variants_response, bulk_create_tagged_variants, DISCOVERY_CATEGORY
 from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL
 
@@ -349,122 +348,3 @@ def _get_airtable_collaborator_names(user, collaborator_ids):
         collaborator_id: collaborator_map.get(collaborator_id, {}).get('CollaboratorID')
         for collaborator_id in collaborator_ids
     }
-
-
-@login_and_policies_required
-def family_metadata(request, project_guid):
-    projects, _ = _get_metadata_projects(request, project_guid)
-
-    families_by_id = {}
-    family_individuals = defaultdict(dict)
-
-    def _add_row(row, family_id, row_type):
-        if row_type == FAMILY_ROW_TYPE:
-            families_by_id[family_id] = row
-        elif row_type == SUBJECT_ROW_TYPE:
-            family_individuals[family_id][row['participant_id']] = row
-        elif row_type == SAMPLE_ROW_TYPE:
-            family_individuals[family_id][row['participant_id']].update(row)
-        elif row_type == DISCOVERY_ROW_TYPE:
-            family = families_by_id[family_id]
-            if 'inheritance_models' not in family:
-                family.update({'genes': set(), 'inheritance_models': set()})
-            family['genes'].update({v.get('gene') or v.get('sv_name') or v.get('gene_id') or '' for v in row})
-            family['inheritance_models'].update({v['variant_inheritance'] for v in row})
-
-    parse_anvil_metadata(
-        projects, user=request.user, add_row=_add_row, omit_airtable=True, include_metadata=True, include_no_individual_families=True)
-
-    for family_id, f in families_by_id.items():
-        individuals_by_id = family_individuals[family_id]
-        proband = next((i for i in individuals_by_id.values() if i['proband_relationship'] == 'Self'), None)
-        individuals_ids = set(individuals_by_id.keys())
-        known_ids = {}
-        if proband:
-            known_ids = {
-                'proband_id': proband['participant_id'],
-                'paternal_id': proband['paternal_id'],
-                'maternal_id': proband['maternal_id'],
-            }
-            f.update(known_ids)
-            individuals_ids -= set(known_ids.values())
-
-        sorted_samples = sorted(individuals_by_id.values(), key=lambda x: x.get('date_data_generation', ''))
-        earliest_sample = next((s for s in [proband or {}] + sorted_samples if s.get('date_data_generation')), {})
-
-        inheritance_models = f.pop('inheritance_models', [])
-        f.update({
-            'individual_count': len(individuals_by_id),
-            'other_individual_ids':  '; '.join(sorted(individuals_ids)),
-            'family_structure': _get_family_structure(len(individuals_by_id), sum(1 for id in known_ids.values() if id)),
-            'data_type': earliest_sample.get('data_type'),
-            'date_data_generation': earliest_sample.get('date_data_generation'),
-            'genes': '; '.join(sorted(f.get('genes', []))),
-            'actual_inheritance': 'unknown' if inheritance_models == {'unknown'} else ';'.join(
-                sorted([i for i in inheritance_models if i != 'unknown'])),
-        })
-
-    return create_json_response({'rows': list(families_by_id.values())})
-
-
-FAMILY_STRUCTURES = {
-    1: 'singleton',
-    2: 'duo',
-    3: 'trio',
-    4: 'quad',
-}
-
-
-def _get_family_structure(num_individuals, num_known_individuals):
-    if (num_individuals and num_known_individuals == num_individuals) or (
-            num_known_individuals in {0, 3} and num_individuals == num_known_individuals + 1):
-        return FAMILY_STRUCTURES[num_individuals]
-    return 'other'
-
-
-@login_and_policies_required
-def variant_metadata(request, project_guid):
-    projects, _ = _get_metadata_projects(request, project_guid)
-
-    individuals = Individual.objects.filter(
-        family__project__in=projects, family__savedvariant__varianttag__variant_tag_type__category=DISCOVERY_CATEGORY,
-    ).distinct().annotate(
-        data_types=ArrayAgg('sample__sample_type', distinct=True, filter=Q(sample__isnull=False))
-    )
-
-    families_by_id = {}
-    participant_mme = {}
-    variant_rows = []
-
-    def _add_row(row, family_id, row_type):
-        if row_type == FAMILY_ROW_TYPE:
-            families_by_id[family_id] = row
-        elif row_type == SUBJECT_ROW_TYPE:
-            participant_mme[row['participant_id']] = row.get('MME', {})
-        elif row_type == DISCOVERY_ROW_TYPE:
-            family = families_by_id[family_id]
-            for variant in row:
-                del variant['gene_ids']
-                variant_rows.append({
-                    'MME': variant.pop('variantId') in participant_mme[variant['participant_id']].get('variant_ids', []),
-                    'phenotype_contribution': 'Full',
-                    **family,
-                    **variant,
-                })
-
-    parse_anvil_metadata(
-        projects,
-        user=request.user,
-        individual_samples={i: None for i in individuals},
-        individual_data_types={i.individual_id: i.data_types for i in individuals},
-        add_row=_add_row,
-        variant_json_fields=['clinvar', 'variantId'],
-        mme_values={'variant_ids': ArrayAgg('matchmakersubmissiongenes__saved_variant__saved_variant_json__variantId')},
-        include_metadata=True,
-        include_mondo=True,
-        omit_airtable=True,
-        proband_only_variants=True,
-        include_parent_mnvs=True,
-    )
-
-    return create_json_response({'rows': variant_rows})

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -6,7 +6,7 @@ import mock
 import responses
 
 from seqr.views.apis.summary_data_api import mme_details, success_story, saved_variants_page, hpo_summary_data, \
-    bulk_update_family_external_analysis, individual_metadata, family_metadata, variant_metadata
+    bulk_update_family_external_analysis, individual_metadata
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, AirtableTest, PARSED_VARIANTS
 from seqr.models import FamilyAnalysedBy, SavedVariant, VariantTag
 from settings import AIRTABLE_URL
@@ -250,32 +250,6 @@ AIRTABLE_COLLABORATOR_RECORDS = {
 }
 
 
-BASE_VARIANT_METADATA_ROW = {
-    'MME': False,
-    'additional_family_members_with_variant': '',
-    'allele_balance_or_heteroplasmy_percentage': None,
-    'analysisStatus': 'Q',
-    'analysis_groups': '',
-    'clinvar': None,
-    'condition_id': None,
-    'consanguinity': 'Unknown',
-    'end': None,
-    'hgvsc': '',
-    'hgvsp': '',
-    'method_of_discovery': 'SR-ES',
-    'notes': None,
-    'phenotype_contribution': 'Full',
-    'phenotype_description': None,
-    'pmid_id': None,
-    'seqr_chosen_consequence': None,
-    'solve_status': 'Unsolved',
-    'svName': None,
-    'svType': None,
-    'sv_name': None,
-    'transcript': None,
-}
-
-
 @mock.patch('seqr.views.utils.permissions_utils.safe_redis_get_json', lambda *args: None)
 class SummaryDataAPITest(AirtableTest):
 
@@ -374,10 +348,6 @@ class SummaryDataAPITest(AirtableTest):
         all_tag_url = reverse(saved_variants_page, args=['ALL'])
         response = self.client.get('{}?gene=ENSG00000135953'.format(all_tag_url))
         self.assertEqual(response.status_code, 200)
-        report_variant_guids = {
-            'SV0027168_191912632_r0384_rare', 'SV0027167_191912633_r0384_rare', 'SV0027166_191912634_r0384_rare',
-        }
-        expected_variant_guids.update(report_variant_guids)
         expected_variant_guids.add('SV0000002_1248367227_r0390_100')
         self.assertSetEqual(set(response.json()['savedVariantsByGuid'].keys()), expected_variant_guids)
 
@@ -396,7 +366,7 @@ class SummaryDataAPITest(AirtableTest):
         self.assertEqual(response.status_code, 200)
         self.assertSetEqual(set(response.json()['savedVariantsByGuid'].keys()), {
             'SV0000001_2103343353_r0390_100', 'SV0000002_1248367227_r0390_100', 'SV0000007_prefix_19107_DEL_r00',
-            'SV0000006_1248367227_r0003_tes', *report_variant_guids,
+            'SV0000006_1248367227_r0003_tes',
         })
 
         multi_discovery_tag_url = reverse(saved_variants_page, args=['CMG Discovery Tags;Review'])
@@ -731,253 +701,12 @@ class SummaryDataAPITest(AirtableTest):
         response = self.client.get(f'{gregor_projects_url}?includeAirtable=true')
         self._has_expected_metadata_response(response, multi_project_individuals, has_airtable=True, has_duplicate=True)
 
-    def test_family_metadata(self):
-        url = reverse(family_metadata, args=['R0003_test'])
-        self.check_collaborator_login(url)
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        self.assertListEqual(list(response_json.keys()), ['rows'])
-        self.assertListEqual(sorted([r['familyGuid'] for r in response_json['rows']]), ['F000011_11', 'F000012_12'])
-        test_row = next(r for r in response_json['rows'] if r['familyGuid'] == 'F000012_12')
-        self.assertDictEqual(test_row, {
-            'projectGuid': 'R0003_test',
-            'internal_project_id': 'Test Reprocessed Project',
-            'familyGuid': 'F000012_12',
-            'family_id': '12',
-            'displayName': '12',
-            'solve_status': 'Unsolved',
-            'actual_inheritance': 'unknown',
-            'date_data_generation': '2017-02-05',
-            'data_type': 'WES',
-            'proband_id': 'NA20889',
-            'maternal_id': '',
-            'paternal_id': '',
-            'other_individual_ids': 'NA20870; NA20888',
-            'individual_count': 3,
-            'family_structure': 'other',
-            'family_history': 'Yes',
-            'genes': 'DEL:chr1:249045487-249045898; OR4G11P',
-            'pmid_id': None,
-            'phenotype_description': None,
-            'analysisStatus': 'Q',
-            'analysis_groups': '',
-            'consanguinity': 'Unknown',
-        })
-
-        # Test all projects
-        all_projects_url = reverse(family_metadata, args=['all'])
-        response = self.client.get(all_projects_url)
-        self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        self.assertListEqual(list(response_json.keys()), ['rows'])
-        all_project_families = [
-            'F000001_1', 'F000002_2', 'F000003_3', 'F000004_4', 'F000005_5', 'F000006_6', 'F000007_7', 'F000008_8',
-            'F000009_9', 'F000010_10', 'F000011_11', 'F000012_12', 'F000013_13']
-        self.assertListEqual(sorted([r['familyGuid'] for r in response_json['rows']]), all_project_families)
-        test_row = next(r for r in response_json['rows'] if r['familyGuid'] == 'F000003_3')
-        self.assertDictEqual(test_row, {
-            'projectGuid': 'R0001_1kg',
-            'internal_project_id': '1kg project nåme with uniçøde',
-            'familyGuid': 'F000003_3',
-            'family_id': '3',
-            'displayName': '3',
-            'solve_status': 'Unsolved',
-            'actual_inheritance': '',
-            'date_data_generation': '2017-02-05',
-            'data_type': 'WES',
-            'other_individual_ids': 'NA20870',
-            'individual_count': 1,
-            'family_structure': 'singleton',
-            'genes': '',
-            'pmid_id': None,
-            'phenotype_description': None,
-            'analysisStatus': 'Q',
-            'analysis_groups': 'Accepted; Test Group 1',
-            'consanguinity': 'Unknown',
-            'condition_id': 'OMIM:615123',
-            'known_condition_name': '',
-            'condition_inheritance': 'Unknown',
-        })
-
-        # Test analyst access
-        self.login_analyst_user()
-        response = self.client.get(all_projects_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertListEqual(
-            sorted([r['familyGuid'] for r in response.json()['rows']]), all_project_families + self.ADDITIONAL_FAMILIES)
-
-        # Test empty project
-        empty_project_url = reverse(family_metadata, args=['R0002_empty'])
-        response = self.client.get(empty_project_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'rows': []})
-
-    def test_variant_metadata(self):
-        url = reverse(variant_metadata, args=[PROJECT_GUID])
-        self.check_collaborator_login(url)
-
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        self.assertListEqual(list(response_json.keys()), ['rows'])
-        row_ids = ['NA19675_1_21_3343353', 'HG00731_1_248367227', 'HG00731_19_1912634', 'HG00731_19_1912633', 'HG00731_19_1912632']
-        self.assertListEqual([r['genetic_findings_id'] for r in response_json['rows']], row_ids)
-        expected_row = {
-            **BASE_VARIANT_METADATA_ROW,
-            'additional_family_members_with_variant': 'HG00732',
-            'alt': 'T',
-            'chrom': '1',
-            'clinvar': {'alleleId': None, 'clinicalSignificance': '', 'goldStars': None, 'variationId': None},
-            'condition_id': 'MONDO:0044970',
-            'condition_inheritance': None,
-            'displayName': '2',
-            'familyGuid': 'F000002_2',
-            'family_id': '2',
-            'gene': 'RP11',
-            'gene_id': 'ENSG00000135953',
-            'gene_known_for_phenotype': 'Known',
-            'genetic_findings_id': 'HG00731_1_248367227',
-            'known_condition_name': 'mitochondrial disease',
-            'participant_id': 'HG00731',
-            'phenotype_contribution': 'Full',
-            'phenotype_description': 'microcephaly; seizures',
-            'pos': 248367227,
-            'projectGuid': 'R0001_1kg',
-            'internal_project_id': '1kg project nåme with uniçøde',
-            'ref': 'TC',
-            'tags': ['Known gene for phenotype'],
-            'variant_inheritance': 'paternal',
-            'variant_reference_assembly': 'GRCh37',
-            'zygosity': 'Homozygous',
-        }
-        self.assertDictEqual(response_json['rows'][1], expected_row)
-        expected_mnv = {
-            **BASE_VARIANT_METADATA_ROW,
-            'alt': 'T',
-            'chrom': '19',
-            'condition_id': 'MONDO:0044970',
-            'condition_inheritance': None,
-            'displayName': '2',
-            'end': 1912634,
-            'familyGuid': 'F000002_2',
-            'family_id': '2',
-            'gene': 'OR4G11P',
-            'gene_id': 'ENSG00000240361',
-            'gene_known_for_phenotype': 'Known',
-            'genetic_findings_id': 'HG00731_19_1912634',
-            'known_condition_name': 'mitochondrial disease',
-            'notes': 'The following variants are part of the multinucleotide variant 19-1912632-GC-TT (c.586_587delinsTT, p.Ala196Leu): 19-1912633-G-T, 19-1912634-C-T',
-            'participant_id': 'HG00731',
-            'phenotype_description': 'microcephaly; seizures',
-            'pos': 1912634,
-            'projectGuid': 'R0001_1kg',
-            'internal_project_id': '1kg project nåme with uniçøde',
-            'ref': 'C',
-            'tags': ['Known gene for phenotype'],
-            'transcript': 'ENST00000371839',
-            'variant_inheritance': 'unknown',
-            'variant_reference_assembly': 'GRCh38',
-            'zygosity': 'Heterozygous',
-        }
-        self.assertDictEqual(response_json['rows'][2], expected_mnv)
-
-        # Test gregor projects
-        gregor_projects_url = reverse(variant_metadata, args=['gregor'])
-        response = self.client.get(gregor_projects_url)
-        self.assertEqual(response.status_code, 403)
-
-        self.login_analyst_user()
-        response = self.client.get(gregor_projects_url)
-        self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        self.assertListEqual(list(response_json.keys()), ['rows'])
-        row_ids += ['NA20889_1_248367227', 'NA20889_1_249045487']
-        self.assertListEqual([r['genetic_findings_id'] for r in response_json['rows']], row_ids)
-        self.assertDictEqual(response_json['rows'][1], expected_row)
-        self.assertDictEqual(response_json['rows'][2], expected_mnv)
-        self.assertDictEqual(response_json['rows'][5], {
-            **BASE_VARIANT_METADATA_ROW,
-            'MME': True,
-            'alt': 'T',
-            'chrom': '1',
-            'clinvar': {'alleleId': None, 'clinicalSignificance': '', 'goldStars': None, 'variationId': None},
-            'condition_id': 'MONDO:0008788',
-            'displayName': '12',
-            'familyGuid': 'F000012_12',
-            'family_id': '12',
-            'family_history': 'Yes',
-            'gene': 'OR4G11P',
-            'gene_id': 'ENSG00000240361',
-            'gene_known_for_phenotype': 'Candidate',
-            'genetic_findings_id': 'NA20889_1_248367227',
-            'hgvsc': 'c.3955G>A',
-            'hgvsp': 'c.1586-17C>G',
-            'participant_id': 'NA20889',
-            'pos': 248367227,
-            'projectGuid': 'R0003_test',
-            'internal_project_id': 'Test Reprocessed Project',
-            'ref': 'TC',
-            'seqr_chosen_consequence': 'intron_variant',
-            'tags': ['Tier 1 - Novel gene and phenotype'],
-            'transcript': 'ENST00000505820',
-            'variant_inheritance': 'unknown',
-            'variant_reference_assembly': 'GRCh37',
-            'zygosity': 'Heterozygous',
-        })
-        self.assertDictEqual(response_json['rows'][6], {
-            **BASE_VARIANT_METADATA_ROW,
-            'alt': None,
-            'chrom': '1',
-            'condition_id': 'MONDO:0008788',
-            'displayName': '12',
-            'end': 249045898,
-            'familyGuid': 'F000012_12',
-            'family_id': '12',
-            'family_history': 'Yes',
-            'gene': None,
-            'gene_id': None,
-            'gene_known_for_phenotype': 'Candidate',
-            'genetic_findings_id': 'NA20889_1_249045487',
-            'participant_id': 'NA20889',
-            'pos': 249045487,
-            'projectGuid': 'R0003_test',
-            'internal_project_id': 'Test Reprocessed Project',
-            'ref': None,
-            'svType': 'DEL',
-            'sv_name': 'DEL:chr1:249045487-249045898',
-            'tags': ['Tier 1 - Novel gene and phenotype'],
-            'variant_inheritance': 'unknown',
-            'variant_reference_assembly': 'GRCh37',
-            'zygosity': 'Heterozygous',
-        })
-
-        # Test all projects
-        all_projects_url = reverse(variant_metadata, args=['all'])
-        response = self.client.get(all_projects_url)
-        self.assertEqual(response.status_code, 200)
-        response_json = response.json()
-        self.assertListEqual(list(response_json.keys()), ['rows'])
-        row_ids += self.ADDITIONAL_FINDINGS
-        self.assertListEqual([r['genetic_findings_id'] for r in response_json['rows']], row_ids)
-        self.assertDictEqual(response_json['rows'][1], expected_row)
-        self.assertDictEqual(response_json['rows'][2], expected_mnv)
-
-        # Test empty project
-        empty_project_url = reverse(family_metadata, args=['R0002_empty'])
-        response = self.client.get(empty_project_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'rows': []})
-
 
 # Tests for AnVIL access disabled
 class LocalSummaryDataAPITest(AuthenticationTestCase, SummaryDataAPITest):
-    fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
+    fixtures = ['users', '1kg_project', 'reference_data']
     NUM_MANAGER_SUBMISSIONS = 4
     ADDITIONAL_SAMPLES = ['NA21234', 'NA21987']
-    ADDITIONAL_FAMILIES = ['F000014_14']
-    ADDITIONAL_FINDINGS = ['NA21234_1_248367227']
 
 
 def assert_has_expected_calls(self, users, skip_group_call_idxs=None):
@@ -991,11 +720,9 @@ def assert_has_expected_calls(self, users, skip_group_call_idxs=None):
 
 # Test for permissions from AnVIL only
 class AnvilSummaryDataAPITest(AnvilAuthenticationTestCase, SummaryDataAPITest):
-    fixtures = ['users', 'social_auth', '1kg_project', 'reference_data', 'report_variants']
+    fixtures = ['users', 'social_auth', '1kg_project', 'reference_data']
     NUM_MANAGER_SUBMISSIONS = 4
     ADDITIONAL_SAMPLES = []
-    ADDITIONAL_FAMILIES = []
-    ADDITIONAL_FINDINGS = []
 
     def test_mme_details(self, *args):
         super(AnvilSummaryDataAPITest, self).test_mme_details(*args)

--- a/ui/pages/Report/Report.jsx
+++ b/ui/pages/Report/Report.jsx
@@ -8,12 +8,16 @@ import { Error404, Error401 } from 'shared/components/page/Errors'
 
 import Anvil from './components/Anvil'
 import CustomSearch from './components/CustomSearch'
+import FamilyMetadata from './components/FamilyMetadata'
 import Gregor from './components/Gregor'
 import SeqrStats from './components/SeqrStats'
+import VariantMetadata from './components/VariantMetadata'
 
 export const REPORT_PAGES = [
   { path: 'anvil', component: Anvil },
   { path: 'custom_search', params: '/:searchHash?', component: CustomSearch },
+  { path: 'family_metadata', params: '/:projectGuid?', component: FamilyMetadata },
+  { path: 'variant_metadata', params: '/:projectGuid?', component: VariantMetadata },
   { path: 'gregor', component: Gregor },
   { path: 'seqr_stats', component: SeqrStats },
 ]

--- a/ui/pages/Report/components/FamilyMetadata.jsx
+++ b/ui/pages/Report/components/FamilyMetadata.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 
+import LoadReportTable from 'shared/components/table/LoadReportTable'
 import { FAMILY_ANALYSIS_STATUS_LOOKUP } from 'shared/utils/constants'
-import LoadReportTable from './LoadReportTable'
+
+const VIEW_ALL_PAGES = [{ name: 'Broad', downloadName: 'All', path: 'all' }]
 
 const COLUMNS = [
   { name: 'data_type' },
@@ -31,8 +33,10 @@ const COLUMNS = [
 const FamilyMetadata = props => (
   <LoadReportTable
     columns={COLUMNS}
-    urlPath="family_metadata"
+    viewAllPages={VIEW_ALL_PAGES}
+    urlBase="report/family_metadata"
     idField="family_id"
+    fileName="Family_Metadata"
     {...props}
   />
 )

--- a/ui/pages/Report/components/VariantMetadata.jsx
+++ b/ui/pages/Report/components/VariantMetadata.jsx
@@ -1,7 +1,12 @@
 import React from 'react'
 
+import LoadReportTable from 'shared/components/table/LoadReportTable'
 import { clinvarSignificance, VARIANT_METADATA_COLUMNS } from 'shared/utils/constants'
-import LoadReportTable from './LoadReportTable'
+
+const VIEW_ALL_PAGES = [
+  { name: 'GREGoR', downloadName: 'GREGoR', path: 'gregor' },
+  { name: 'Broad', downloadName: 'All', path: 'all' },
+]
 
 const COLUMNS = [
   { name: 'participant_id' },
@@ -24,8 +29,10 @@ const COLUMNS = [
 const FamilyMetadata = props => (
   <LoadReportTable
     columns={COLUMNS}
-    urlPath="variant_metadata"
+    viewAllPages={VIEW_ALL_PAGES}
+    urlBase="report/variant_metadata"
     idField="genetic_findings_id"
+    fileName="Variant_Metadata"
     {...props}
   />
 )

--- a/ui/pages/SummaryData/SummaryData.jsx
+++ b/ui/pages/SummaryData/SummaryData.jsx
@@ -15,8 +15,6 @@ import GeneInfoSearch from './components/GeneInfoSearch'
 import LocusLists from './components/LocusLists'
 import ExternalAnalysis from './components/ExternalAnalysis'
 import Hpo from './components/Hpo'
-import FamilyMetadata from './components/FamilyMetadata'
-import VariantMetadata from './components/VariantMetadata'
 import IndividualMetadata from './components/IndividualMetadata'
 import VariantLookup from './components/VariantLookup'
 
@@ -33,8 +31,6 @@ const SUMMARY_DATA_PAGES = [
   { path: 'gene_lists', component: LocusLists },
   { path: 'saved_variants', component: SavedVariants },
   { path: 'individual_metadata', params: '/:projectGuid?', component: IndividualMetadata },
-  { path: 'family_metadata', params: '/:projectGuid?', component: FamilyMetadata },
-  { path: 'variant_metadata', params: '/:projectGuid?', component: VariantMetadata },
   { path: 'hpo_terms', component: Hpo },
   { path: 'matchmaker', component: Matchmaker },
 ]

--- a/ui/pages/SummaryData/components/IndividualMetadata.jsx
+++ b/ui/pages/SummaryData/components/IndividualMetadata.jsx
@@ -1,8 +1,12 @@
-import React from 'react'
+import { connect } from 'react-redux'
 
+import { getUser } from 'redux/selectors'
 import { BaseSemanticInput, BooleanCheckbox } from 'shared/components/form/Inputs'
+import LoadReportTable from 'shared/components/table/LoadReportTable'
 import { FAMILY_ANALYSIS_STATUS_LOOKUP, VARIANT_METADATA_COLUMNS } from 'shared/utils/constants'
-import LoadReportTable from './LoadReportTable'
+
+const ALL_PROJECTS_PATH = 'all'
+const GREGOR_PROJECT_PATH = 'gregor'
 
 const FIELDS = [
   {
@@ -63,6 +67,12 @@ const AIRTABLE_COLUMNS = [
   { name: 'sample_provider' },
 ]
 
+const ANALYST_VIEW_ALL_PAGES = [
+  { name: 'GREGoR', downloadName: 'All_GREGoR_Projects', path: GREGOR_PROJECT_PATH },
+  { name: 'Broad', downloadName: 'All_AnVIL_Projects', path: ALL_PROJECTS_PATH },
+]
+const VIEW_ALL_PAGES = [{ name: 'my', downloadName: 'All_Projects', path: ALL_PROJECTS_PATH }]
+
 const getColumns = (data) => {
   const maxSavedVariants = Math.max(1, ...(data || []).map(row => row.num_saved_variants))
   const hasAirtable = data && data[0] && data[0][AIRTABLE_DBGAP_SUBMISSION_FIELD]
@@ -78,15 +88,16 @@ const getColumns = (data) => {
   )
 }
 
-const IndividualMetadata = props => (
-  <LoadReportTable
-    getColumns={getColumns}
-    allQueryFields={AIRTABLE_FIELDS}
-    queryFields={FIELDS}
-    urlPath="individual_metadata"
-    idField="participant_id"
-    {...props}
-  />
-)
+const mapStateToProps = (state, ownProps) => {
+  const user = getUser(state)
+  return {
+    getColumns,
+    queryFields: (user.isAnalyst && ownProps.match.params.projectGuid !== ALL_PROJECTS_PATH) ? AIRTABLE_FIELDS : FIELDS,
+    viewAllPages: (user.isAnalyst ? ANALYST_VIEW_ALL_PAGES : VIEW_ALL_PAGES),
+    urlBase: 'summary_data/individual_metadata',
+    idField: 'participant_id',
+    fileName: 'Metadata',
+  }
+}
 
-export default IndividualMetadata
+export default connect(mapStateToProps)(LoadReportTable)

--- a/ui/shared/components/table/LoadReportTable.jsx
+++ b/ui/shared/components/table/LoadReportTable.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 
-import { getUser } from 'redux/selectors'
 import { NoHoverFamilyLink } from 'shared/components/buttons/FamilyLink'
 import AwesomeBar from 'shared/components/page/AwesomeBar'
 import DataTable from 'shared/components/table/DataTable'
@@ -11,17 +9,9 @@ import { HorizontalSpacer } from 'shared/components/Spacers'
 import StateDataLoader from 'shared/components/StateDataLoader'
 import { InlineHeader, ActiveDisabledNavLink } from 'shared/components/StyledComponents'
 
-const ALL_PAGE = { downloadName: 'all_projects', path: 'all' }
-const ANALYST_VIEW_ALL_PAGES = [
-  { name: 'GREGoR', downloadName: 'all_GREGoR_projects', path: 'gregor' },
-  { name: 'Broad', ...ALL_PAGE },
-]
-const VIEW_ALL_PAGES = [{ name: 'my', ...ALL_PAGE }]
-
 const SEARCH_CATEGORIES = ['projects']
-const URL_BASE = 'summary_data'
 
-const getResultHref = urlPath => result => `/${URL_BASE}/${urlPath}/${result.key}`
+const getResultHref = urlBase => result => `/${urlBase}/${result.key}`
 
 const PROJECT_ID_FIELD = 'internal_project_id'
 
@@ -42,7 +32,7 @@ const getTableColumns = columns => ([
 ].map(({ name, ...props }) => ({ name, content: name, ...props })))
 
 const ReportTable = React.memo((
-  { projectGuid, queryForm, data, urlPath, user, columns, getColumns, idField },
+  { projectGuid, queryForm, data, urlBase, viewAllPages, columns, getColumns, idField, fileName },
 ) => (
   <div>
     <InlineHeader size="medium" content="Project:" />
@@ -50,12 +40,12 @@ const ReportTable = React.memo((
       categories={SEARCH_CATEGORIES}
       placeholder="Enter project name"
       inputwidth="350px"
-      getResultHref={getResultHref(urlPath)}
+      getResultHref={getResultHref(urlBase)}
     />
-    {(user.isAnalyst ? ANALYST_VIEW_ALL_PAGES : VIEW_ALL_PAGES).map(({ name, path }) => (
+    {viewAllPages.map(({ name, path }) => (
       <span key={path}>
         &nbsp; or &nbsp;
-        <ActiveDisabledNavLink to={`/${URL_BASE}/${urlPath}/${path}`}>{`view all ${name} projects`}</ActiveDisabledNavLink>
+        <ActiveDisabledNavLink to={`/${urlBase}/${path}`}>{`view all ${name} projects`}</ActiveDisabledNavLink>
       </span>
     ))}
     <HorizontalSpacer width={20} />
@@ -64,7 +54,7 @@ const ReportTable = React.memo((
       striped
       collapsing
       horizontalScroll
-      downloadFileName={`${ANALYST_VIEW_ALL_PAGES.find(({ path }) => path === projectGuid)?.downloadName || (data?.length && data[0][PROJECT_ID_FIELD].replace(/ /g, '_'))}_${new Date().toISOString().slice(0, 10)}_${urlPath.split('_')[0]}_metadata`}
+      downloadFileName={`${viewAllPages.find(({ path }) => path === projectGuid)?.downloadName || (data?.length && data[0][PROJECT_ID_FIELD].replace(/ /g, '_'))}_${new Date().toISOString().slice(0, 10)}_${fileName}`}
       idField={idField}
       defaultSortColumn="family_id"
       emptyContent={projectGuid ? '0 cases found' : 'Select a project to view data'}
@@ -78,20 +68,21 @@ const ReportTable = React.memo((
 ReportTable.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
   projectGuid: PropTypes.string,
-  user: PropTypes.object,
+  viewAllPages: PropTypes.arrayOf(PropTypes.object),
   queryForm: PropTypes.node,
   columns: PropTypes.arrayOf(PropTypes.object),
   getColumns: PropTypes.func,
-  urlPath: PropTypes.string,
+  urlBase: PropTypes.string,
   idField: PropTypes.string,
+  fileName: PropTypes.string,
 }
 
 const parseResponse = ({ rows }) => ({ data: rows })
 
-const LoadReportTable = ({ match, urlPath, ...props }) => (
+const LoadReportTable = ({ match, urlBase, ...props }) => (
   <StateDataLoader
-    url={match.params.projectGuid ? `/api/${URL_BASE}/${urlPath}/${match.params.projectGuid}` : ''}
-    urlPath={urlPath}
+    url={match.params.projectGuid ? `/api/${urlBase}/${match.params.projectGuid}` : ''}
+    urlBase={urlBase}
     parseResponse={parseResponse}
     childComponent={ReportTable}
     projectGuid={match.params.projectGuid}
@@ -101,16 +92,7 @@ const LoadReportTable = ({ match, urlPath, ...props }) => (
 
 LoadReportTable.propTypes = {
   match: PropTypes.object,
-  urlPath: PropTypes.string,
+  urlBase: PropTypes.string,
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const user = getUser(state)
-  return {
-    user,
-    queryFields: (user.isAnalyst && ownProps.match.params.projectGuid !== ALL_PAGE.path) ?
-      ownProps.allQueryFields : ownProps.queryFields,
-  }
-}
-
-export default connect(mapStateToProps)(LoadReportTable)
+export default LoadReportTable


### PR DESCRIPTION
Reverts broadinstitute/seqr#4015

The ticket requests that certain reports be made available to local installations by default. Since local installations do not have an analyst role and the reports tab is only show to analysts, we moved the reports from the "reports" tab to the "summary data" tab (which is available to all users). However, the unintended consequence of this is it meant these reports were also made available to AnVLl users on the Broad's seqr instance. AnVIL projects can not be configured to work for these reports, and the support burden on the seqr team is too high to try and get these to work. Therefore, we are reverting this change entirely and will instead make the reports available to local installs by making updates to the reports tab access