### PR TITLE
Local install reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## dev
 * Adds guid and created fields to PhenotypePrioritization model (REQUIRES DB MIGRATION)
+* Enable "Reports" tab by default for local installations
 
 ## 5/8/24
 * Adds dynamic analysis groups (REQUIRES DB MIGRATION)

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -18,7 +18,7 @@ from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, \
 from seqr.views.utils.export_utils import export_multiple_files, write_multiple_files_to_gs
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.permissions_utils import analyst_required, get_project_and_check_permissions, \
-    get_project_guids_user_can_view, get_internal_projects
+    get_project_guids_user_can_view, get_internal_projects, pm_or_analyst_required
 from seqr.views.utils.terra_api_utils import anvil_enabled
 from seqr.views.utils.variant_utils import DISCOVERY_CATEGORY
 
@@ -31,7 +31,7 @@ logger = SeqrLogger(__name__)
 MONDO_BASE_URL = 'https://monarchinitiative.org/v3/api/entity'
 
 
-@analyst_required
+@pm_or_analyst_required
 def seqr_stats(request):
     non_demo_projects = Project.objects.filter(is_demo=False)
 
@@ -793,7 +793,7 @@ def _get_row_id(row):
     return row[id_col]
 
 
-@analyst_required
+@pm_or_analyst_required
 def family_metadata(request, project_guid):
     projects = _get_metadata_projects(project_guid, request.user)
 
@@ -851,7 +851,7 @@ def family_metadata(request, project_guid):
 
 def _get_metadata_projects(project_guid, user):
     if project_guid == 'all':
-        return get_internal_projects()
+        return get_internal_projects().filter(guid__in=get_project_guids_user_can_view(user))
     if project_guid == GREGOR_CATEGORY.lower():
         return Project.objects.filter(projectcategory__name=GREGOR_CATEGORY)
     return [get_project_and_check_permissions(project_guid, user)]
@@ -872,7 +872,7 @@ def _get_family_structure(num_individuals, num_known_individuals):
     return 'other'
 
 
-@analyst_required
+@pm_or_analyst_required
 def variant_metadata(request, project_guid):
     projects = _get_metadata_projects(project_guid, request.user)
 

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -648,7 +648,7 @@ class ReportAPITest(AirtableTest):
         self.assertDictEqual(response_json['familiesCount'], self.STATS_DATA['familiesCount'])
         self.assertDictEqual(response_json['sampleCountsByType'], self.STATS_DATA['sampleCountsByType'])
 
-        self.check_no_analyst_no_access(url, has_override=True)
+        self.check_no_analyst_no_access(url, has_override=self.HAS_PM_OVERRIDE)
 
     @mock.patch('seqr.views.utils.export_utils.zipfile.ZipFile')
     @mock.patch('seqr.views.utils.airtable_utils.is_google_authenticated')
@@ -1176,9 +1176,10 @@ class ReportAPITest(AirtableTest):
         self.assertDictEqual(response.json(), {'rows': []})
 
         # Test access with no analyst group
-        response = self.check_no_analyst_no_access(all_projects_url, has_override=True)
-        self.assertListEqual(
-            sorted([r['familyGuid'] for r in response.json()['rows']]), expected_families + self.ADDITIONAL_FAMILIES)
+        response = self.check_no_analyst_no_access(all_projects_url, has_override=self.HAS_PM_OVERRIDE)
+        if self.HAS_PM_OVERRIDE:
+            self.assertListEqual(
+                sorted([r['familyGuid'] for r in response.json()['rows']]), expected_families + self.ADDITIONAL_FAMILIES)
 
     def test_variant_metadata(self):
         url = reverse(variant_metadata, args=[PROJECT_GUID])
@@ -1332,15 +1333,17 @@ class ReportAPITest(AirtableTest):
         self.assertDictEqual(response.json(), {'rows': []})
 
         # Test access with no analyst group
-        response = self.check_no_analyst_no_access(all_projects_url, has_override=True)
-        row_ids += self.ADDITIONAL_FINDINGS
-        self.assertListEqual([r['genetic_findings_id'] for r in response.json()['rows']], row_ids)
+        response = self.check_no_analyst_no_access(all_projects_url, has_override=self.HAS_PM_OVERRIDE)
+        if self.HAS_PM_OVERRIDE:
+            row_ids += self.ADDITIONAL_FINDINGS
+            self.assertListEqual([r['genetic_findings_id'] for r in response.json()['rows']], row_ids)
 
 
 class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
     fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
     ADDITIONAL_FAMILIES = ['F000014_14']
     ADDITIONAL_FINDINGS = ['NA21234_1_248367227']
