### PR TITLE
Better airtable enabled checks

### DIFF
--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -8,7 +8,7 @@ import responses
 from seqr.models import Project, Family, Individual
 from seqr.views.apis.anvil_workspace_api import anvil_workspace_page, create_project_from_workspace, \
     validate_anvil_vcf, grant_workspace_access, add_workspace_data, get_anvil_vcf_list, get_anvil_igv_options
-from seqr.views.utils.test_utils import AnvilAuthenticationTestCase, AuthenticationTestCase, AirflowTestCase, \
+from seqr.views.utils.test_utils import AnvilAuthenticationTestCase, AuthenticationTestCase, AirflowTestCase, AirtableTest, \
     TEST_WORKSPACE_NAMESPACE, TEST_WORKSPACE_NAME, TEST_WORKSPACE_NAME1, TEST_NO_PROJECT_WORKSPACE_NAME, TEST_NO_PROJECT_WORKSPACE_NAME2
 from seqr.views.utils.terra_api_utils import remove_token, TerraAPIException, TerraRefreshTokenFailedException
 from settings import SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL, SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL
@@ -67,7 +67,6 @@ REQUEST_BODY.update(VALIDATE_VFC_RESPONSE)
 TEMP_PATH = '/temp_path/temp_filename'
 
 MOCK_AIRTABLE_URL = 'http://testairtable'
-MOCK_AIRTABLE_KEY = 'mock_key' # nosec
 
 PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA20870', 'HG00732', 'NA19675_1', 'NA20874', 'HG00733', 'HG00731']
 PROJECT2_SAMPLES = ['NA20885', 'NA19675_1', 'NA19678', 'HG00735']
@@ -484,7 +483,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         ])
 
 
-class LoadAnvilDataAPITest(AirflowTestCase):
+class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
     fixtures = ['users', 'social_auth', 'reference_data', '1kg_project']
 
     LOADING_PROJECT_GUID = f'P_{TEST_NO_PROJECT_WORKSPACE_NAME}'
@@ -509,9 +508,6 @@ class LoadAnvilDataAPITest(AirflowTestCase):
     def setUp(self):
         # Set up api responses
         responses.add(responses.POST, f'{MOCK_AIRTABLE_URL}/appUelDNM3BnWaR7M/AnVIL%20Seqr%20Loading%20Requests%20Tracking', status=400)
-        patcher = mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_API_KEY', MOCK_AIRTABLE_KEY)
-        patcher.start()
-        self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_URL', MOCK_AIRTABLE_URL)
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -777,7 +773,7 @@ class LoadAnvilDataAPITest(AirflowTestCase):
             'Number of Samples': 8 if test_add_data else 3,
             'Status': 'Loading',
         }}]})
