### PR TITLE
Job to update savedvariant annotations

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -12,7 +12,7 @@ from seqr.utils.communication_utils import safe_post_to_slack
 from seqr.utils.file_utils import file_iter, does_file_exist
 from seqr.utils.search.add_data_utils import notify_search_data_loaded
 from seqr.utils.search.utils import parse_valid_variant_id
-from seqr.utils.search.hail_search_utils import hail_variant_multi_lookup
+from seqr.utils.search.hail_search_utils import hail_variant_multi_lookup, search_data_type
 from seqr.views.utils.dataset_utils import match_and_update_search_samples
 from seqr.views.utils.variant_utils import reset_cached_search_results, update_projects_saved_variant_json, \
     saved_variants_dataset_type_filter
@@ -133,9 +133,8 @@ class Command(BaseCommand):
         updated_variants_by_id = update_projects_saved_variant_json(
             updated_project_families, user_email=USER_EMAIL, dataset_type=dataset_type)
 
-        data_type = f'{dataset_type}_{sample_type}' if dataset_type == Sample.DATASET_TYPE_SV_CALLS else dataset_type
         self._reload_shared_variant_annotations(
-            data_type, genome_version, updated_variants_by_id, exclude_families=updated_families)
+            search_data_type(dataset_type, sample_type), genome_version, updated_variants_by_id, exclude_families=updated_families)
 
         logger.info('DONE')
 
@@ -167,7 +166,7 @@ class Command(BaseCommand):
         for v in variant_models:
             variants_by_id[v.variant_id].append(v)
 
-        logger.info(f'Reloading shared annotations for {len(variant_models)} saved variants ({len(variants_by_id)} unique)')
+        logger.info(f'Reloading shared annotations for {len(variant_models)} {data_type} {genome_version} saved variants ({len(variants_by_id)} unique)')
 
         updated_variants_by_id = {
             variant_id: {k: v for k, v in variant.items() if k not in {'familyGuids', 'genotypes', 'genotypeFilters'}}

--- a/seqr/management/commands/reload_saved_variant_annotations.py
+++ b/seqr/management/commands/reload_saved_variant_annotations.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from reference_data.models import GENOME_VERSION_LOOKUP
 from seqr.models import Sample
 from seqr.management.commands.check_for_new_samples_from_pipeline import reload_shared_variant_annotations
-from seqr.utils.search.hail_search_utils import hail_variant_multi_lookup, search_data_type
+from seqr.utils.search.hail_search_utils import search_data_type
 
 DATA_TYPE_CHOICES = {
     search_data_type(dt, st) for dt in Sample.DATASET_TYPE_LOOKUP for st in [Sample.SAMPLE_TYPE_WGS, Sample.SAMPLE_TYPE_WES]
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     help = 'Reload shared variant annotations for all saved variants'
 
     def add_arguments(self, parser):
-        parser.add_argument('data_type', choices=soretd(DATA_TYPE_CONFIGS))
+        parser.add_argument('data_type', choices=sorted(DATA_TYPE_CHOICES))
         parser.add_argument('genome_version', choices=sorted(GENOME_VERSION_LOOKUP.values()))
 
     def handle(self, *args, **options):

--- a/seqr/management/commands/reload_saved_variant_annotations.py
+++ b/seqr/management/commands/reload_saved_variant_annotations.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+from reference_data.models import GENOME_VERSION_LOOKUP
+from seqr.models import Sample
+from seqr.management.commands.check_for_new_samples_from_pipeline import reload_shared_variant_annotations
+from seqr.utils.search.hail_search_utils import hail_variant_multi_lookup, search_data_type
+
+DATA_TYPE_CHOICES = {
+    search_data_type(dt, st) for dt in Sample.DATASET_TYPE_LOOKUP for st in [Sample.SAMPLE_TYPE_WGS, Sample.SAMPLE_TYPE_WES]
+}
+
+
+class Command(BaseCommand):
+    help = 'Reload shared variant annotations for all saved variants'
+
+    def add_arguments(self, parser):
+        parser.add_argument('data_type', choices=soretd(DATA_TYPE_CONFIGS))
+        parser.add_argument('genome_version', choices=sorted(GENOME_VERSION_LOOKUP.values()))
+
+    def handle(self, *args, **options):
+        reload_shared_variant_annotations(options['data_type'], options['genome_version'])

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -220,7 +220,7 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
                 {'individual_guid': 'I000018_na21234', 'family_guid': 'F000014_14', 'project_guid': 'R0004_non_analyst_project', 'affected': 'A', 'sample_id': 'NA21234'},
             ]}},
         ], reload_annotations_logs=[
-            'Reloading shared annotations for 3 saved variants (3 unique)', 'Fetched 1 additional variants', 'Fetched 1 additional variants', 'Updated 2 saved variants',
+            'Reloading shared annotations for 3 SNV_INDEL GRCh38 saved variants (3 unique)', 'Fetched 1 additional variants', 'Fetched 1 additional variants', 'Updated 2 saved variants',
         ])
 
         old_data_sample_guid = 'S000143_na20885'