+    HAS_PM_OVERRIDE = True
     STATS_DATA = {
         'projectsCount': {'non_demo': 3, 'demo': 1},
         'familiesCount': {'non_demo': 12, 'demo': 2},
@@ -1357,8 +1360,7 @@ class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
 
 class AnvilReportAPITest(AnvilAuthenticationTestCase, ReportAPITest):
     fixtures = ['users', 'social_auth', '1kg_project', 'reference_data', 'report_variants']
-    ADDITIONAL_FAMILIES = []
-    ADDITIONAL_FINDINGS = []
+    HAS_PM_OVERRIDE = False
     STATS_DATA = {
         'projectsCount': {'internal': 1, 'external': 1, 'no_anvil': 1, 'demo': 1},
         'familiesCount': {'internal': 11, 'external': 1, 'no_anvil': 0, 'demo': 2},

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -96,6 +96,8 @@ data_manager_required = active_user_has_policies_and_passes_test(user_is_data_ma
 pm_required = active_user_has_policies_and_passes_test(user_is_pm)
 pm_or_data_manager_required = active_user_has_policies_and_passes_test(
     lambda user: user_is_data_manager(user) or user_is_pm(user))
+pm_or_analyst_required = active_user_has_policies_and_passes_test(
+    lambda user: user_is_analyst(user) or user_is_pm(user))
 superuser_required = active_user_has_policies_and_passes_test(lambda user: user.is_superuser)
 
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -229,12 +229,17 @@ class AuthenticationTestCase(TestCase):
     def get_initial_page_json(self, response):
         return self.get_initial_page_window('initialJSON', response)
 
-    def check_no_analyst_no_access(self, url, get_response=None):
+    def check_no_analyst_no_access(self, url, get_response=None, has_override=False):
         self.mock_analyst_group.__str__.return_value = ''
 
         response = get_response() if get_response else self.client.get(url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
+
+        self.login_pm_user()
+        response = get_response() if get_response else self.client.get(url)
+        self.assertEqual(response.status_code, 200 if has_override else 403)
+        return response
 
     def reset_logs(self):
         self._log_stream.truncate(0)

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -236,7 +236,7 @@ class AuthenticationTestCase(TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
 
-        self.login_pm_user()
+        self.client.force_login(self.super_user)
         response = get_response() if get_response else self.client.get(url)
         self.assertEqual(response.status_code, 200 if has_override else 403)
         return response

--- a/ui/pages/Report/Report.jsx
+++ b/ui/pages/Report/Report.jsx
@@ -13,19 +13,23 @@ import Gregor from './components/Gregor'
 import SeqrStats from './components/SeqrStats'
 import VariantMetadata from './components/VariantMetadata'
 
-export const REPORT_PAGES = [
-  { path: 'anvil', component: Anvil },
+const LOCAL_REPORT_PAGES = [
   { path: 'custom_search', params: '/:searchHash?', component: CustomSearch },
   { path: 'family_metadata', params: '/:projectGuid?', component: FamilyMetadata },
   { path: 'variant_metadata', params: '/:projectGuid?', component: VariantMetadata },
-  { path: 'gregor', component: Gregor },
   { path: 'seqr_stats', component: SeqrStats },
 ]
 
+export const REPORT_PAGES = [
+  { path: 'anvil', component: Anvil },
+  { path: 'gregor', component: Gregor },
+  ...LOCAL_REPORT_PAGES,
+]
+
 const Report = ({ match, user }) => (
-  user.isAnalyst ? (
+  (user.isAnalyst || user.isPm) ? (
     <Switch>
-      {REPORT_PAGES.map(
+      {(user.isAnalyst ? REPORT_PAGES : LOCAL_REPORT_PAGES).map(
         ({ path, params, component }) => <Route key={path} path={`${match.url}/${path}${params || ''}`} component={component} />,
       )}
       <Route path={match.url} component={null} />

--- a/ui/shared/components/page/Header.jsx
+++ b/ui/shared/components/page/Header.jsx
@@ -23,7 +23,7 @@ const PageHeader = React.memo(({ user, googleLoginEnabled, onSubmit }) => (
     <Menu.Item as={Link} to="/"><Header size="medium" inverted>seqr</Header></Menu.Item>
     {Object.keys(user).length ? [
       <Menu.Item key="summary_data" as={Link} to="/summary_data" content="Summary Data" />,
-      user.isAnalyst ? <Menu.Item key="report" as={Link} to="/report" content="Reports" /> : null,
+      (user.isAnalyst || user.isPm) ? <Menu.Item key="report" as={Link} to="/report" content="Reports" /> : null,
       (user.isDataManager || user.isPm) ? <Menu.Item key="data_management" as={Link} to="/data_management" content="Data Management" /> : null,
       <Menu.Item key="awesomebar" fitted="vertically"><AwesomeBar newWindow inputwidth="350px" /></Menu.Item>,
     ] : null }


### PR DESCRIPTION
In local installations there is no analyst role by default but there is a PM role. Therefore in order to make these reports available to local users we are updating the report tab to show some relevant reports to PMs as well as analysts. This will have no impact on the Broad seqr instance, as all our PMs also have analyst permissions. 