-        self.assertEqual(responses.calls[-1].request.headers['Authorization'], 'Bearer {}'.format(MOCK_AIRTABLE_KEY))
+        self.assert_expected_airtable_headers(-1)
 
         dag_json = {
             'projects_to_run': [project.guid],

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -471,12 +471,15 @@ def get_loaded_projects(request, sample_type, dataset_type):
     projects = get_internal_projects().filter(is_demo=False)
     project_samples = None
     if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
-        project_samples = _fetch_airtable_loadable_project_samples(request.user)
-        projects = projects.filter(guid__in=project_samples.keys())
+        import pdb; pdb.set_trace()
+        if AirtableSession.is_airtable_enabled():
+            project_samples = _fetch_airtable_loadable_project_samples(request.user)
+            projects = projects.filter(guid__in=project_samples.keys())
         exclude_sample_type = Sample.SAMPLE_TYPE_WES if sample_type == Sample.SAMPLE_TYPE_WGS else Sample.SAMPLE_TYPE_WGS
         # Include projects with either the matched sample type OR with no loaded data
         projects = projects.exclude(family__individual__sample__sample_type=exclude_sample_type)
     else:
+        # All other data types can only be loaded to projects which already have loaded data
         projects = projects.filter(family__individual__sample__sample_type=sample_type)
 
     projects = projects.distinct().order_by('name').values('name', projectGuid=F('guid'), dataTypeLastLoaded=Max(

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -471,12 +471,14 @@ def get_loaded_projects(request, sample_type, dataset_type):
     projects = get_internal_projects().filter(is_demo=False)
     project_samples = None
     if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
-        project_samples = _fetch_airtable_loadable_project_samples(request.user)
-        projects = projects.filter(guid__in=project_samples.keys())
+        if AirtableSession.is_airtable_enabled():
+            project_samples = _fetch_airtable_loadable_project_samples(request.user)
+            projects = projects.filter(guid__in=project_samples.keys())
         exclude_sample_type = Sample.SAMPLE_TYPE_WES if sample_type == Sample.SAMPLE_TYPE_WGS else Sample.SAMPLE_TYPE_WGS
         # Include projects with either the matched sample type OR with no loaded data
         projects = projects.exclude(family__individual__sample__sample_type=exclude_sample_type)
     else:
+        # All other data types can only be loaded to projects which already have loaded data
         projects = projects.filter(family__individual__sample__sample_type=sample_type)
 
     projects = projects.distinct().order_by('name').values('name', projectGuid=F('guid'), dataTypeLastLoaded=Max(

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -477,7 +477,6 @@ def get_loaded_projects(request, sample_type, dataset_type):
         # Include projects with either the matched sample type OR with no loaded data
         projects = projects.exclude(family__individual__sample__sample_type=exclude_sample_type)
     else:
-        # All other data types can only be loaded to projects which already have loaded data
         projects = projects.filter(family__individual__sample__sample_type=sample_type)
 
     projects = projects.distinct().order_by('name').values('name', projectGuid=F('guid'), dataTypeLastLoaded=Max(

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -471,8 +471,14 @@ def get_loaded_projects(request, sample_type, dataset_type):
     projects = get_internal_projects().filter(is_demo=False)
     project_samples = None
     if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
-        if AirtableSession.is_airtable_enabled():
-            project_samples = _fetch_airtable_loadable_project_samples(request.user)
+        try:
+            airtable_session = AirtableSession(request.user)
+        except ValueError:
+            # Airtable is not configured for the deployment
+            airtable_session = None
+        if airtable_session:
+            project_samples = _fetch_airtable_loadable_project_samples(airtable_session)
+            import pdb; pdb.set_trace()
             projects = projects.filter(guid__in=project_samples.keys())
         exclude_sample_type = Sample.SAMPLE_TYPE_WES if sample_type == Sample.SAMPLE_TYPE_WGS else Sample.SAMPLE_TYPE_WGS
         # Include projects with either the matched sample type OR with no loaded data
@@ -482,7 +488,8 @@ def get_loaded_projects(request, sample_type, dataset_type):
         projects = projects.filter(family__individual__sample__sample_type=sample_type)
 
     projects = projects.distinct().order_by('name').values('name', projectGuid=F('guid'), dataTypeLastLoaded=Max(
-        'family__individual__sample__loaded_date', filter=Q(family__individual__sample__dataset_type=dataset_type),
+        'family__individual__sample__loaded_date',
+        filter=Q(family__individual__sample__dataset_type=dataset_type) & Q(family__individual__sample__sample_type=sample_type),
     ))
 
     if project_samples:
@@ -492,8 +499,8 @@ def get_loaded_projects(request, sample_type, dataset_type):
     return create_json_response({'projects': list(projects)})
 
 
-def _fetch_airtable_loadable_project_samples(user):
-    pdos = AirtableSession(user).fetch_records(
+def _fetch_airtable_loadable_project_samples(session):
+    pdos = session.fetch_records(
         'PDO', fields=['PassingCollaboratorSampleIDs', 'SeqrIDs', 'SeqrProjectURL'],
         or_filters={'PDOStatus': LOADABLE_PDO_STATUSES}
     )

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -471,10 +471,8 @@ def get_loaded_projects(request, sample_type, dataset_type):
     projects = get_internal_projects().filter(is_demo=False)
     project_samples = None
     if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
-        import pdb; pdb.set_trace()
-        if AirtableSession.is_airtable_enabled():
-            project_samples = _fetch_airtable_loadable_project_samples(request.user)
-            projects = projects.filter(guid__in=project_samples.keys())
+        project_samples = _fetch_airtable_loadable_project_samples(request.user)
+        projects = projects.filter(guid__in=project_samples.keys())
         exclude_sample_type = Sample.SAMPLE_TYPE_WES if sample_type == Sample.SAMPLE_TYPE_WGS else Sample.SAMPLE_TYPE_WGS
         # Include projects with either the matched sample type OR with no loaded data
         projects = projects.exclude(family__individual__sample__sample_type=exclude_sample_type)

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1481,6 +1481,7 @@ class DataManagerAPITest(AirtableTest):
         self.assertEqual(response.status_code, 200)
 
         # test with airtable filter
+        # TODO failing
         responses.add(
             responses.GET, 'https://api.airtable.com/v0/app3Y97xtbbaOopVR/PDO', json=AIRTABLE_PDO_RECORDS, status=200,
         )

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -405,8 +405,8 @@ EMPTY_PROJECT_OPTION = {
     'dataTypeLastLoaded': None,
     'name': 'Empty Project',
     'projectGuid': 'R0002_empty',
-    'sampleIds': ['HG00738', 'HG00739'],
 }
+EMPTY_PROJECT_SAMPLES_OPTION = {**EMPTY_PROJECT_OPTION, 'sampleIds': ['HG00738', 'HG00739']}
 
 AIRTABLE_PDO_RECORDS = {
     'records': [
@@ -1481,27 +1481,28 @@ class DataManagerAPITest(AirtableTest):
         self.assertEqual(response.status_code, 200)
 
         # test with airtable filter
-        # TODO failing
         responses.add(
             responses.GET, 'https://api.airtable.com/v0/app3Y97xtbbaOopVR/PDO', json=AIRTABLE_PDO_RECORDS, status=200,
         )
         snv_indel_url = url.replace('SV', 'SNV_INDEL')
         response = self.client.get(snv_indel_url)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'projects': [EMPTY_PROJECT_OPTION, PROJECT_SAMPLES_OPTION]})
-        self.assert_expected_airtable_call(
-            call_index=0, filter_formula="OR(PDOStatus='Methods (Loading)',PDOStatus='On hold for phenotips, but ready to load')",
-            fields=['PassingCollaboratorSampleIDs', 'SeqrIDs', 'SeqrProjectURL'],
-        )
+        self.assertDictEqual(response.json(), {'projects': self.WGS_PROJECT_OPTIONS})
 
         # test projects with no data loaded are returned for any sample type
         response = self.client.get(snv_indel_url.replace('WGS', 'WES'))
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'projects': [EMPTY_PROJECT_OPTION]})
+        self.assertDictEqual(response.json(), {'projects': self.WES_PROJECT_OPTIONS})
 
 
 class LocalDataManagerAPITest(AuthenticationTestCase, DataManagerAPITest):
     fixtures = ['users', '1kg_project', 'reference_data']
+
+    WGS_PROJECT_OPTIONS = [EMPTY_PROJECT_OPTION, PROJECT_OPTION]
+    WES_PROJECT_OPTIONS = [
+        {'name': '1kg project nåme with uniçøde', 'projectGuid': 'R0001_1kg', 'dataTypeLastLoaded': '2017-02-05T06:25:55.397Z'},
+        EMPTY_PROJECT_OPTION,
+    ]
 
     def setUp(self):
         patcher = mock.patch('seqr.utils.file_utils.os.path.isfile')
@@ -1530,6 +1531,8 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
 
     LOADING_PROJECT_GUID = 'R0004_non_analyst_project'
     PROJECTS = [PROJECT_GUID, LOADING_PROJECT_GUID]
+    WGS_PROJECT_OPTIONS = [EMPTY_PROJECT_SAMPLES_OPTION, PROJECT_SAMPLES_OPTION]
+    WES_PROJECT_OPTIONS = [EMPTY_PROJECT_SAMPLES_OPTION, PROJECT_SAMPLES_OPTION]
 
     def setUp(self):
         patcher = mock.patch('seqr.utils.file_utils.subprocess.Popen')
@@ -1577,8 +1580,12 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
         self.assertEqual(response.json()['error'], 'Deleting indices is disabled for the hail backend')
 
     def test_get_loaded_projects(self, *args, **kwargs):
-        # Test relies on the local-only project data, and has no real difference for local/ non-local behavior
-        pass
+        super().test_get_loaded_projects(*args, **kwargs)
+        self.assert_expected_airtable_call(
+            call_index=0,
+            filter_formula="OR(PDOStatus='Methods (Loading)',PDOStatus='On hold for phenotips, but ready to load')",
+            fields=['PassingCollaboratorSampleIDs', 'SeqrIDs', 'SeqrProjectURL'],
+        )
 
     @staticmethod
     def _get_dag_variable_overrides(*args, **kwargs):

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -31,8 +31,8 @@ logger = SeqrLogger(__name__)
 MONDO_BASE_URL = 'https://monarchinitiative.org/v3/api/entity'
 
 
-anvil_enabled_analyst_required = active_user_has_policies_and_passes_test(
-    lambda user: user_is_analyst(user) and anvil_enabled())
+airtable_enabled_analyst_required = active_user_has_policies_and_passes_test(
+    lambda user: user_is_analyst(user) and AirtableSession.is_airtable_enabled())
 
 
 @pm_or_analyst_required
@@ -115,7 +115,7 @@ PHENOTYPE_PROJECT_CATEGORIES = [
 ]
 
 
-@anvil_enabled_analyst_required
+@airtable_enabled_analyst_required
 def anvil_export(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)
 
@@ -353,7 +353,7 @@ HPO_QUALIFIERS = {
 }
 
 
-@anvil_enabled_analyst_required
+@airtable_enabled_analyst_required
 def gregor_export(request):
     request_json = json.loads(request.body)
     missing_required_fields = [field for field in ['consentCode', 'deliveryPath'] if not request_json.get(field)]

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -17,8 +17,8 @@ from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, anvil_ex
     EXPERIMENT_TABLE, EXPERIMENT_LOOKUP_TABLE, FINDINGS_TABLE, GENE_COLUMN, FAMILY_INDIVIDUAL_FIELDS
 from seqr.views.utils.export_utils import export_multiple_files, write_multiple_files_to_gs
 from seqr.views.utils.json_utils import create_json_response
-from seqr.views.utils.permissions_utils import analyst_required, get_project_and_check_permissions, \
-    get_project_guids_user_can_view, get_internal_projects, pm_or_analyst_required
+from seqr.views.utils.permissions_utils import user_is_analyst, get_project_and_check_permissions, \
+    get_project_guids_user_can_view, get_internal_projects, pm_or_analyst_required, active_user_has_policies_and_passes_test
 from seqr.views.utils.terra_api_utils import anvil_enabled
 from seqr.views.utils.variant_utils import DISCOVERY_CATEGORY
 
@@ -29,6 +29,10 @@ from settings import GREGOR_DATA_MODEL_URL
 logger = SeqrLogger(__name__)
 
 MONDO_BASE_URL = 'https://monarchinitiative.org/v3/api/entity'
+
+
+anvil_enabled_analyst_required = active_user_has_policies_and_passes_test(
+    lambda user: user_is_analyst(user) and anvil_enabled())
 
 
 @pm_or_analyst_required
@@ -111,7 +115,7 @@ PHENOTYPE_PROJECT_CATEGORIES = [
 ]
 
 
-@analyst_required
+@anvil_enabled_analyst_required
 def anvil_export(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)
 
@@ -349,7 +353,7 @@ HPO_QUALIFIERS = {
 }
 
 
-@analyst_required
+@anvil_enabled_analyst_required
 def gregor_export(request):
     request_json = json.loads(request.body)
     missing_required_fields = [field for field in ['consentCode', 'deliveryPath'] if not request_json.get(field)]

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -677,10 +677,8 @@ class ReportAPITest(AirtableTest):
         self.check_no_analyst_no_access(url, has_override=self.HAS_PM_OVERRIDE)
 
     @mock.patch('seqr.views.utils.export_utils.zipfile.ZipFile')
-    @mock.patch('seqr.views.utils.airtable_utils.is_google_authenticated')
     @responses.activate
-    def test_anvil_export(self, mock_google_authenticated,  mock_zip):
-        mock_google_authenticated.return_value = False
+    def test_anvil_export(self, mock_zip):
         url = reverse(anvil_export, args=[PROJECT_GUID])
         self.check_analyst_login(url)
 
@@ -689,13 +687,19 @@ class ReportAPITest(AirtableTest):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
 
+        responses.add(responses.GET, '{}/app3Y97xtbbaOopVR/Samples'.format(AIRTABLE_URL), json=AIRTABLE_SAMPLE_RECORDS, status=200)
+        response = self.client.get(url)
+        self._check_anvil_export_response(response, mock_zip, no_analyst_project_url)
+
+        # Test non-broad analysts do not have access
+        self.login_pm_user()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
-        mock_google_authenticated.return_value = True
 
-        responses.add(responses.GET, '{}/app3Y97xtbbaOopVR/Samples'.format(AIRTABLE_URL), json=AIRTABLE_SAMPLE_RECORDS, status=200)
-        response = self.client.get(url)
+        self.check_no_analyst_no_access(url)
+
+    def _check_anvil_export_response(self, response, mock_zip, no_analyst_project_url):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.get('content-disposition'),
@@ -764,30 +768,27 @@ class ReportAPITest(AirtableTest):
             'p.Ala196Leu): 19-1912633-G-T, 19-1912634-C-T'],
             discovery_file)
 
-        added_perm = self.add_analyst_project(4)
-        if added_perm:
-            response = self.client.get(no_analyst_project_url)
-            self.assertEqual(response.status_code, 400)
-            self.assertEqual(response.json()['errors'], ['Discovery variant(s) 1-248367227-TC-T in family 14 have no associated gene'])
-
-        self.check_no_analyst_no_access(url)
-
-        # Test non-broad analysts do not have access
-        self.login_pm_user()
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Permission Denied')
+        self.login_data_manager_user()
+        self.mock_get_groups.side_effect = lambda user: ['Analysts']
+        response = self.client.get(no_analyst_project_url)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()['errors'],
+                         ['Discovery variant(s) 1-248367227-TC-T in family 14 have no associated gene'])
 
     @mock.patch('seqr.views.apis.report_api.GREGOR_DATA_MODEL_URL', MOCK_DATA_MODEL_URL)
-    @mock.patch('seqr.views.utils.airtable_utils.is_google_authenticated')
     @mock.patch('seqr.views.apis.report_api.datetime')
     @mock.patch('seqr.views.utils.export_utils.open')
     @mock.patch('seqr.views.utils.export_utils.TemporaryDirectory')
     @mock.patch('seqr.utils.file_utils.subprocess.Popen')
     @responses.activate
-    def test_gregor_export(self, mock_subprocess, mock_temp_dir, mock_open, mock_datetime, mock_google_authenticated):
+    def test_gregor_export(self, *args):
+        url = reverse(gregor_export)
+        self.check_analyst_login(url)
+
+        self._test_gregor_export(url, *args)
+
+    def _test_gregor_export(self, url, mock_subprocess, mock_temp_dir, mock_open, mock_datetime):
         mock_datetime.now.return_value.year = 2020
-        mock_google_authenticated.return_value = False
         mock_temp_dir.return_value.__enter__.return_value = '/mock/tmp'
         mock_subprocess.return_value.wait.return_value = 1
 
@@ -798,9 +799,6 @@ class ReportAPITest(AirtableTest):
             responses.GET, '{}/app3Y97xtbbaOopVR/GREGoR Data Model'.format(AIRTABLE_URL), json=AIRTABLE_GREGOR_RECORDS,
             status=200)
         responses.add(responses.GET, MOCK_DATA_MODEL_URL, status=404)
-
-        url = reverse(gregor_export)
-        self.check_analyst_login(url)
 
         response = self.client.post(url, content_type='application/json', data=json.dumps({}))
         self.assertEqual(response.status_code, 400)
@@ -817,11 +815,6 @@ class ReportAPITest(AirtableTest):
         self.assertListEqual(response.json()['errors'], ['Invalid Delivery Path: folder not found'])
 
         mock_subprocess.return_value.wait.return_value = 0
-        response = self.client.post(url, content_type='application/json', data=json.dumps(body))
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Permission Denied')
-
-        mock_google_authenticated.return_value = True
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 400)
         self.assertListEqual(response.json()['errors'], [
@@ -1443,7 +1436,6 @@ class ReportAPITest(AirtableTest):
 
 
 class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
-    # TODO tests failing for non-local reports
 
     fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
     ADDITIONAL_FAMILIES = ['F000014_14']
@@ -1463,6 +1455,13 @@ class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
             'RNA__E': {'non_demo': 1},
         },
     }
+
+    def _check_anvil_export_response(self, response, *args):
+        self.assertEqual(response.status_code, 403)
+
+    def _test_gregor_export(self, url, *args):
+        response = self.client.post(url, content_type='application/json', data=json.dumps({}))
+        self.assertEqual(response.status_code, 403)
 
 
 class AnvilReportAPITest(AnvilAuthenticationTestCase, ReportAPITest):

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -1443,6 +1443,8 @@ class ReportAPITest(AirtableTest):
 
 
 class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
+    # TODO tests failing for non-local reports
+
     fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
     ADDITIONAL_FAMILIES = ['F000014_14']
     ADDITIONAL_FINDINGS = ['NA21234_1_248367227']

--- a/seqr/views/apis/summary_data_api.py
+++ b/seqr/views/apis/summary_data_api.py
@@ -274,7 +274,7 @@ GREGOR_CATEGORY = 'gregor'
 def _get_metadata_projects(request, project_guid):
     is_analyst = user_is_analyst(request.user)
     is_all_projects = project_guid == ALL_PROJECTS
-    include_airtable = 'true' in request.GET.get('includeAirtable', '') and is_analyst and not is_all_projects
+    include_airtable = 'true' in request.GET.get('includeAirtable', '') and AirtableSession.is_airtable_enabled() and is_analyst and not is_all_projects
     if is_all_projects:
         projects = get_internal_projects() if is_analyst else Project.objects.filter(
             guid__in=get_project_guids_user_can_view(request.user))

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -581,10 +581,8 @@ class SummaryDataAPITest(AirtableTest):
             self.assertEqual(len([r['participant_id'] for r in response_json['rows'] if r['participant_id'] == 'NA20888']), 2)
 
     @mock.patch('seqr.views.utils.airtable_utils.MAX_OR_FILTERS', 2)
-    @mock.patch('seqr.views.utils.airtable_utils.is_google_authenticated')
     @responses.activate
-    def test_sample_metadata_export(self, mock_google_authenticated):
-        mock_google_authenticated.return_value = False
+    def test_sample_metadata_export(self):
         url = reverse(individual_metadata, args=['R0003_test'])
         self.check_require_login(url)
 
@@ -653,12 +651,16 @@ class SummaryDataAPITest(AirtableTest):
         self._has_expected_metadata_response(response, all_project_individuals, has_duplicate=True)
 
         # Test invalid airtable responses
-        response = self.client.get(include_airtable_url)
-        # TODO failing for local
-        self.assertEqual(response.status_code, 403)
-        self.assertEqual(response.json()['error'], 'Permission Denied')
-        mock_google_authenticated.return_value = True
+        self._test_metadata_airtable_responses(include_airtable_url, expected_individuals)
 
+        # Test gregor projects
+        response = self.client.get(gregor_projects_url)
+        self._has_expected_metadata_response(response, multi_project_individuals, has_duplicate=True)
+
+        response = self.client.get(f'{gregor_projects_url}?includeAirtable=true')
+        self._has_expected_metadata_response(response, multi_project_individuals, has_airtable=self.HAS_AIRTABLE, has_duplicate=True)
+
+    def _test_metadata_airtable_responses(self, include_airtable_url, expected_individuals):
         responses.add(responses.GET, '{}/app3Y97xtbbaOopVR/Samples'.format(AIRTABLE_URL), status=402)
         response = self.client.get(include_airtable_url)
         self.assertEqual(response.status_code, 402)
@@ -682,7 +684,6 @@ class SummaryDataAPITest(AirtableTest):
                 'validate': lambda log_value: self.assertTrue(log_value['traceback'].startswith('Traceback'))
             })
         ])
