### PR TITLE
actually remove deprecated populations on header freq change

### DIFF
--- a/ui/shared/components/panel/search/FrequencyFilter.jsx
+++ b/ui/shared/components/panel/search/FrequencyFilter.jsx
@@ -147,7 +147,7 @@ const callsetChange = (onChange, initialValues) => val => onChange(
 
 const freqChange = (onChange, initialValues) => val => onChange(FREQUENCIES.reduce((acc, { name }) => ({
   ...acc, [name]: name !== THIS_CALLSET_FREQUENCY && name !== SV_CALLSET_FREQUENCY ? val : initialValues[name],
-}), initialValues || {}))
+}), {}))
 
 export const HeaderFrequencyFilter = ({ value, onChange, esEnabled, ...props }) => {
   const { callset, sv_callset: svCallset, ...freqValues } = value || {}


### PR DESCRIPTION
Same philosophical fix as https://github.com/broadinstitute/seqr/pull/4262/files#r1693453061 but this time actually removes all the unsupported frequencies instead of leaving them unchanged