### PR TITLE
No max families for hpo search

### DIFF
--- a/ui/pages/Search/VariantSearch.jsx
+++ b/ui/pages/Search/VariantSearch.jsx
@@ -28,7 +28,7 @@ const VariantSearch = ({ match }) => (
       <Grid.Column width={16}>
         <Switch>
           <Route path={SEARCH_FORM_PAGES.map(pagePath => `${match.url}/${pagePath}`)} component={VariantSearchForm} />
-          <Route path={`${match.url}/families/:families`} component={NoEditProjectsVariantSearchForm} />
+          <Route path={`${match.url}/families/:familiesHash`} component={NoEditProjectsVariantSearchForm} />
           <Route path={`${match.url}/${SINGLE_VARIANT_RESULTS_PATH}`} />
           <Route path={match.url} exact component={VariantSearchForm} />
           <Route component={Error404} />

--- a/ui/pages/Search/selectors.js
+++ b/ui/pages/Search/selectors.js
@@ -10,6 +10,7 @@ import {
   getCurrentSearchParams,
   getUser,
   getProjectDatasetTypes,
+  getSearchFamiliesByHash,
 } from 'redux/selectors'
 import { FAMILY_ANALYSIS_STATUS_LOOKUP } from 'shared/utils/constants'
 import { compareObjects } from 'shared/utils/sortUtils'
@@ -66,9 +67,10 @@ export const getProjectFamilies = createSelector(
 
 export const getMultiProjectFamilies = createSelector(
   (state, props) => props.match.params,
-  params => ({
-    projectFamilies: params.families.split(':').map(f => f.split(';')).map(
-      ([projectGuid, familyGuids]) => ({ projectGuid, familyGuids: familyGuids.split(',') }),
+  getSearchFamiliesByHash,
+  (params, searchFamiliesByHash) => ({
+    projectFamilies: Object.entries(searchFamiliesByHash[params.familiesHash] || {}).map(
+      ([projectGuid, familyGuids]) => ({ projectGuid, familyGuids }),
     ),
   }),
 )

--- a/ui/redux/rootReducer.js
+++ b/ui/redux/rootReducer.js
@@ -187,11 +187,11 @@ export const updateGeneNote = values => updateEntity(
   values, RECEIVE_DATA, `/api/gene_info/${values.geneId || values.gene_id}/note`, 'noteGuid',
 )
 
-export const navigateSavedHashedSearch = (search, navigateSearch, resultsPath) => (dispatch) => {
+export const navigateSavedHashedSearch = (search, navigateSearch, resultsPath, hashKey) => (dispatch) => {
   // lazy load object-hash library as it is not used anywhere else
   import('object-hash').then((hash) => {
     const searchHash = hash.default.MD5(search)
-    dispatch({ type: RECEIVE_SAVED_SEARCHES, updatesById: { searchesByHash: { [searchHash]: search } } })
+    dispatch({ type: RECEIVE_SAVED_SEARCHES, updatesById: { [hashKey || 'searchesByHash']: { [searchHash]: search } } })
     navigateSearch(`${resultsPath || '/variant_search/results'}/${searchHash}`)
   })
 }
@@ -343,6 +343,7 @@ const rootReducer = combineReducers({
   variantNotesByGuid: createObjectsByIdReducer(RECEIVE_DATA, 'variantNotesByGuid'),
   variantFunctionalDataByGuid: createObjectsByIdReducer(RECEIVE_DATA, 'variantFunctionalDataByGuid'),
   searchesByHash: createObjectsByIdReducer(RECEIVE_SAVED_SEARCHES, 'searchesByHash'),
+  searchFamiliesByHash: createObjectsByIdReducer(RECEIVE_SAVED_SEARCHES, 'searchFamiliesByHash'),
   searchedVariants: createSingleValueReducer(RECEIVE_SEARCHED_VARIANTS, []),
   searchedVariantsLoading: loadingReducer(REQUEST_SEARCHED_VARIANTS, RECEIVE_SEARCHED_VARIANTS),
   searchGeneBreakdown: createObjectsByIdReducer(RECEIVE_SEARCH_GENE_BREAKDOWN, 'searchGeneBreakdown'),

--- a/ui/redux/selectors.js
+++ b/ui/redux/selectors.js
@@ -45,6 +45,7 @@ export const getAnvilLoadingDelayDate = state => state.meta.anvilLoadingDelayDat
 export const getSavedVariantsIsLoading = state => state.savedVariantsLoading.isLoading
 export const getSavedVariantsLoadingError = state => state.savedVariantsLoading.errorMessage
 export const getSearchesByHash = state => state.searchesByHash
+export const getSearchFamiliesByHash = state => state.searchFamiliesByHash
 export const getSearchedVariants = state => state.searchedVariants
 export const getSearchedVariantsIsLoading = state => state.searchedVariantsLoading.isLoading
 export const getSearchedVariantsErrorMessage = state => state.searchedVariantsLoading.errorMessage

--- a/ui/redux/utils/configureStore.js
+++ b/ui/redux/utils/configureStore.js
@@ -5,7 +5,7 @@ import { loadState, saveState } from 'shared/utils/localStorage'
 
 const PERSISTING_STATE = [
   'projectsTableState', 'familyTableState', 'savedVariantTableState', 'variantSearchDisplay', 'searchesByHash',
-  'familyTableFilterState',
+  'familyTableFilterState', 'searchFamiliesByHash',
 ]
 
 const persistStoreMiddleware = store => next => (action) => {


### PR DESCRIPTION
The HPO summary page created search links that put the projects and families for the relevant families directly in the URL. This ran into browser URL size limits if there were too many families, so we disabled search over that number. Since users want to do searches in more families than the limit, this rearchitects that link to instead save the families to the state/ local storage and put a hash in the URL (similar to the behavior we use for running searches)