-
 
         responses.reset()
         responses.add(responses.GET, '{}/app3Y97xtbbaOopVR/Samples'.format(AIRTABLE_URL),
@@ -715,13 +716,6 @@ class SummaryDataAPITest(AirtableTest):
         self.assertEqual(len(responses.calls), 8)
         self.assert_expected_airtable_call(
             -1, "OR(RECORD_ID()='reca4hcBnbA2cnZf9')", ['CollaboratorID'])
-
-        # Test gregor projects
-        response = self.client.get(gregor_projects_url)
-        self._has_expected_metadata_response(response, multi_project_individuals, has_duplicate=True)
-
-        response = self.client.get(f'{gregor_projects_url}?includeAirtable=true')
-        self._has_expected_metadata_response(response, multi_project_individuals, has_airtable=True, has_duplicate=True)
 
     @mock.patch('seqr.views.apis.summary_data_api.EmailMessage')
     def test_send_vlm_email(self, mock_email):
@@ -773,6 +767,13 @@ class LocalSummaryDataAPITest(AuthenticationTestCase, SummaryDataAPITest):
     fixtures = ['users', '1kg_project', 'reference_data', 'report_variants']
     NUM_MANAGER_SUBMISSIONS = 4
     ADDITIONAL_SAMPLES = ['NA21234', 'NA21987']
+    HAS_AIRTABLE = False
+
+    def _test_metadata_airtable_responses(self, include_airtable_url, expected_individuals):
+        # Returns successfully without airtable data when disabled
+        response = self.client.get(include_airtable_url)
+        self.assertEqual(response.status_code, 200)
+        self._has_expected_metadata_response(response, expected_individuals)
 
 
 def assert_has_expected_calls(self, users, skip_group_call_idxs=None):
@@ -789,6 +790,7 @@ class AnvilSummaryDataAPITest(AnvilAuthenticationTestCase, SummaryDataAPITest):
     fixtures = ['users', 'social_auth', '1kg_project', 'reference_data', 'report_variants']
     NUM_MANAGER_SUBMISSIONS = 4
     ADDITIONAL_SAMPLES = []
+    HAS_AIRTABLE = True
 
     def test_mme_details(self, *args):
         super(AnvilSummaryDataAPITest, self).test_mme_details(*args)

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -581,7 +581,6 @@ class SummaryDataAPITest(AirtableTest):
             self.assertEqual(len([r['participant_id'] for r in response_json['rows'] if r['participant_id'] == 'NA20888']), 2)
 
     @mock.patch('seqr.views.utils.airtable_utils.MAX_OR_FILTERS', 2)
-    @mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_API_KEY', 'mock_key')
     @mock.patch('seqr.views.utils.airtable_utils.is_google_authenticated')
     @responses.activate
     def test_sample_metadata_export(self, mock_google_authenticated):
@@ -655,6 +654,7 @@ class SummaryDataAPITest(AirtableTest):
 
         # Test invalid airtable responses
         response = self.client.get(include_airtable_url)
+        # TODO failing for local
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()['error'], 'Permission Denied')
         mock_google_authenticated.return_value = True
