### PR TITLE
Shared saved searches in source control

### DIFF
--- a/deploy/docker/seqr/entrypoint.sh
+++ b/deploy/docker/seqr/entrypoint.sh
@@ -46,13 +46,13 @@ if ! psql --host "$POSTGRES_SERVICE_HOSTNAME" -U "$POSTGRES_USERNAME" -l | grep 
     python -u manage.py migrate
     python -u manage.py migrate --database=reference_data
     python -u manage.py loaddata variant_tag_types
-    python -u manage.py loaddata variant_searches
     python -u manage.py update_all_reference_data --use-cached-omim
 else
     # run any pending migrations if the database already exists
     python -u manage.py migrate
     python -u manage.py migrate --database=reference_data
 fi
+python -u manage.py loaddata variant_searches
 
 python -u manage.py check
 

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -329,9 +329,11 @@ class MitoHailTableQuery(BaseHailTableQuery):
         )[0]
 
         for project_guid, families in variant_projects.items():
-            if os.path.exists(self._get_table_path(f'projects/WES/{project_guid}.ht')):
+            # Temporarily use try/except to determine sample_type, to be removed when lookup table contains sample_type
+            try:
+                hl.read_table(self._get_table_path(f'projects/WES/{project_guid}.ht'))
                 sample_type = 'WES'
-            else:
+            except Exception:
                 sample_type = 'WGS'
             for family_guid, value in families.items():
                 families[family_guid] = {sample_type: value}

