### PR TITLE
Optimize SQL queries for project page performance

### DIFF
--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -139,7 +139,7 @@ def family_variant_tag_summary(request, family_guid):
         saved_variants__matchmakersubmissiongenes__isnull=False).values('saved_variants__guid').distinct().count()
 
     response['projectsByGuid'] = {project.guid: {}}
-    add_project_tag_types(response['projectsByGuid'])
+    add_project_tag_types(response['projectsByGuid'], project=project)
 
     return create_json_response(response)
 

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -24,7 +24,7 @@ from seqr.views.utils.pedigree_info_utils import parse_pedigree_table, validate_
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
     get_project_and_check_pm_permissions, login_and_policies_required, has_project_permissions, project_has_anvil, \
     is_internal_anvil_project, pm_or_data_manager_required, check_workspace_perm
-from seqr.views.utils.project_context_utils import add_project_tag_types
+from seqr.views.utils.project_context_utils import add_project_tag_type_counts
 from seqr.views.utils.individual_utils import delete_individuals, add_or_update_individuals_and_families
 from seqr.views.utils.variant_utils import bulk_create_tagged_variants
 
@@ -936,8 +936,7 @@ def import_gregor_metadata(request, project_guid):
     )
     info.append(f'Loaded {num_new} new and {num_updated} updated findings tags')
 
-    response_json['projectsByGuid'] = {project_guid: {}}
-    response_json['familyTagTypeCounts'] = add_project_tag_types(response_json['projectsByGuid'], add_counts=True)
+    add_project_tag_type_counts(project, response_json)
 
     response_json['importStats'] = {'gregorMetadata': {'info': info, 'warnings': warnings}}
     return create_json_response(response_json)

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -207,7 +207,7 @@ def project_families(request, project_guid):
         individual__family__project=project).values_list('individual__family', flat=True).distinct())
     for family in families:
         family['hasPhenotypePrioritization'] = family.pop('_id') in phenotype_priority_family_ids
-    response = families_discovery_tags(families)
+    response = families_discovery_tags(families, project=project)
     return create_json_response(response)
 
 

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -203,10 +203,11 @@ def project_families(request, project_guid):
         family_models, request.user, has_case_review_perm=has_case_review_permissions(project, request.user),
         project_guid=project_guid, add_individual_guids_field=True, additional_values=family_annotations,
     )
+    families_by_id = {f.pop('_id'): f for f in families}
     phenotype_priority_family_ids = set(PhenotypePrioritization.objects.filter(
-        individual__family__project=project).values_list('individual__family', flat=True).distinct())
-    for family in families:
-        family['hasPhenotypePrioritization'] = family.pop('_id') in phenotype_priority_family_ids
+        individual__family_id__in=families_by_id).values_list('individual__family', flat=True).distinct())
+    for family_id, family in families_by_id.items():
+        family['hasPhenotypePrioritization'] = family_id in phenotype_priority_family_ids
     response = families_discovery_tags(families, project=project)
     return create_json_response(response)
 

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -227,11 +227,9 @@ def project_overview(request, project_guid):
 
     sample_models = Sample.objects.filter(individual__family__project=project)
 