@@ -715,7 +715,6 @@ class SummaryDataAPITest(AirtableTest):
         self.assertEqual(len(responses.calls), 8)
         self.assert_expected_airtable_call(
             -1, "OR(RECORD_ID()='reca4hcBnbA2cnZf9')", ['CollaboratorID'])
-        self.assertSetEqual({call.request.headers['Authorization'] for call in responses.calls}, {'Bearer mock_key'})
 
         # Test gregor projects
         response = self.client.get(gregor_projects_url)

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -24,7 +24,14 @@ class AirtableSession(object):
         ANVIL_BASE: 'appUelDNM3BnWaR7M',
     }
 
+    @staticmethod
+    def is_airtable_enabled():
+        return bool(AIRTABLE_API_KEY)
+
     def __init__(self, user, base=RDG_BASE, no_auth=False):
+        if not self.is_airtable_enabled():
+            raise ValueError('Airtable is not configured')
+
         self._user = user
         if not no_auth:
             self._check_user_access(base)

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -24,12 +24,8 @@ class AirtableSession(object):
         ANVIL_BASE: 'appUelDNM3BnWaR7M',
     }
 
-    @staticmethod
-    def is_airtable_enabled():
-        return bool(AIRTABLE_API_KEY)
-
     def __init__(self, user, base=RDG_BASE, no_auth=False):
