### PR TITLE
remove unused param from create analysis group body

### DIFF
--- a/seqr/views/apis/analysis_group_api.py
+++ b/seqr/views/apis/analysis_group_api.py
@@ -55,6 +55,7 @@ def update_analysis_group_handler(request, project_guid, analysis_group_guid=Non
     valid_families = set()
 
     def _validate_families(request_json):
+        request_json.pop('uploadedFamilyIds', None)
         family_guids = request_json.pop('familyGuids')
         families = Family.objects.filter(guid__in=family_guids).only('guid')
         if len(families) != len(family_guids):

--- a/seqr/views/apis/analysis_group_api_tests.py
+++ b/seqr/views/apis/analysis_group_api_tests.py
@@ -30,7 +30,9 @@ class AnalysisGroupAPITest(AuthenticationTestCase):
 
         # send valid request to create analysis_group
         response = self.client.post(create_analysis_group_url, content_type='application/json', data=json.dumps({
-            'name': 'new_analysis_group', 'familyGuids': ['F000001_1', 'F000002_2']
+            'name': 'new_analysis_group', 'familyGuids': ['F000001_1', 'F000002_2'], 'uploadedFamilyIds': {
+                'info': ["Uploaded 2 families"], 'parsedData': [['F000001_1'], ['F000002_2']],
+            },
         }))
         self.assertEqual(response.status_code, 200)
         new_analysis_group_response = response.json()


### PR DESCRIPTION
If a user creates an analysis group by uploading a file, there is an extra field in the POST body that should be ignored