### PR TITLE
fix update_gencc command

### DIFF
--- a/reference_data/management/commands/utils/download_utils.py
+++ b/reference_data/management/commands/utils/download_utils.py
@@ -39,7 +39,7 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
 
 def _get_remote_file_size(url):
     try:
-        response = requests.head(url, timeout=10)
+        response = requests.head(url, timeout=5)
         return int(response.headers.get('Content-Length', '0'))
     except Exception:
         # file size not yet implemented for FTP and other protocols, and HEAD not supported for all http requests

--- a/reference_data/management/commands/utils/download_utils.py
+++ b/reference_data/management/commands/utils/download_utils.py
@@ -18,8 +18,7 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
     if not (url and url.startswith(("http://", "https://"))):
         raise ValueError("Invalid url: {}".format(url))
     local_file_path = os.path.join(to_dir, os.path.basename(url))
-    remote_file_size = _get_remote_file_size(url)
-    if os.path.isfile(local_file_path) and os.path.getsize(local_file_path) == remote_file_size:
+    if os.path.isfile(local_file_path) and os.path.getsize(local_file_path) == _get_remote_file_size(url):
         logger.info("Re-using {} previously downloaded from {}".format(local_file_path, url))
         return local_file_path
 
@@ -39,9 +38,10 @@ def download_file(url, to_dir=tempfile.gettempdir(), verbose=True):
 
 
 def _get_remote_file_size(url):
-    if url.startswith("http"):
+    try:
         response = requests.head(url, timeout=10)
         return int(response.headers.get('Content-Length', '0'))
-    else:
-        return 0  # file size not yet implemented for FTP and other protocols
+    except Exception:
+        # file size not yet implemented for FTP and other protocols, and HEAD not supported for all http requests
+        return 0
 

--- a/reference_data/management/commands/utils/update_utils.py
+++ b/reference_data/management/commands/utils/update_utils.py
@@ -73,14 +73,14 @@ def update_records(reference_data_handler, file_path=None):
     Args:
         file_path (str): optional local file path. If not specified, or the path doesn't exist, the table will be downloaded.
     """
-    logger.info('Updating {}'.format(reference_data_handler))
-
-    if not file_path or not os.path.isfile(file_path):
-        file_path = download_file(reference_data_handler.url)
-
     model_cls = reference_data_handler.model_cls
     model_name = model_cls.__name__
     model_objects = getattr(model_cls, 'objects')
+
+    logger.info(f'Updating {model_name}')
+
+    if not file_path or not os.path.isfile(file_path):
+        file_path = download_file(reference_data_handler.url)
 
     models = []
     skip_counter = 0

--- a/reference_data/management/tests/test_utils.py
+++ b/reference_data/management/tests/test_utils.py
@@ -28,7 +28,6 @@ class ReferenceDataCommandTestCase(TestCase):
     @responses.activate
     def _test_update_command(self, command_name, model_name, existing_records=1, created_records=1, skipped_records=1):
         # test without a file_path parameter
-        responses.add(responses.HEAD, self.URL, headers={"Content-Length": "1024"})
         body = ''.join(self.DATA)
         if self.URL.endswith('gz'):
             body = gzip.compress(body.encode())
@@ -51,6 +50,7 @@ class ReferenceDataCommandTestCase(TestCase):
 
         # test with a file_path parameter
         self.mock_logger.reset_mock()
+        responses.add(responses.HEAD, self.URL, headers={"Content-Length": "1024"})
         responses.remove(responses.GET, self.URL)
         call_command(command_name, self.tmp_file)
         log_calls[1] = mock.call('Deleting {} existing {} records'.format(created_records, model_name))

--- a/reference_data/management/tests/update_gencode_tests.py
+++ b/reference_data/management/tests/update_gencode_tests.py
@@ -150,7 +150,7 @@ class UpdateGencodeTest(TestCase):
         responses.add(responses.GET, url_23_lift, body=self.gzipped_gtf_data, stream=True)
         call_command('update_gencode', '--gencode-release=23')
         self.assertEqual(responses.calls[0].request.url, url_23_lift)
-        self.assertEqual(responses.calls[2].request.url, url_23)
+        self.assertEqual(responses.calls[1].request.url, url_23)
 
     def _has_expected_new_genes(self, expected_release=None):
         gene_info = GeneInfo.objects.get(gene_id='ENSG00000223972')
@@ -261,7 +261,7 @@ class UpdateGencodeTest(TestCase):
         ])
 
         self.assertEqual(responses.calls[0].request.url, url_lift)
-        self.assertEqual(responses.calls[2].request.url, url)
+        self.assertEqual(responses.calls[1].request.url, url)
 
     @responses.activate
     @mock.patch('reference_data.management.commands.utils.update_utils.logger')


### PR DESCRIPTION
The GenCC download no longer supports HEAD requests. Since these are only used for an optimization to prevent re-downloading a file this is not a blocking change, we just need to update error handling to allow loading to prceed