### PR TITLE
Igv proxy error

### DIFF
--- a/seqr/views/apis/igv_api_tests.py
+++ b/seqr/views/apis/igv_api_tests.py
@@ -317,10 +317,11 @@ class IgvAPITest(AnvilAuthenticationTestCase):
             responses.GET, 'https://s3.amazonaws.com/igv.org.genomes/foo?query=true', match_querystring=True,
             content_type='application/json', body=json.dumps(expected_body))
 
-        response = self.client.get(s3_url)
+        response = self.client.get(s3_url, HTTP_TEST_HEADER='test/value')
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(json.loads(response.content), expected_body)
         self.assertIsNone(responses.calls[0].request.headers.get('Range'))
+        self.assertEqual(responses.calls[0].request.headers.get('Test-Header'), 'test/value')
 
         # test with range header proxy
         gs_url = reverse(igv_genomes_proxy, args=['gs', 'test-bucket/foo.fasta'])
@@ -329,7 +330,8 @@ class IgvAPITest(AnvilAuthenticationTestCase):
             responses.GET, 'https://storage.googleapis.com/test-bucket/foo.fasta', match_querystring=True,
             body=expected_content)
 
-        response = self.client.get(gs_url, HTTP_RANGE='bytes=100-200')
+        response = self.client.get(gs_url, HTTP_RANGE='bytes=100-200', HTTP_TEST_HEADER='test/value')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content.decode(), expected_content)
         self.assertEqual(responses.calls[1].request.headers.get('Range'), 'bytes=100-200')
+        self.assertIsNone(responses.calls[1].request.headers.get('Test-Header'))

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -620,3 +620,18 @@ def load_phenotype_prioritization_data_file(file_path, user):
                 raise ValueError(f'Multiple tools found {tool} and {row_dict["tool"]}. Only one in a file is supported.')
 
     return tool, data_by_project_sample_id
+
+
+def convert_django_meta_to_http_headers(request):
+
+    def convert_key(key):
+        # converting Django's all-caps keys (eg. 'HTTP_RANGE') to regular HTTP header keys (eg. 'Range')
+        return key.replace("HTTP_", "").replace('_', '-').title()
+
+    http_headers = {
+        convert_key(key): str(value).lstrip()
+        for key, value in request.META.items()
+        if key.startswith("HTTP_") or (key in ('CONTENT_LENGTH', 'CONTENT_TYPE') and value)
+    }
+
+    return http_headers


### PR DESCRIPTION
IGV JS's reference files are now returning 403 errors, but proxying the headers fixes this issue