### PR TITLE
better interval filtering and partitioning

### DIFF
--- a/hail_search/constants.py
+++ b/hail_search/constants.py
@@ -88,3 +88,5 @@ HGMD_PATH_RANGES = [
     ('likely_disease_causing', 'DM?', 'DM?'),
     ('hgmd_other', 'DP', None),
 ]
+
+MAX_LOAD_INTERVALS = 1000

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -6,7 +6,7 @@ import os
 
 from hail_search.constants import AFFECTED_ID, ALT_ALT, ANNOTATION_OVERRIDE_FIELDS, ANY_AFFECTED, COMP_HET_ALT, \
     COMPOUND_HET, GENOME_VERSION_GRCh38, GROUPED_VARIANTS_FIELD, ALLOWED_TRANSCRIPTS, ALLOWED_SECONDARY_TRANSCRIPTS,  HAS_ANNOTATION_OVERRIDE, \
-    HAS_ALT, HAS_REF,INHERITANCE_FILTERS, PATH_FREQ_OVERRIDE_CUTOFF, MALE, RECESSIVE, REF_ALT, REF_REF, \
+    HAS_ALT, HAS_REF,INHERITANCE_FILTERS, PATH_FREQ_OVERRIDE_CUTOFF, MALE, RECESSIVE, REF_ALT, REF_REF, MAX_LOAD_INTERVALS, \
     UNAFFECTED_ID, X_LINKED_RECESSIVE, XPOS, OMIM_SORT, FAMILY_GUID_FIELD, GENOTYPES_FIELD, AFFECTED_ID_MAP
 
 DATASETS_DIR = os.environ.get('DATASETS_DIR', '/hail_datasets')
@@ -14,7 +14,7 @@ SSD_DATASETS_DIR = os.environ.get('SSD_DATASETS_DIR', DATASETS_DIR)
 
 # Number of filtered genes at which pre-filtering a table by gene-intervals does not improve performance
 # Estimated based on behavior for several representative gene lists
-MAX_GENE_INTERVALS = int(os.environ.get('MAX_GENE_INTERVALS', 100))
+MAX_GENE_INTERVALS = int(os.environ.get('MAX_GENE_INTERVALS', MAX_LOAD_INTERVALS))
 
 # Optimal number of entry table partitions, balancing parallelization with partition overhead
 # Experimentally determined based on compound het search performance:
@@ -237,7 +237,8 @@ class BaseHailTableQuery(object):
         self._has_secondary_annotations = False
         self._is_multi_data_type_comp_het = False
         self.max_unaffected_samples = None
-        self._load_table_kwargs = {'_n_partitions': min(MAX_PARTITIONS, (os.cpu_count() or 2)-1)}
+        self._n_partitions = min(MAX_PARTITIONS, (os.cpu_count() or 2)-1)
+        self._load_table_kwargs = {'_n_partitions': self._n_partitions}
         self.entry_samples_by_family_guid = {}
 
         if sample_data:

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -6,10 +6,9 @@ import logging
 
 from hail_search.constants import ABSENT_PATH_SORT_OFFSET, CLINVAR_KEY, CLINVAR_MITO_KEY, CLINVAR_LIKELY_PATH_FILTER, CLINVAR_PATH_FILTER, \
     CLINVAR_PATH_RANGES, CLINVAR_PATH_SIGNIFICANCES, ALLOWED_TRANSCRIPTS, ALLOWED_SECONDARY_TRANSCRIPTS, PATHOGENICTY_SORT_KEY, CONSEQUENCE_SORT, \
-    PATHOGENICTY_HGMD_SORT_KEY
+    PATHOGENICTY_HGMD_SORT_KEY, MAX_LOAD_INTERVALS
 from hail_search.queries.base import BaseHailTableQuery, PredictionPath, QualityFilterFormat
 
-MAX_LOAD_INTERVALS = 1000
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +214,10 @@ class MitoHailTableQuery(BaseHailTableQuery):
             ht = hl.filter_intervals(ht, parsed_intervals, keep=False)
         elif len(parsed_intervals or []) >= MAX_LOAD_INTERVALS:
             ht = hl.filter_intervals(ht, parsed_intervals)
+
+        if '_n_partitions' not in self._load_table_kwargs:
+            ht = ht.naive_coalesce(self._n_partitions)
+
         return ht
 
     def _get_allowed_consequence_ids(self, annotations):

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -210,12 +210,13 @@ class MitoHailTableQuery(BaseHailTableQuery):
         ]
 
     def _prefilter_entries_table(self, ht, parsed_intervals=None, exclude_intervals=False, **kwargs):
+        num_intervals = len(parsed_intervals or [])
         if exclude_intervals and parsed_intervals:
             ht = hl.filter_intervals(ht, parsed_intervals, keep=False)
-        elif len(parsed_intervals or []) >= MAX_LOAD_INTERVALS:
+        elif num_intervals >= MAX_LOAD_INTERVALS:
             ht = hl.filter_intervals(ht, parsed_intervals)
 
-        if '_n_partitions' not in self._load_table_kwargs:
+        if '_n_partitions' not in self._load_table_kwargs and num_intervals > self._n_partitions:
             ht = ht.naive_coalesce(self._n_partitions)
 
         return ht


### PR DESCRIPTION
Improves large gene search performance in a couple ways:
 - Allows for a larger number of clustered intervals (meaning far fewer variants outside of the true intervals are included)
 - Reduces the number of partitions. Hail does not allow for specifying both intervals and number of partitions at table read time, but the number of partitions based on the large number of intervals is too high and reduces performance. While a full `repartiton` is far too slow to be helpful, `naive_coalesce` reduces the number of paritions quickly and does not seem to introduce any problems with how balanced the partitions are