-        if not self.is_airtable_enabled():
+        if not AIRTABLE_API_KEY:
             raise ValueError('Airtable is not configured')
 
         self._user = user

--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -24,8 +24,12 @@ class AirtableSession(object):
         ANVIL_BASE: 'appUelDNM3BnWaR7M',
     }
 
+    @staticmethod
+    def is_airtable_enabled():
+        return bool(AIRTABLE_API_KEY)
+
     def __init__(self, user, base=RDG_BASE, no_auth=False):
-        if not AIRTABLE_API_KEY:
+        if not self.is_airtable_enabled():
             raise ValueError('Airtable is not configured')
 
         self._user = user

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -549,6 +549,7 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_API_KEY', MOCK_AIRTABLE_KEY)
         patcher.start()
+        self.addCleanup(patcher.stop)
         super(AnvilAuthenticationTestCase, self).setUp()
 
     @classmethod

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -30,6 +30,7 @@ class AuthenticationTestCase(TestCase):
     NO_POLICY_USER = 'no_policy'
 
     ES_HOSTNAME = 'testhost'
+    MOCK_AIRTABLE_KEY = ''
 
     super_user = None
     analyst_user = None
@@ -43,6 +44,9 @@ class AuthenticationTestCase(TestCase):
 
     def setUp(self):
         patcher = mock.patch('seqr.utils.search.elasticsearch.es_utils.ELASTICSEARCH_SERVICE_HOSTNAME', self.ES_HOSTNAME)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        patcher = mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_API_KEY', self.MOCK_AIRTABLE_KEY)
         patcher.start()
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.views.utils.permissions_utils.SEQR_PRIVACY_VERSION', 2.1)
@@ -509,6 +513,7 @@ def get_group_members_side_effect(user, group, use_sa_credentials=False):
 class AnvilAuthenticationTestCase(AuthenticationTestCase):
 
     ES_HOSTNAME = ''