--- a/seqr/fixtures/variant_searches.json
+++ b/seqr/fixtures/variant_searches.json
@@ -1,31 +1,37 @@
 [
 {
     "model": "seqr.variantsearch",
-    "pk": 1,
+    "pk": 79516,
     "fields": {
-        "guid": "VS0000001_de_novo_dominant_res",
-        "name": "De Novo/ Dominant Restrictive",
+        "guid": "VS0079516_",
+        "created_date": "2022-02-04T20:49:42Z",
+        "created_by": null,
+        "last_modified_date": "2024-04-01T16:11:45.701Z",
+        "name": "De Novo/Dominant Restrictive",
+        "order": 1.0,
         "search": {
-            "qualityFilter": {
-                "vcf_filter": "pass",
-                "min_ab": 20,
-                "min_gq": 20
-            },
-            "pathogenicity": {
-                "hgmd": [
-                    "disease_causing"
-                ],
-                "clinvar": [
-                    "pathogenic",
-                    "likely_pathogenic"
-                ]
-            },
             "freqs": {
                 "g1k": {
                     "ac": null,
+                    "af": 1
+                },
+                "exac": {
+                    "ac": null,
+                    "af": 1
+                },
+                "topmed": {
+                    "ac": null,
+                    "af": 1
+                },
+                "callset": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "gnomad_svs": {
+                    "ac": null,
                     "af": 0.001
                 },
-                "gnomad_genomes": {
+                "sv_callset": {
                     "ac": null,
                     "af": 0.001
                 },
@@ -33,29 +39,15 @@
                     "ac": null,
                     "af": 0.001
                 },
-                "exac": {
+                "gnomad_genomes": {
                     "ac": null,
                     "af": 0.001
-                },
-                "topmed": {
-                    "ac": null,
-                    "af": 0.001
-                },
-                "callset": {
-                    "ac": null,
-                    "af": 0.01
                 }
             },
             "annotations": {
                 "in_frame": [
                     "inframe_insertion",
                     "inframe_deletion"
-                ],
-                "nonsense": [
-                    "stop_gained"
-                ],
-                "frameshift": [
-                    "frameshift_variant"
                 ],
                 "missense": [
                     "stop_lost",
@@ -64,35 +56,32 @@
                     "protein_altering_variant",
                     "missense_variant"
                 ],
-                "extended_splice_site": [
-                    "splice_region_variant"
+                "nonsense": [
+                    "stop_gained"
                 ],
+                "splice_ai": "0.2",
+                "frameshift": [
+                    "frameshift_variant"
+                ],
+                "structural": [],
+                "extended_splice_site": [],
                 "essential_splice_site": [
                     "splice_donor_variant",
                     "splice_acceptor_variant"
+                ],
+                "structural_consequence": [
+                    "LOF",
+                    "INV_SPAN",
+                    "COPY_GAIN"
                 ]
             },
+            "datasetType": "VARIANTS",
             "inheritance": {
+                "mode": "de_novo",
                 "filter": {
                     "A": "has_alt",
                     "N": "ref_ref"
-                },
-                "mode": "de_novo"
-            }
-        }
-    }
-},
-{
-    "model": "seqr.variantsearch",
-    "pk": 2,
-    "fields": {
-        "guid": "VS0000002_recessive_restrictiv",
-        "name": "Recessive Restrictive",
-        "search": {
-            "qualityFilter": {
-                "vcf_filter": "pass",
-                "min_ab": 20,
-                "min_gq": 20
+                }
             },
             "pathogenicity": {
                 "hgmd": [
@@ -103,42 +92,65 @@
                     "likely_pathogenic"
                 ]
             },
+            "qualityFilter": {
+                "min_ab": 20,
+                "min_gq": 30,
+                "min_qs": 50,
+                "vcf_filter": "pass"
+            }
+        }
+    }
+},
+{
+    "model": "seqr.variantsearch",
+    "pk": 79525,
+    "fields": {
+        "guid": "VS0079525_",
+        "created_date": "2022-02-04T21:28:12Z",
+        "created_by": null,
+        "last_modified_date": "2024-05-03T18:21:08.983Z",
+        "name": "Recessive Restrictive",
+        "order": 2.0,
+        "search": {
             "freqs": {
                 "g1k": {
                     "ac": null,
-                    "af": 0.01
-                },
-                "gnomad_genomes": {
-                    "ac": null,
-                    "af": 0.01
-                },
-                "gnomad_exomes": {
-                    "ac": null,
-                    "af": 0.01
+                    "af": 1
                 },
                 "exac": {
                     "ac": null,
-                    "af": 0.01
+                    "af": 1
                 },
                 "topmed": {
                     "ac": null,
-                    "af": 0.01
+                    "af": 1
                 },
                 "callset": {
                     "ac": null,
                     "af": 0.03
+                },
+                "gnomad_svs": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "sv_callset": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "gnomad_exomes": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "gnomad_genomes": {
+                    "ac": null,
+                    "af": 0.01
                 }
             },
             "annotations": {
+                "other": [],
                 "in_frame": [
                     "inframe_insertion",
                     "inframe_deletion"
-                ],
-                "nonsense": [
-                    "stop_gained"
-                ],
-                "frameshift": [
-                    "frameshift_variant"
                 ],
                 "missense": [
                     "stop_lost",
@@ -147,35 +159,191 @@
                     "protein_altering_variant",
                     "missense_variant"
                 ],
-                "extended_splice_site": [
-                    "splice_region_variant"
+                "nonsense": [
+                    "stop_gained"
                 ],
+                "splice_ai": "0.2",
+                "frameshift": [
+                    "frameshift_variant"
+                ],
+                "structural": [],
+                "synonymous": [],
+                "extended_splice_site": [],
                 "essential_splice_site": [
                     "splice_donor_variant",
                     "splice_acceptor_variant"
+                ],
+                "structural_consequence": [
+                    "LOF",
+                    "INV_SPAN"
                 ]
             },
             "inheritance": {
+                "mode": "recessive",
                 "filter": {
                     "A": null,
                     "N": null
                 },
-                "mode": "recessive"
+                "annotationSecondary": true
+            },
+            "pathogenicity": {
+                "hgmd": [
+                    "disease_causing"
+                ],
+                "clinvar": [
+                    "pathogenic",
+                    "likely_pathogenic"
+                ]
+            },
+            "qualityFilter": {
+                "min_ab": 20,
+                "min_gq": 30,
+                "min_qs": 50,
+                "vcf_filter": "pass"
+            },
+            "annotations_secondary": {
+                "in_frame": [
+                    "inframe_insertion",
+                    "inframe_deletion"
+                ],
+                "missense": [
+                    "stop_lost",
+                    "initiator_codon_variant",
+                    "start_lost",
+                    "protein_altering_variant",
+                    "missense_variant"
+                ],
+                "nonsense": [
+                    "stop_gained"
+                ],
+                "frameshift": [
+                    "frameshift_variant"
+                ],
+                "structural": [],
+                "extended_splice_site": [],
+                "essential_splice_site": [
+                    "splice_donor_variant",
+                    "splice_acceptor_variant"
+                ],
+                "structural_consequence": [
+                    "LOF",
+                    "INV_SPAN"
+                ]
             }
         }
     }
 },
 {
     "model": "seqr.variantsearch",
-    "pk": 3,
+    "pk": 79517,
     "fields": {
-        "guid": "VS0000003_de_novo_dominant_per",
-        "name": "De Novo/ Dominant Permissive",
+        "guid": "VS0079517_",
+        "created_date": "2022-02-04T20:51:58Z",
+        "created_by": null,
+        "last_modified_date": "2024-04-01T16:12:23.216Z",
+        "name": "De Novo/Dominant Permissive",
+        "order": 3.0,
         "search": {
-            "qualityFilter": {
-                "vcf_filter": null,
-                "min_ab": 0,
-                "min_gq": 20
+            "freqs": {
+                "g1k": {
+                    "ac": null,
+                    "af": 1
+                },
+                "exac": {
+                    "ac": null,
+                    "af": 1
+                },
+                "topmed": {
+                    "ac": null,
+                    "af": 1
+                },
+                "callset": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "gnomad_svs": {
+                    "ac": null,
+                    "af": 0.001
+                },
+                "sv_callset": {
+                    "ac": null,
+                    "af": 0.001
+                },
+                "gnomad_exomes": {
+                    "ac": null,
+                    "af": 0.001
+                },
+                "gnomad_genomes": {
+                    "ac": null,
+                    "af": 0.001
+                }
+            },
+            "annotations": {
+                "other": [
+                    "transcript_ablation",
+                    "transcript_amplification",
+                    "5_prime_UTR_variant",
+                    "3_prime_UTR_variant",
+                    "non_coding_exon_variant",
+                    "TFBS_ablation",
+                    "TFBS_amplification",
+                    "TF_binding_site_variant",
+                    "regulatory_region_variant",
+                    "regulatory_region_ablation",
+                    "regulatory_region_amplification"
+                ],
+                "in_frame": [
+                    "inframe_insertion",
+                    "inframe_deletion"
+                ],
+                "missense": [
+                    "stop_lost",
+                    "initiator_codon_variant",
+                    "start_lost",
+                    "protein_altering_variant",
+                    "missense_variant"
+                ],
+                "nonsense": [
+                    "stop_gained"
+                ],
+                "splice_ai": "0.1",
+                "frameshift": [
+                    "frameshift_variant"
+                ],
+                "structural": [
+                    "gCNV_DEL",
+                    "gCNV_DUP"
+                ],
+                "synonymous": [
+                    "synonymous_variant",
+                    "stop_retained_variant"
+                ],
+                "extended_splice_site": [
+                    "splice_region_variant"
+                ],
+                "essential_splice_site": [
+                    "splice_donor_variant",
+                    "splice_acceptor_variant"
+                ],
+                "structural_consequence": [
+                    "LOF",
+                    "COPY_GAIN",
+                    "DUP_PARTIAL",
+                    "MSV_EXON_OVR",
+                    "INTRONIC",
+                    "INV_SPAN",
+                    "UTR",
+                    "INTERGENIC",
+                    "PROMOTER"
+                ]
+            },
+            "datasetType": "VARIANTS",
+            "inheritance": {
+                "mode": "de_novo",
+                "filter": {
+                    "A": "has_alt",
+                    "N": "ref_ref"
+                }
             },
             "pathogenicity": {
                 "hgmd": [
@@ -187,59 +355,67 @@
                     "vus_or_conflicting"
                 ]
             },
+            "qualityFilter": {
+                "min_ab": 10,
+                "min_gq": 30,
+                "min_qs": 20,
+                "vcf_filter": null
+            }
+        }
+    }
+},
+{
+    "model": "seqr.variantsearch",
+    "pk": 145435,
+    "fields": {
+        "guid": "VS0145435_",
+        "created_date": "2023-11-06T16:31:06Z",
+        "created_by": null,
+        "last_modified_date": "2024-05-03T18:21:23.219Z",
+        "name": "Recessive Permissive",
+        "order": 4.0,
+        "search": {
             "freqs": {
                 "g1k": {
                     "ac": null,
-                    "af": 0.001
-                },
-                "gnomad_genomes": {
-                    "ac": null,
-                    "af": 0.001
-                },
-                "gnomad_exomes": {
-                    "ac": null,
-                    "af": 0.001
+                    "af": 1
                 },
                 "exac": {
                     "ac": null,
-                    "af": 0.001
+                    "af": 1
                 },
                 "topmed": {
                     "ac": null,
-                    "af": 0.001
+                    "af": 1
                 },
                 "callset": {
+                    "ac": null,
+                    "af": 0.03
+                },
+                "gnomad_svs": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "sv_callset": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "gnomad_exomes": {
+                    "ac": null,
+                    "af": 0.01
+                },
+                "gnomad_genomes": {
                     "ac": null,
                     "af": 0.01
                 }
             },
             "annotations": {
+                "other": [
+                    "non_coding_exon_variant"
+                ],
                 "in_frame": [
                     "inframe_insertion",
                     "inframe_deletion"
-                ],
-                "synonymous": [
-                    "synonymous_variant",
-                    "stop_retained_variant"
-                ],
-                "nonsense": [
-                    "stop_gained"
-                ],
-                "frameshift": [
-                    "frameshift_variant"
-                ],
-                "other": [
-                    "5_prime_UTR_variant",
-                    "3_prime_UTR_variant",
-                    "TF_binding_site_variant",
-                    "non_coding_exon_variant",
-                    "regulatory_region_variant",
-                    "transcript_ablation",
-                    "transcript_amplification",
-                    "TFBS_ablation",
-                    "TFBS_amplification",
-                    "regulatory_region_ablation",
-                    "regulatory_region_amplification"
                 ],
                 "missense": [
                     "stop_lost",
@@ -248,20 +424,107 @@
                     "protein_altering_variant",
                     "missense_variant"
                 ],
+                "nonsense": [
+                    "stop_gained"
+                ],
+                "splice_ai": "0.1",
+                "frameshift": [
+                    "frameshift_variant"
+                ],
+                "structural": [
+                    "gCNV_DUP",
+                    "gCNV_DEL"
+                ],
+                "synonymous": [],
+                "extended_splice_site": [],
+                "essential_splice_site": [
+                    "splice_donor_variant",
+                    "splice_acceptor_variant"
+                ],
+                "structural_consequence": [
+                    "LOF",
+                    "MSV_EXON_OVR",
+                    "INTRAGENIC_EXON_DUP",
+                    "PARTIAL_EXON_DUP"
+                ]
+            },
+            "inheritance": {
+                "mode": "recessive",
+                "filter": {
+                    "A": null,
+                    "N": null
+                },
+                "annotationSecondary": true
+            },
+            "pathogenicity": {
+                "hgmd": [
+                    "disease_causing"
+                ],
+                "clinvar": [
+                    "pathogenic",
+                    "likely_pathogenic",
+                    "vus_or_conflicting"
+                ]
+            },
+            "qualityFilter": {
+                "min_ab": 10,
+                "min_gq": 30,
+                "min_qs": 50
+            },
+            "annotations_secondary": {
+                "other": [
+                    "transcript_ablation",
+                    "transcript_amplification",
+                    "5_prime_UTR_variant",
+                    "3_prime_UTR_variant",
+                    "TFBS_ablation",
+                    "TFBS_amplification",
+                    "TF_binding_site_variant",
+                    "regulatory_region_variant",
+                    "regulatory_region_ablation",
+                    "regulatory_region_amplification",
+                    "non_coding_transcript_exon_variant__canonical"
+                ],
+                "in_frame": [
+                    "inframe_insertion",
+                    "inframe_deletion"
+                ],
+                "missense": [
+                    "stop_lost",
+                    "initiator_codon_variant",
+                    "start_lost",
+                    "protein_altering_variant",
+                    "missense_variant"
+                ],
+                "nonsense": [
+                    "stop_gained"
+                ],
+                "frameshift": [
+                    "frameshift_variant"
+                ],
+                "structural": [
+                    "gCNV_DEL",
+                    "gCNV_DUP"
+                ],
+                "synonymous": [
+                    "synonymous_variant",
+                    "stop_retained_variant"
+                ],
                 "extended_splice_site": [
                     "splice_region_variant"
                 ],
                 "essential_splice_site": [
                     "splice_donor_variant",
                     "splice_acceptor_variant"
+                ],
+                "structural_consequence": [
+                    "LOF",
+                    "INTRONIC",
+                    "UTR",
+                    "PROMOTER",
+                    "INTRAGENIC_EXON_DUP",
+                    "PARTIAL_EXON_DUP"
                 ]
-            },
-            "inheritance": {
-                "filter": {
-                    "A": "has_alt",
-                    "N": "ref_ref"
-                },
-                "mode": "de_novo"
             }
         }
     }

--- a/seqr/management/tests/reset_cached_search_results_tests.py
+++ b/seqr/management/tests/reset_cached_search_results_tests.py
@@ -15,7 +15,7 @@ class ResetCachedSearchResultsTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        result = VariantSearchResults.objects.create(search_hash='abc', variant_search_id=1)
+        result = VariantSearchResults.objects.create(search_hash='abc', variant_search_id=79516)
         result.families.set(Family.objects.filter(pk=1))
         cls.result_guid = result.guid
 

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -132,7 +132,7 @@ EXPECTED_TRANSCRIPTS_RESPONSE = {
 
 EXPECTED_SEARCH_CONTEXT_RESPONSE = {
     'savedSearchesByGuid': {
-        'VS0000001_de_novo_dominant_res': mock.ANY, 'VS0000002_recessive_restrictiv': mock.ANY, 'VS0000003_de_novo_dominant_per': mock.ANY,
+        'VS0079516_': mock.ANY, 'VS0079525_': mock.ANY, 'VS0079517_': mock.ANY, 'VS0145435_': mock.ANY,
     },
     'projectsByGuid': {PROJECT_GUID: mock.ANY},
     'familiesByGuid': mock.ANY,
@@ -700,7 +700,7 @@ class VariantSearchAPITest(object):
         expected_response['projectsByGuid']['R0003_test'] = mock.ANY
         self.assertSetEqual(set(response_json), set(expected_response))
         self.assertDictEqual(response_json, expected_response)
-        self.assertEqual(len(response_json['savedSearchesByGuid']), 3)
+        self.assertEqual(len(response_json['savedSearchesByGuid']), 4)
         self.assertSetEqual(set(response_json['projectsByGuid'][PROJECT_GUID].keys()), PROJECT_CONTEXT_FIELDS)
         self.assertSetEqual(set(response_json['projectsByGuid'][PROJECT_GUID]['datasetTypes']), {'SNV_INDEL', 'SV', 'MITO'})
         self.assertSetEqual(set(response_json['projectsByGuid']['R0003_test']['datasetTypes']), {'SNV_INDEL'})
@@ -936,7 +936,7 @@ class VariantSearchAPITest(object):
 
         response = self.client.get(get_saved_search_url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['savedSearchesByGuid']), 3)
+        self.assertEqual(len(response.json()['savedSearchesByGuid']), 4)
 
         create_saved_search_url = reverse(create_saved_search_handler)
 
@@ -971,7 +971,7 @@ class VariantSearchAPITest(object):
 
         response = self.client.get(get_saved_search_url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['savedSearchesByGuid']), 4)
+        self.assertEqual(len(response.json()['savedSearchesByGuid']), 5)
 
         # Test cannot save different searches with the same name
         body['filters'] = {'test': 'filter'}
@@ -1001,7 +1001,7 @@ class VariantSearchAPITest(object):
 
         response = self.client.get(get_saved_search_url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.json()['savedSearchesByGuid']), 3)
+        self.assertEqual(len(response.json()['savedSearchesByGuid']), 4)
 
         global_saved_search_guid = next(iter(response.json()['savedSearchesByGuid']))
 

--- a/seqr/views/utils/orm_to_json_utils_tests.py
+++ b/seqr/views/utils/orm_to_json_utils_tests.py
@@ -178,7 +178,7 @@ class JSONUtilsTest(object):
         self.assertSetEqual(set(json.keys()), fields)
 
     def test_json_for_saved_search(self):
-        searches = VariantSearch.objects.filter(id=1)
+        searches = VariantSearch.objects.filter(name='De Novo/Dominant Restrictive')
         user = User.objects.get(username='test_user')
         json = get_json_for_saved_searches(searches, user)[0]
 


### PR DESCRIPTION
Django's `loaddata` command will update data in the database based on fixture json. If PK is specified, Django will create a model with that pk if none exists, or will update the existing model if it does. There is no harm in running the command if nothing changes

This PR encodes our current saved searches into source control with no change