### PR TITLE
Update action seqr platform

### DIFF
--- a/.github/workflows/dev-hail-search-release.yaml
+++ b/.github/workflows/dev-hail-search-release.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: mikefarah/yq@v4.22.1
         with:
           cmd: >
-            yq -i '.hail-search.image.tag = "${{ github.event.workflow_run.head_sha }}"' charts/dev-broad-seqr/values.yaml
+            yq -i '.seqr-platform.hail-search.image.tag = "${{ github.event.workflow_run.head_sha }}"' charts/dev-broad-seqr/values.yaml
 
       - name: Commit and Push changes
         uses: Andro999b/push@v1.3

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: mikefarah/yq@v4.22.1
         with:
           cmd: >
-            yq -i '.seqr.image.tag = "${{ github.event.workflow_run.head_sha }}"' charts/dev-broad-seqr/values.yaml
+            yq -i '.seqr-platform.seqr.image.tag = "${{ github.event.workflow_run.head_sha }}"' charts/dev-broad-seqr/values.yaml
 
       - name: Commit and Push changes
         uses: Andro999b/push@v1.3


### PR DESCRIPTION
Per [this pr](https://github.com/broadinstitute/tgg-helm/pull/109), the `tag` will be nested under `seer-platform` going forwards.

Note: this only updates the `dev` actions. 