### PR TITLE
improve mgration performance

### DIFF
--- a/seqr/migrations/0064_alter_phenotypeprioritization.py
+++ b/seqr/migrations/0064_alter_phenotypeprioritization.py
@@ -19,10 +19,11 @@ class Migration(migrations.Migration):
         PhenotypePrioritization = apps.get_model('seqr', 'PhenotypePrioritization')
         db_alias = schema_editor.connection.alias
         pps = PhenotypePrioritization.objects.using(db_alias).all()
+        individual_id_map = dict(pps.values_list('id', 'individual__individual_id'))
         for pp in pps:
-            ids_as_str = "%s:%s:%s" % (pp.individual.individual_id, pp.gene_id, pp.disease_id)
+            ids_as_str = "%s:%s:%s" % (individual_id_map[pp.id], pp.gene_id, pp.disease_id)
             pp.guid = 'PP%07d_%s' % (pp.id, _slugify(str(ids_as_str)))[:MAX_GUID_SIZE]
-        PhenotypePrioritization.objects.using(db_alias).bulk_update(pps, ['guid'])
+        PhenotypePrioritization.objects.using(db_alias).bulk_update(pps, ['guid'], batch_size=1000)
 
     operations = [
         migrations.AddField(


### PR DESCRIPTION
This migration is actually taking longer than the timeout for the seqr pod in dev, causing it to terminate before the migration can complete. This improves performance by doing one query to map PP models to individuals, instead of one query per model