### PR TITLE
igv fix - get cytobandURL from hgdownload.soe.ucsc.edu 

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -78,7 +78,7 @@ SECURE_BROWSER_XSS_FILTER = True
 CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src', 'style-src-elem']
 CSP_FONT_SRC = ('https://fonts.gstatic.com', 'data:', "'self'")
 CSP_CONNECT_SRC = ("'self'", 'https://gtexportal.org', 'https://www.google-analytics.com', 'https://igv.org',
-                   'https://storage.googleapis.com',  'https://s3.amazonaws.com', 'https://hgdownload.soe.ucsc.edu', 'https://igv-genepattern-org.s3.amazonaws.com',  # used by IGV
+                   'https://storage.googleapis.com', 'https://hgdownload.soe.ucsc.edu',  # used by IGV
                    'https://reg.genome.network')
 CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'", 'https://www.googletagmanager.com')
 CSP_IMG_SRC = ("'self'", 'https://www.google-analytics.com', 'https://storage.googleapis.com',

--- a/settings.py
+++ b/settings.py
@@ -78,7 +78,7 @@ SECURE_BROWSER_XSS_FILTER = True
 CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src', 'style-src-elem']
 CSP_FONT_SRC = ('https://fonts.gstatic.com', 'data:', "'self'")
 CSP_CONNECT_SRC = ("'self'", 'https://gtexportal.org', 'https://www.google-analytics.com', 'https://igv.org',
-                   'https://storage.googleapis.com',  # google storage used by IGV
+                   'https://storage.googleapis.com',  'https://s3.amazonaws.com', 'https://hgdownload.soe.ucsc.edu', 'https://igv-genepattern-org.s3.amazonaws.com',  # used by IGV
                    'https://reg.genome.network')
 CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'", 'https://www.googletagmanager.com')
 CSP_IMG_SRC = ("'self'", 'https://www.google-analytics.com', 'https://storage.googleapis.com',

--- a/ui/shared/components/panel/family/constants.js
+++ b/ui/shared/components/panel/family/constants.js
@@ -90,15 +90,15 @@ const REFERENCE_URLS = [
   },
   {
     key: 'cytobandURL',
-    baseUrl: `${BASE_REFERENCE_URL}/s3`,
+    baseUrl: 'https://hgdownload.soe.ucsc.edu/goldenPath',
     path: {
-      37: 'igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt',
-      38: 'igv.org.genomes/hg38/annotations/cytoBandIdeo.txt.gz',
+      37: 'hg19/database/cytoBand.txt.gz',
+      38: 'hg38/database/cytoBandIdeo.txt.gz',
     },
   },
   {
     key: 'aliasURL',
-    baseUrl: `${BASE_REFERENCE_URL}/s3/igv.org.genomes`,
+    baseUrl: 'https://igv-genepattern-org.s3.amazonaws.com/genomes',
     path: {
       37: 'hg19/hg19_alias.tab',
       38: 'hg38/hg38_alias.tab',
@@ -121,7 +121,7 @@ const REFERENCE_TRACKS = [
   {
     name: 'Refseq',
     indexPostfix: 'tbi',
-    baseUrl: `${BASE_REFERENCE_URL}/s3/igv.org.genomes`,
+    baseUrl: 'https://s3.amazonaws.com/igv.org.genomes',
     path: {
       37: 'hg19/refGene.sorted.txt.gz',
       38: 'hg38/refGene.sorted.txt.gz',

--- a/ui/shared/components/panel/family/constants.js
+++ b/ui/shared/components/panel/family/constants.js
@@ -98,7 +98,7 @@ const REFERENCE_URLS = [
   },
   {
     key: 'aliasURL',
-    baseUrl: 'https://igv-genepattern-org.s3.amazonaws.com/genomes',
+    baseUrl: `${BASE_REFERENCE_URL}/s3/igv.org.genomes`,
     path: {
       37: 'hg19/hg19_alias.tab',
       38: 'hg38/hg38_alias.tab',
@@ -121,7 +121,7 @@ const REFERENCE_TRACKS = [
   {
     name: 'Refseq',
     indexPostfix: 'tbi',
-    baseUrl: 'https://s3.amazonaws.com/igv.org.genomes',
+    baseUrl: `${BASE_REFERENCE_URL}/s3/igv.org.genomes`,
     path: {
       37: 'hg19/refGene.sorted.txt.gz',
       38: 'hg38/refGene.sorted.txt.gz',


### PR DESCRIPTION
- fetching `cytoBandIdeo.txt.gz` through the proxy is failing on dev and prod (but not locally)
- `cytobandURL` has a different source [here](https://igv.org/genomes/genomes.json) so use that source instead of the s3 bucket proxy