### PR TITLE
remove trailing slash from BASE_URL in CSRF_TRUSTED_ORIGINS

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -257,7 +257,7 @@ BASE_URL = os.environ.get("BASE_URL", "/")
 if DEPLOYMENT_TYPE in {'prod', 'dev'}:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
-    CSRF_TRUSTED_ORIGINS = [BASE_URL, BASE_URL.replace('https', 'http')]
+    CSRF_TRUSTED_ORIGINS = [BASE_URL.rstrip('/')]
     DEBUG = False
 else:
     DEBUG = True


### PR DESCRIPTION
logged request_origin: https://seqr-dev.broadinstitute.org
expected CSRF_TRUSTED_ORIGINS: ['https://seqr-dev.broadinstitute.org/', 'http://seqr-dev.broadinstitute.org/']

