### PR TITLE
Vep consequence updates

### DIFF
--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -941,11 +941,32 @@ const ORDERED_VEP_CONSEQUENCES = [
     so: 'SO:0001583',
   },
   {
+    description: 'A sequence variant that causes a change at the 5th base pair after the start of the intron in the orientation of the transcript',
+    text: 'Splice donor 5th base',
+    value: 'splice_donor_5th_base_variant',
+    group: VEP_GROUP_EXTENDED_SPLICE_SITE,
+    so: 'SO:0001787',
+  },
+  {
     description: 'A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron',
     text: 'Splice region',
     value: 'splice_region_variant',
     group: VEP_GROUP_EXTENDED_SPLICE_SITE,
     so: 'SO:0001630',
+  },
+  {
+    description: "A sequence variant that falls in the region between the 3rd and 6th base after splice junction (5' end of intron)",
+    text: 'Splice donor region',
+    value: 'splice_donor_region_variant',
+    group: VEP_GROUP_EXTENDED_SPLICE_SITE,
+    so: 'SO:0002170',
+  },
+  {
+    description: "A sequence variant that falls in the polypyrimidine tract at 3' end of intron between 17 and 3 bases from the end (acceptor -3 to acceptor -17)",
+    text: 'Splice polypyrimidine tract',
+    value: 'splice_polypyrimidine_tract_variant',
+    group: VEP_GROUP_EXTENDED_SPLICE_SITE,
+    so: 'SO:0002169',
   },
   {
     description: 'A sequence variant where at least one base of the final codon of an incompletely annotated transcript is changed',

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -1028,6 +1028,12 @@ const ORDERED_VEP_CONSEQUENCES = [
     so: 'SO:0001619',
   },
   {
+    description: 'A transcript variant of a protein coding gene',
+    text: 'Coding transcript variant',
+    value: 'coding_transcript_variant',
+    so: 'SO:0001968',
+  },
+  {
     description: 'A feature ablation whereby the deleted region includes a transcription factor binding site',
     text: 'TFBS ablation',
     value: 'TFBS_ablation',
@@ -1080,6 +1086,12 @@ const ORDERED_VEP_CONSEQUENCES = [
     text: 'Intergenic variant',
     value: 'intergenic_variant',
     so: 'SO:0001628',
+  },
+  {
+    description: 'A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration',
+    text: 'Sequence variant',
+    value: 'sequence_variant',
+    so: 'SO:0001060',
   },
 ]
 

--- a/ui/shared/utils/constants.js
+++ b/ui/shared/utils/constants.js
@@ -900,13 +900,6 @@ const ORDERED_VEP_CONSEQUENCES = [
     so: 'SO:0001578',
   },
   {
-    description: 'A codon variant that changes at least one base of the first codon of a transcript',
-    text: 'Initiator codon',
-    value: 'initiator_codon_variant',
-    group: VEP_GROUP_MISSENSE,
-    so: 'SO:0001582',
-  },
-  {
     description: 'A codon variant that changes at least one base of the canonical start codon.',
     text: 'Start lost',
     value: 'start_lost',
@@ -966,6 +959,13 @@ const ORDERED_VEP_CONSEQUENCES = [
     value: 'synonymous_variant',
     group: VEP_GROUP_SYNONYMOUS,
     so: 'SO:0001819',
+  },
+  {
+    description: 'A sequence variant where at least one base in the start codon is changed, but the start remains',
+    text: 'Start retained',
+    value: 'start_retained_variant',
+    group: VEP_GROUP_SYNONYMOUS,
+    so: 'SO:0002019',
   },
   {
     description: 'A sequence variant where at least one base in the terminator codon is changed, but the terminator remains',


### PR DESCRIPTION
Updates the search UI to match the newly available transcript consequences. No change to the search backend neccessary for these filters to work. 

Note that this code is not conditional, and will update for local installs on elasticsearch as well. There are already many search consequence options in the UI that are not actually available in search (theres an open bug on this) and a couple consequences that were in the data but not available in the UI. Therefore I do not think these changes will significantly degrade behavior for local installs, and adding conditional logic to the UI for which set of consequences to show did not therefore seem to be worth it.  

This code is against a branch and will be rleeased to production after the updated VEP is live