--- a/seqr/management/tests/reload_saved_variant_annotations_tests.py
+++ b/seqr/management/tests/reload_saved_variant_annotations_tests.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from django.core.management import call_command
+from django.core.management.base import CommandError
+import json
+import mock
+import responses
+
+from seqr.views.utils.test_utils import AnvilAuthenticationTestCase
+from seqr.models import Project, Family, Individual, Sample, SavedVariant
+
+MOCK_HAIL_HOST = 'http://test-hail-host'
+
+
+@mock.patch('seqr.utils.search.hail_search_utils.HAIL_BACKEND_SERVICE_HOSTNAME', MOCK_HAIL_HOST)
+class ReloadVariantAnnotationsTest(AnvilAuthenticationTestCase):
+    fixtures = ['users', '1kg_project']
+
+    @mock.patch('seqr.management.commands.check_for_new_samples_from_pipeline.logger')
+    @responses.activate
+    def test_command(self, mock_logger):
+        responses.add(responses.POST, f'{MOCK_HAIL_HOST}:5000/multi_lookup', status=200, json={
+            'results': [
+                {'variantId': '1-46859832-G-A', 'updated_new_field': 'updated_value', 'rsid': 'rs123'},
+                {'variantId': '1-248367227-TC-T', 'updated_field': 'updated_value'},
+            ],
+        })
+
+        # Test errors
+        with self.assertRaises(CommandError) as ce:
+            call_command('reload_saved_variant_annotations')
+        self.assertEqual(str(ce.exception), 'Error: the following arguments are required: data_type, genome_version')
+
+        with self.assertRaises(CommandError) as ce:
+            call_command('reload_saved_variant_annotations', 'SV', 'GRCh37')
+        self.assertEqual(str(ce.exception), "Error: argument data_type: invalid choice: 'SV' (choose from 'MITO', 'ONT_SNV_INDEL', 'SNV_INDEL', 'SV_WES', 'SV_WGS')")
+
+        # Test success
+        call_command('reload_saved_variant_annotations', 'SNV_INDEL', 'GRCh37')
+
+        mock_logger.info.assert_has_calls([mock.call(log) for log in [
+            'Reloading shared annotations for 3 SNV_INDEL GRCh37 saved variants (3 unique)',
+            'Fetched 2 additional variants',
+            'Updated 2 saved variants',
+        ]])
+
+        self.assertEqual(len(responses.calls), 1)
+        multi_lookup_request = responses.calls[0].request
+        self.assertEqual(multi_lookup_request.url, f'{MOCK_HAIL_HOST}:5000/multi_lookup')
+        self.assertEqual(multi_lookup_request.headers.get('From'), 'manage_command')
+        self.assertDictEqual(json.loads(multi_lookup_request.body), {
+            'genome_version': 'GRCh37',
+            'data_type': 'SNV_INDEL',
+            'variant_ids': [['1', 248367227, 'TC', 'T'], ['1', 46859832, 'G', 'A'], ['21', 3343353, 'GAGA', 'G']],
+        })
+
+        annotation_updated_json_1 = SavedVariant.objects.get(guid='SV0000002_1248367227_r0390_100').saved_variant_json
+        self.assertEqual(len(annotation_updated_json_1), 18)
+        self.assertListEqual(annotation_updated_json_1['familyGuids'], ['F000001_1'])
+        self.assertEqual(annotation_updated_json_1['updated_field'], 'updated_value')
+
+        annotation_updated_json_2 = SavedVariant.objects.get(guid='SV0059956_11560662_f019313_1').saved_variant_json
+        self.assertEqual(len(annotation_updated_json_2), 18)
+        self.assertEqual(annotation_updated_json_2['updated_new_field'], 'updated_value')
+        self.assertEqual(annotation_updated_json_2['rsid'], 'rs123')
+        self.assertEqual(annotation_updated_json_2['mainTranscriptId'], 'ENST00000505820')
+        self.assertEqual(len(annotation_updated_json_2['genotypes']), 3)
+
+        # Test SVs
+        Sample.objects.filter(guid='S000147_na21234').update(individual_id=20)
+        call_command('reload_saved_variant_annotations', 'SV_WGS', 'GRCh37')
+
+        self.assertEqual(len(responses.calls), 2)
+        self.assertDictEqual(json.loads(responses.calls[1].request.body), {
+            'genome_version': 'GRCh37',
+            'data_type': 'SV_WGS',
+            'variant_ids': ['prefix_19107_DEL'],
+        })

--- a/seqr/management/tests/reload_saved_variant_annotations_tests.py
+++ b/seqr/management/tests/reload_saved_variant_annotations_tests.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from django.core.management import call_command
 from django.core.management.base import CommandError
 import json
@@ -6,7 +5,7 @@ import mock
 import responses
 
 from seqr.views.utils.test_utils import AnvilAuthenticationTestCase
-from seqr.models import Project, Family, Individual, Sample, SavedVariant
+from seqr.models import Sample, SavedVariant
 
 MOCK_HAIL_HOST = 'http://test-hail-host'
 

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -129,6 +129,10 @@ def _format_search_body(samples, genome_version, num_results, search):
     return search_body
 
 
+def search_data_type(dataset_type, sample_type):
+    return f'{dataset_type}_{sample_type}' if dataset_type == Sample.DATASET_TYPE_SV_CALLS else dataset_type
+
+
 def _get_sample_data(samples, inheritance_filter=None, inheritance_mode=None, **kwargs):
     sample_values = dict(
         individual_guid=F('individual__guid'),

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -154,7 +154,7 @@ def _get_sample_data(samples, inheritance_filter=None, inheritance_mode=None, **
         dataset_type = s.pop('dataset_type')
         sample_type = s.pop('sample_type')
         s['sample_id'] = s.pop('individual__individual_id')
-        data_type_key = f'{dataset_type}_{sample_type}' if dataset_type == Sample.DATASET_TYPE_SV_CALLS else dataset_type
+        data_type_key = search_data_type(dataset_type, sample_type)
         sample_data_by_data_type[data_type_key].append(s)
 
     return sample_data_by_data_type


### PR DESCRIPTION
Currently all the annotations for saved variants are automatically updated whenever new data is available in seqr. However, there will be times when we may update the annotations table without loading new samples (i.e. for new VEP table) so having the ability to sync annotations with the backend is useful (and also can be useful during local development)