### PR TITLE
do not raise unhandled error on airtable mismatch

### DIFF
--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -679,10 +679,10 @@ class SummaryDataAPITest(AirtableTest):
         responses.add(responses.GET, '{}/app3Y97xtbbaOopVR/Collaborator'.format(AIRTABLE_URL),
                       json=AIRTABLE_COLLABORATOR_RECORDS, status=200)
         response = self.client.get(include_airtable_url)
-        self.assertEqual(response.status_code, 500)
-        self.assertEqual(
-            response.json()['error'],
-            'Found multiple airtable records for sample NA19675 with mismatched values in field dbgap_study_id')
+        self.assertEqual(response.status_code, 400)
+        self.assertListEqual(
+            response.json()['errors'],
+            ['Found multiple airtable records for sample NA19675 with mismatched values in field dbgap_study_id'])
         self.assertEqual(len(responses.calls), 4)
         first_formula = "OR({CollaboratorSampleID}='NA20885',{CollaboratorSampleID}='NA20888')"
         expected_fields = [

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -2,6 +2,7 @@ import requests
 from collections import defaultdict
 from django.core.exceptions import PermissionDenied
 
+from seqr.utils.middleware import ErrorsWarningsException
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.views.utils.terra_api_utils import is_google_authenticated
 
@@ -138,7 +139,7 @@ def get_airtable_samples(sample_ids, user, fields, list_fields=None):
             if len(record_field) > 1:
                 error = 'Found multiple airtable records for sample {} with mismatched values in field {}'.format(
                     record_id, field)
-                raise Exception(error)
+                raise ErrorsWarningsException([error])
             if record_field:
                 parsed_record[field] = record_field.pop()
         for field in list_fields:


### PR DESCRIPTION
Unhandled errors in seqr alert the engineers, but in the case where airtable is misconfigured theres no need for a seqr engineer - any user getting this error would either be a PM or would be an internal user who would know to reach out to the PMs with airtable issues, and the error is sufficiently user-friendly and descriptive. Therefore continuing to alert the engineers is just unnecessary alert fatigue