### PR TITLE
Search backend conditional unit tests

### DIFF
--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -46,7 +46,6 @@ MOCK_RECORD_ID = 'recH4SEO1CeoIlOiE'
 MOCK_RECORDS = {'records': [{'id': MOCK_RECORD_ID, 'fields': {'Status': 'Loading'}}]}
 
 
-@mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', 'testhost')
 @mock.patch('seqr.utils.redis_utils.redis.StrictRedis', lambda **kwargs: MOCK_REDIS)
 @mock.patch('seqr.utils.file_utils.open', MOCK_OPEN)
 class DatasetAPITest(object):
@@ -326,14 +325,12 @@ Let us know if you have any questions.""".format(
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['Invalid dataset type "NOT_A_TYPE"']})
 
+        self._assert_expected_add_dataset_errors(url)
+
+    def _assert_expected_add_dataset_errors(self, url):
         response = self.client.post(url, content_type='application/json', data=json.dumps({'datasetType': 'SV'}))
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'errors': ['request must contain field: "elasticsearchIndex"']})
-
-        with mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', ''):
-            response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['errors'][0], 'Adding samples is disabled for the hail backend')
 
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
@@ -498,6 +495,11 @@ class AnvilDatasetAPITest(AnvilAuthenticationTestCase, DatasetAPITest):
     fixtures = ['users', 'social_auth', '1kg_project']
     ANVIL_DISABLED = False
 
+    def _assert_expected_add_dataset_errors(self, url):
+        response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['errors'][0], 'Adding samples is disabled for the hail backend')
+
     def test_add_variants_dataset(self, *args):
-        super(AnvilDatasetAPITest, self).test_add_variants_dataset(*args)
-        assert_no_anvil_calls(self)
+        # Adding dataset is always disabled when ES is disabled, which is tested in test_add_variants_dataset_errors
+        pass

--- a/seqr/views/react_app_tests.py
+++ b/seqr/views/react_app_tests.py
@@ -24,7 +24,7 @@ class AppPageTest(object):
             'version': mock.ANY,
             'hijakEnabled': False,
             'googleLoginEnabled': self.GOOGLE_ENABLED,
-            'elasticsearchEnabled': self.ES_ENABLED,
+            'elasticsearchEnabled': bool(self.ES_HOSTNAME),
             'warningMessages': [{'id': 1, 'header': 'Warning!', 'message': 'A sample warning'}],
             'anvilLoadingDelayDate': anvil_loading_date,
         })
@@ -100,13 +100,11 @@ class AppPageTest(object):
 class LocalAppPageTest(AuthenticationTestCase, AppPageTest):
     fixtures = ['users']
     GOOGLE_ENABLED = False
-    ES_ENABLED = True
 
 
 class AnvilAppPageTest(AnvilAuthenticationTestCase, AppPageTest):
     fixtures = ['users']
     GOOGLE_ENABLED = True
-    ES_ENABLED = False
 
     def test_react_page(self, *args, **kwargs):
         super(AnvilAppPageTest, self).test_react_page(*args, **kwargs)

--- a/seqr/views/react_app_tests.py
+++ b/seqr/views/react_app_tests.py
@@ -13,7 +13,7 @@ class AppPageTest(object):
     databases = '__all__'
     fixtures = ['users']
 
-    def _check_page_html(self, response,  user, user_key='user', user_fields=None, ga_token_id=None, anvil_loading_date=None, elasticsearch_enabled=False):
+    def _check_page_html(self, response,  user, user_key='user', user_fields=None, ga_token_id=None, anvil_loading_date=None):
         user_fields = user_fields or USER_FIELDS
         self.assertEqual(response.status_code, 200)
         initial_json = self.get_initial_page_json(response)
@@ -24,7 +24,7 @@ class AppPageTest(object):
             'version': mock.ANY,
             'hijakEnabled': False,
             'googleLoginEnabled': self.GOOGLE_ENABLED,
-            'elasticsearchEnabled': elasticsearch_enabled,
+            'elasticsearchEnabled': self.ES_ENABLED,
             'warningMessages': [{'id': 1, 'header': 'Warning!', 'message': 'A sample warning'}],
             'anvilLoadingDelayDate': anvil_loading_date,
         })
@@ -80,7 +80,6 @@ class AppPageTest(object):
         response = self.client.get(url)
         self._check_page_html(response, 'test_user')
 
-    @mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', 'testhost')
     @mock.patch('seqr.views.react_app.ANVIL_LOADING_DELAY_EMAIL_START_DATE', '2022-12-01')
     @mock.patch('seqr.views.react_app.datetime')
     def test_react_page_additional_configs(self, mock_datetime):
@@ -91,21 +90,23 @@ class AppPageTest(object):
         self.check_require_login_no_policies(url, login_redirect_url='/login')
 
         response = self.client.get(url)
-        self._check_page_html(response, 'test_user_no_policies', elasticsearch_enabled=True)
+        self._check_page_html(response, 'test_user_no_policies')
 
         mock_datetime.now.return_value = datetime(2022, 12, 30, 0, 0, 0)
         response = self.client.get(url)
-        self._check_page_html(response, 'test_user_no_policies', anvil_loading_date='2022-12-01', elasticsearch_enabled=True)
+        self._check_page_html(response, 'test_user_no_policies', anvil_loading_date='2022-12-01')
 
 
 class LocalAppPageTest(AuthenticationTestCase, AppPageTest):
     fixtures = ['users']
     GOOGLE_ENABLED = False
+    ES_ENABLED = True
 
 
 class AnvilAppPageTest(AnvilAuthenticationTestCase, AppPageTest):
     fixtures = ['users']
     GOOGLE_ENABLED = True
+    ES_ENABLED = False
 
     def test_react_page(self, *args, **kwargs):
         super(AnvilAppPageTest, self).test_react_page(*args, **kwargs)

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -29,6 +29,8 @@ class AuthenticationTestCase(TestCase):
     AUTHENTICATED_USER = 'authenticated'
     NO_POLICY_USER = 'no_policy'
 
+    ES_HOSTNAME = 'testhost'
+
     super_user = None
     analyst_user = None
     pm_user = None
@@ -40,6 +42,9 @@ class AuthenticationTestCase(TestCase):
     no_policy_user = None
 
     def setUp(self):
+        patcher = mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', self.ES_HOSTNAME)
+        patcher.start()
+        self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.permissions_utils.SEQR_PRIVACY_VERSION', 2.1)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -505,6 +510,8 @@ def get_group_members_side_effect(user, group, use_sa_credentials=False):
 
 
 class AnvilAuthenticationTestCase(AuthenticationTestCase):
+
+    ES_HOSTNAME = ''
 
     # mock the terra apis
     def setUp(self):


### PR DESCRIPTION
Updates the behqvior of our Local/Anvil test cases that are used extensively in the repo to also handle conditionally testing the search backend. Currently, we have a few places where we add some nested `with mock.patch` to test behaviors, but it is not as robust and makes it difficult to add additional backend-specific tests (which I need to do for some of the upcoming VEP work). 