-    active_samples = sample_models.filter(is_active=True)
-    first_loaded_samples = sample_models.order_by('individual__family', 'loaded_date').distinct('individual__family')
-    samples_by_guid = {}
-    for samples in [active_samples, first_loaded_samples]:
-        samples_by_guid.update({s['sampleGuid']: s for s in get_json_for_samples(samples, project_guid=project_guid)})
+    first_loaded_samples = sample_models.order_by('individual__family', 'loaded_date').distinct('individual__family').values_list('id', flat=True)
+    samples = sample_models.filter(Q(is_active=True) | Q(id__in=first_loaded_samples))
+    samples_by_guid = {s['sampleGuid']: s for s in get_json_for_samples(samples, project_guid=project_guid)}
 
     sample_load_counts = sample_models.values(
         'sample_type', 'dataset_type', loadedDate=TruncDate('loaded_date'),

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -24,7 +24,7 @@ from seqr.views.utils.permissions_utils import get_project_and_check_permissions
     check_user_created_object_permissions, pm_required, user_is_pm, login_and_policies_required, \
     has_workspace_perm, has_case_review_permissions, is_internal_anvil_project
 from seqr.views.utils.project_context_utils import families_discovery_tags, \
-    add_project_tag_types, get_project_analysis_groups, get_project_locus_lists
+    add_project_tag_type_counts, get_project_analysis_groups, get_project_locus_lists
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated, anvil_enabled
 from settings import BASE_URL
 
@@ -241,12 +241,12 @@ def project_overview(request, project_guid):
         s['familyCounts'] = {f: s['familyCounts'].count(f) for f in s['familyCounts']}
         grouped_sample_counts[f'{s.pop("sample_type")}__{s.pop("dataset_type")}'].append(s)
 
+    project_json = {'projectGuid': project_guid, 'sampleCounts': grouped_sample_counts}
     response = {
-        'projectsByGuid': {project_guid: {'projectGuid': project_guid, 'sampleCounts': grouped_sample_counts}},
         'samplesByGuid': samples_by_guid,
     }
 
-    response['familyTagTypeCounts'] = add_project_tag_types(response['projectsByGuid'], add_counts=True)
+    add_project_tag_type_counts(project, response, project_json=project_json)
 
     project_mme_submissions = MatchmakerSubmission.objects.filter(individual__family__project=project)
 

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -168,7 +168,8 @@ def add_project_tag_types(projects_by_guid, project=None):
 
 
 def add_project_tag_type_counts(project, response_json, project_json=None):
-    response_json['projectsByGuid'] = {project.guid: project_json or {}}
+    project_json = project_json or {}
+    response_json['projectsByGuid'] = {project.guid: project_json}
     add_project_tag_types(response_json['projectsByGuid'], project=project)
 
     saved_variants = SavedVariant.objects.filter(family__project=project)

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
-from django.db.models import Count, Q, prefetch_related_objects
+from django.db.models import Count, Q, F, prefetch_related_objects
 
 from seqr.models import Individual, IgvSample, AnalysisGroup, DynamicAnalysisGroup, LocusList, VariantTagType,\
     VariantFunctionalData, FamilyNote, SavedVariant, VariantTag, VariantNote
 from seqr.utils.gene_utils import get_genes
-from seqr.views.utils.orm_to_json_utils import _get_json_for_families, _get_json_for_individuals, _get_json_for_models, \
+from seqr.views.utils.orm_to_json_utils import _get_json_for_families, _get_json_for_individuals, get_json_for_queryset, \
     get_json_for_analysis_groups, get_json_for_samples, get_json_for_locus_lists, \
     get_json_for_family_notes, get_json_for_saved_variants
 
@@ -133,20 +133,20 @@ def families_discovery_tags(families, project=None):
 MME_TAG_NAME = 'MME Submission'
 
 
-def add_project_tag_types(projects_by_guid, add_counts=False):
-    variant_tag_types_models = VariantTagType.objects.filter(Q(project__guid__in=projects_by_guid.keys()) | Q(project__isnull=True))
-    variant_tag_types = _get_json_for_models(variant_tag_types_models)
+def add_project_tag_types(projects_by_guid, project=None):
+    is_single_project = len(projects_by_guid) == 1
+    project_q = dict(project=project) if project else dict(project__guid__in=projects_by_guid.keys())
+    variant_tag_types_models = VariantTagType.objects.filter(Q(**project_q) | Q(project__isnull=True))
+    variant_tag_types = get_json_for_queryset(
+        variant_tag_types_models, nested_fields=None if is_single_project else [{'fields': ('project', 'guid')}])
 
     project_tag_types = defaultdict(list)
-    if len(projects_by_guid) == 1:
+    if is_single_project:
         project_guid = next(iter((projects_by_guid.keys())))
-        project_tag_types[project_guid] = variant_tag_types
+        project_tag_types[project_guid] = list(variant_tag_types)
     else:
-        prefetch_related_objects(variant_tag_types_models, 'project')
-        variant_tag_types_by_guid = {vtt['variantTagTypeGuid']: vtt for vtt in variant_tag_types}
-        for vtt in variant_tag_types_models:
-            project_guid = vtt.project.guid if vtt.project else None
-            project_tag_types[project_guid].append(variant_tag_types_by_guid[vtt.guid])
+        for vtt in variant_tag_types:
+            project_tag_types[vtt.pop('projectGuid')].append(vtt)
 
     project_tag_types[None].append({
         'variantTagTypeGuid': 'mmeSubmissionVariants',
@@ -157,7 +157,6 @@ def add_project_tag_types(projects_by_guid, add_counts=False):
         'order': 99,
     })
 
-    family_counts = {}
     for project_guid, project_json in projects_by_guid.items():
         project_json.update({
             'variantTagTypes': sorted(
@@ -166,17 +165,18 @@ def add_project_tag_types(projects_by_guid, add_counts=False):
             ),
             'variantFunctionalTagTypes': VariantFunctionalData.FUNCTIONAL_DATA_TAG_TYPES,
         })
-        if add_counts:
-            family_counts.update(_add_tag_type_counts(project_guid, project_json['variantTagTypes']))
-
-    return family_counts
 
 
-def _add_tag_type_counts(project_guid, project_variant_tags):
-    project_tags = VariantTag.objects.filter(saved_variants__family__project__guid=project_guid)
-    project_notes = VariantNote.objects.filter(saved_variants__family__project__guid=project_guid)
+def add_project_tag_type_counts(project, response_json, project_json=None):
+    response_json['projectsByGuid'] = {project.guid: project_json or {}}
+    add_project_tag_types(response_json['projectsByGuid'], project=project)
+
+    saved_variants = SavedVariant.objects.filter(family__project=project)
+    project_tags = VariantTag.objects.filter(saved_variants__in=saved_variants)
+    project_notes = VariantNote.saved_variants.through.objects.filter(savedvariant_id__in=saved_variants)
 
     family_tag_type_counts = defaultdict(dict)
+
     note_tag_type = {
         'variantTagTypeGuid': 'notes',
         'name': 'Has Notes',
@@ -184,24 +184,27 @@ def _add_tag_type_counts(project_guid, project_variant_tags):
         'description': '',
         'color': 'grey',
         'order': 100,
-        'numTags': project_notes.aggregate(count=Count('saved_variants__guid', distinct=True))['count'],
+        'numTags': project_notes.values_list('savedvariant_id').distinct().count(),
     }
 
-    mme_counts_by_family = project_tags.filter(saved_variants__matchmakersubmissiongenes__isnull=False) \
-        .values('saved_variants__family__guid').annotate(count=Count('saved_variants__guid', distinct=True))
+    mme_counts_by_family = saved_variants.filter(matchmakersubmissiongenes__isnull=False) \
+        .values(family_guid=F('family__guid')).annotate(count=Count('guid', distinct=True))
 
-    tag_counts_by_type_and_family = project_tags.values(
-        'saved_variants__family__guid', 'variant_tag_type__name').annotate(count=Count('guid', distinct=True))
+    tag_counts_by_type_and_family = defaultdict(list)
+    for counts in project_tags.values(
+        'variant_tag_type__name', family_guid=F('saved_variants__family__guid')).annotate(count=Count('guid', distinct=True)):
+        tag_counts_by_type_and_family[counts['variant_tag_type__name']].append(counts)
+    tag_counts_by_type_and_family[MME_TAG_NAME] = mme_counts_by_family
+
+    project_variant_tags = project_json['variantTagTypes']
     for tag_type in project_variant_tags:
-        current_tag_type_counts = mme_counts_by_family if tag_type['name'] == MME_TAG_NAME else [
-            counts for counts in tag_counts_by_type_and_family if counts['variant_tag_type__name'] == tag_type['name']
-        ]
+        current_tag_type_counts = tag_counts_by_type_and_family[tag_type['name']]
         num_tags = sum(count['count'] for count in current_tag_type_counts)
         tag_type.update({
             'numTags': num_tags,
         })
         for count in current_tag_type_counts:
-            family_tag_type_counts[count['saved_variants__family__guid']].update({tag_type['name']: count['count']})
+            family_tag_type_counts[count['family_guid']].update({tag_type['name']: count['count']})
 
     project_variant_tags.append(note_tag_type)
-    return family_tag_type_counts
+    response_json['familyTagTypeCounts'] = family_tag_type_counts

--- a/seqr/views/utils/project_context_utils.py
+++ b/seqr/views/utils/project_context_utils.py
@@ -110,11 +110,12 @@ def add_child_ids(response):
         family['individualGuids'] = individual_guids_by_family[family['familyGuid']]
 
 
-def families_discovery_tags(families):
+def families_discovery_tags(families, project=None):
     families_by_guid = {f['familyGuid']: dict(discoveryTags=[], **f) for f in families}
 
+    family_filter = {'family__project': project} if project else {'family__guid__in': families_by_guid.keys()}
     discovery_tags = get_json_for_saved_variants(SavedVariant.objects.filter(
-        family__guid__in=families_by_guid.keys(), varianttag__variant_tag_type__category='CMG Discovery Tags',
+        varianttag__variant_tag_type__category='CMG Discovery Tags', **family_filter,
     ), add_details=True)
 
     gene_ids = set()


### PR DESCRIPTION
This PR optimizes the generated SQL queries for a couple of the slower project detail endpoints. Overall, changes work to reduce table joins where possible and reduce duplicating queries to the same table (i.e. get all data in one query instead of multiple). 

A. note on how this sort of optimization is done: django has pretty good debug tools for this. I change the `ENABLE_DJANGO_DEBUG_TOOLBAR` setting in settings.py to True which enables it. The "gotcha" for this tool is it will only profile requests thqt return HTML, so for whatever API endpoint I want to profile I replace the final return statement with the following, and then access the API endpoint directly in my browser 
```
from seqr.views.react_app import render_app_html
return render_app_html(request, include_user=False)
```

The debug toolbar is then shown, I usually focus on the "SQL" tab (you can also look at total time and if the total time is substantially longer than the SQL time then there may be non-SQL related optimization that is needed). From there I usually focus in on the queries that are duplicated and/ or the queries that are the slowest and dig into them to see whats going on and try out other solutions. 

![Screenshot 2024-05-16 at 5 06 21 PM](https://github.com/broadinstitute/seqr/assets/24598672/20ed2887-efe4-42da-894f-2e1d24c14ba6)