+    MOCK_AIRTABLE_KEY = 'airflow_access'
 
     # mock the terra apis
     def setUp(self):
@@ -547,9 +552,6 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
         self.mock_get_group_members = patcher.start()
         self.mock_get_group_members.side_effect = get_group_members_side_effect
         self.addCleanup(patcher.stop)
-        patcher = mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_API_KEY', MOCK_AIRTABLE_KEY)
-        patcher.start()
-        self.addCleanup(patcher.stop)
         super(AnvilAuthenticationTestCase, self).setUp()
 
     @classmethod
@@ -568,7 +570,6 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
 
 
 MOCK_AIRFLOW_URL = 'http://testairflowserver'
-MOCK_AIRTABLE_KEY = 'airflow_access'
 DAG_NAME = 'LOADING_PIPELINE'
 PROJECT_GUID = 'R0001_1kg'
 
@@ -727,7 +728,7 @@ class AirtableTest(object):
         self.assert_expected_airtable_headers(call_index)
 
     def assert_expected_airtable_headers(self, call_index):
-        self.assertEqual(responses.calls[call_index].request.headers['Authorization'], f'Bearer {MOCK_AIRTABLE_KEY}')
+        self.assertEqual(responses.calls[call_index].request.headers['Authorization'], f'Bearer {self.MOCK_AIRTABLE_KEY}')
 
     @staticmethod
     def _get_list_param(call, param):

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -547,6 +547,8 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
         self.mock_get_group_members = patcher.start()
         self.mock_get_group_members.side_effect = get_group_members_side_effect
         self.addCleanup(patcher.stop)
