### PR TITLE
show vlm families grouped by contact email

### DIFF
--- a/ui/pages/SummaryData/selectors.js
+++ b/ui/pages/SummaryData/selectors.js
@@ -12,24 +12,28 @@ export const getMmeMetrics = state => state.mmeMetrics
 export const getMmeSubmissions = state => state.mmeSubmissions
 export const getExternalAnalysisUploadStats = state => state.externalAnalysisUploadStats
 
-export const geVlmDefaultContactEmailByFamily = createSelector(
+export const getVlmFamiliesByContactEmail = createSelector(
   getSortedIndividualsByFamily,
+  (state, ownProps) => ownProps.variant,
+  (individualsByFamily, variant) => (variant.lookupFamilyGuids || []).reduce((acc, familyGuid) => {
+    const individual = individualsByFamily[familyGuid]?.[0]
+    const contactEmail = individual?.projectGuid ? 'internal' : (individual?.vlmContactEmail || 'disabled')
+    return { ...acc, [contactEmail]: [...(acc[contactEmail] || []), familyGuid] }
+  }, {}),
+)
+
+export const getVlmDefaultContactEmails = createSelector(
+  getVlmFamiliesByContactEmail,
   getGenesById,
   getUser,
   (state, ownProps) => ownProps.variant,
-  (individualsByFamily, genesById, user, variant) => {
+  (familiesByContactEmail, genesById, user, variant) => {
     const gene = genesById[getVariantMainGeneId(variant)]?.geneSymbol
-    const defaultEmail = {
-      subject: `${gene || variant.variantId} variant match in seqr`,
-      //
-      body: `Dear researcher,\n\nWe are interested in learning more about your case in seqr harboring ${getVariantSummary(variant)} in ${gene || 'no genes'} (${window.location.href}).\n\nWe appreciate your assistance and look forward to hearing more from you.\n\nBest wishes,\n${user.displayName}`,
-    }
-    return (variant.lookupFamilyGuids || []).reduce((acc, familyGuid) => {
-      const individual = individualsByFamily[familyGuid]?.[0]
-      if (!individual || individual.projectGuid) {
-        return acc
-      }
-      return { ...acc, [familyGuid]: { ...defaultEmail, to: individual.vlmContactEmail } }
-    }, {})
+    const subject = `${gene || variant.variantId} variant match in seqr`
+    const defaultEmailContent = `harboring ${getVariantSummary(variant)} in ${gene || 'no genes'} (${window.location.href}).\n\nWe appreciate your assistance and look forward to hearing more from you.\n\nBest wishes,\n${user.displayName}`
+    return Object.entries(familiesByContactEmail).reduce((acc, [to, familyGuids]) => ({
+      ...acc,
+      [to]: { to, subject, body: `Dear researcher,\n\nWe are interested in learning more about your ${familyGuids.length} cases in seqr ${defaultEmailContent}` },
+    }), {})
   },
 )


### PR DESCRIPTION
In the variant lookup UI, groups cases by their VLM contact so users will only send one email per contact, instead of potentially sending identical messages to the same researcher multiple times

Example where 2 collaborators have the variant, one with 3 cases and one with 1. 
<img width="1390" alt="Screenshot 2024-09-13 at 12 44 22 PM" src="https://github.com/user-attachments/assets/37c30dc9-c513-4ef5-9ac0-62ea012bdfa0">
<img width="667" alt="Screenshot 2024-09-13 at 12 45 29 PM" src="https://github.com/user-attachments/assets/fd0d4067-5349-4264-b49c-0d3b2b835476">