+        patcher = mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_API_KEY', MOCK_AIRTABLE_KEY)
+        patcher.start()
         super(AnvilAuthenticationTestCase, self).setUp()
 
     @classmethod
@@ -565,6 +567,7 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
 
 
 MOCK_AIRFLOW_URL = 'http://testairflowserver'
+MOCK_AIRTABLE_KEY = 'airflow_access'
 DAG_NAME = 'LOADING_PIPELINE'
 PROJECT_GUID = 'R0001_1kg'
 
@@ -720,6 +723,10 @@ class AirtableTest(object):
             expected_params.update(additional_params)
         self.assertDictEqual(responses.calls[call_index].request.params, expected_params)
         self.assertListEqual(self._get_list_param(responses.calls[call_index].request, 'fields%5B%5D'), fields)
+        self.assert_expected_airtable_headers(call_index)
+
+    def assert_expected_airtable_headers(self, call_index):
+        self.assertEqual(responses.calls[call_index].request.headers['Authorization'], f'Bearer {MOCK_AIRTABLE_KEY}')
 
     @staticmethod
     def _get_list_param(call, param):

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -99,12 +99,6 @@ class AuthenticationTestCase(TestCase):
         pm_group = Group.objects.get(pk=5)
         pm_group.user_set.add(cls.pm_user)
 
-    @classmethod
-    def add_analyst_project(cls, project_id):
-        analyst_group = Group.objects.get(pk=4)
-        assign_perm(user_or_group=analyst_group, perm=CAN_VIEW, obj=Project.objects.filter(id=project_id))
-        return True
-
     def check_require_login(self, url, **request_kwargs):
         self._check_login(url, self.AUTHENTICATED_USER, **request_kwargs)
 
@@ -558,10 +552,6 @@ class AnvilAuthenticationTestCase(AuthenticationTestCase):
     def add_additional_user_groups(cls):
         analyst_group = Group.objects.get(pk=4)
         analyst_group.user_set.add(cls.analyst_user, cls.pm_user)
-
-    @classmethod
-    def add_analyst_project(cls, project_id):
-        return False
 
     def assert_no_extra_anvil_calls(self):
         self.mock_get_ws_acl.assert_not_called()


### PR DESCRIPTION
While working to make the data loading interface work for local installs I discovered we are not robustly checking and error handling when airtable requests are made while airtable is not configured. This adds a validation when starting up airtable sessions to sanity check that airtable is configured, and then adds explicit checks where needed to avoid running into that case