### PR TITLE
remove mito highConstraintRegion

### DIFF
--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -71,9 +71,6 @@ class MitoHailTableQuery(BaseHailTableQuery):
     CORE_FIELDS = BaseHailTableQuery.CORE_FIELDS + ['rsid']
     MITO_ANNOTATION_FIELDS = {
         'commonLowHeteroplasmy': lambda r: r.common_low_heteroplasmy,
-        'highConstraintRegion': (
-            lambda r: r.high_constraint_region if hasattr(r, 'high_constraint_region') else r.high_constraint_region_mito
-        ),
         'mitomapPathogenic': lambda r: r.mitomap.pathogenic,
     }
     BASE_ANNOTATION_FIELDS = {

--- a/hail_search/test_utils.py
+++ b/hail_search/test_utils.py
@@ -852,7 +852,6 @@ MITO_VARIANT1 = {
         'mlc': 3.38874,
     },
     'commonLowHeteroplasmy': False,
-    'highConstraintRegion': True,
     'mitomapPathogenic': None,
     'clinvar': {
         'alleleId': 677748,
@@ -906,7 +905,6 @@ MITO_VARIANT2 = {
         'mlc': None,
     },
     'commonLowHeteroplasmy': False,
-    'highConstraintRegion': True,
     'mitomapPathogenic': None,
     'clinvar': None,
     'transcripts': {
@@ -953,7 +951,6 @@ MITO_VARIANT3 = {
         'mlc': 0.7514,
     },
     'commonLowHeteroplasmy': True,
-    'highConstraintRegion': False,
     'mitomapPathogenic': True,
     'clinvar': {
         'alleleId': 150280,

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -1085,7 +1085,6 @@ PARSED_VARIANTS = [
         'bothsidesSupport': None,
         'clinvar': {'clinicalSignificance': 'Pathogenic/Likely_pathogenic', 'alleleId': None, 'variationId': None, 'goldStars': None, 'version': '2023-03-05'},
         'commonLowHeteroplasmy': None,
-        'highConstraintRegion': None,
         'mitomapPathogenic': None,
         'familyGuids': ['F000003_3'],
         'cpxIntervals': None,
@@ -1156,7 +1155,6 @@ PARSED_VARIANTS = [
         'bothsidesSupport': None,
         'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None, 'version': '2023-03-05'},
         'commonLowHeteroplasmy': None,
-        'highConstraintRegion': None,
         'mitomapPathogenic': None,
         'familyGuids': ['F000002_2', 'F000003_3'],
         'cpxIntervals': None,
@@ -1244,7 +1242,6 @@ PARSED_SV_VARIANT = {
     'cpxIntervals': None,
     'algorithms': None,
     'commonLowHeteroplasmy': None,
-    'highConstraintRegion': None,
     'mitomapPathogenic': None,
     'genotypes': {
         'I000004_hg00731': {
@@ -1336,7 +1333,6 @@ PARSED_SV_WGS_VARIANT = {
                      {'chrom': '20', 'end': 13000, 'start': 11000, 'type': 'INV'}],
     'algorithms': 'wham, manta',
     'commonLowHeteroplasmy': None,
-    'highConstraintRegion': None,
     'mitomapPathogenic': None,
     'genotypes': {
         'I000018_na21234': {
@@ -1442,7 +1438,6 @@ PARSED_MITO_VARIANT = {
              {'contamination': 0.0, 'dp': 5139.0, 'gq': 60.0, 'hl': 1.0, 'mitoCn': 319.03225806451616, 'numAlt': 2,
               'sampleId': 'HG00731', 'sampleType': 'WES'}},
     'hgmd': {'accession': None, 'class': None},
-    'highConstraintRegion': True,
     'mainTranscriptId': 'ENST00000361227',
     'mitomapPathogenic': True,
     'numExon': None,

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -1085,6 +1085,7 @@ PARSED_VARIANTS = [
         'bothsidesSupport': None,
         'clinvar': {'clinicalSignificance': 'Pathogenic/Likely_pathogenic', 'alleleId': None, 'variationId': None, 'goldStars': None, 'version': '2023-03-05'},
         'commonLowHeteroplasmy': None,
+        'highConstraintRegion': None,
         'mitomapPathogenic': None,
         'familyGuids': ['F000003_3'],
         'cpxIntervals': None,
@@ -1155,6 +1156,7 @@ PARSED_VARIANTS = [
         'bothsidesSupport': None,
         'clinvar': {'clinicalSignificance': None, 'alleleId': None, 'variationId': None, 'goldStars': None, 'version': '2023-03-05'},
         'commonLowHeteroplasmy': None,
+        'highConstraintRegion': None,
         'mitomapPathogenic': None,
         'familyGuids': ['F000002_2', 'F000003_3'],
         'cpxIntervals': None,
@@ -1242,6 +1244,7 @@ PARSED_SV_VARIANT = {
     'cpxIntervals': None,
     'algorithms': None,
     'commonLowHeteroplasmy': None,
+    'highConstraintRegion': None,
     'mitomapPathogenic': None,
     'genotypes': {
         'I000004_hg00731': {
@@ -1333,6 +1336,7 @@ PARSED_SV_WGS_VARIANT = {
                      {'chrom': '20', 'end': 13000, 'start': 11000, 'type': 'INV'}],
     'algorithms': 'wham, manta',
     'commonLowHeteroplasmy': None,
+    'highConstraintRegion': None,
     'mitomapPathogenic': None,
     'genotypes': {
         'I000018_na21234': {
@@ -1438,6 +1442,7 @@ PARSED_MITO_VARIANT = {
              {'contamination': 0.0, 'dp': 5139.0, 'gq': 60.0, 'hl': 1.0, 'mitoCn': 319.03225806451616, 'numAlt': 2,
               'sampleId': 'HG00731', 'sampleType': 'WES'}},
     'hgmd': {'accession': None, 'class': None},
+    'highConstraintRegion': True,
     'mainTranscriptId': 'ENST00000361227',
     'mitomapPathogenic': True,
     'numExon': None,

--- a/ui/shared/components/panel/variants/Annotations.jsx
+++ b/ui/shared/components/panel/variants/Annotations.jsx
@@ -638,12 +638,6 @@ const Annotations = React.memo(({ variant, mainGeneId, showMainGene, transcripts
           />
         </span>
       )}
-      {variant.highConstraintRegion && (
-        <span>
-          <HorizontalSpacer width={12} />
-          <Label color="red" horizontal size="tiny">High Constraint Region</Label>
-        </span>
-      )}
       {nonMajorConsequences.length > 0 && (
         <div>
           <b>Additonal VEP consequences: &nbsp;</b>


### PR DESCRIPTION
Since MITO is not supported for local installs we do not need to maintain backwards compatibility for elasticsearch and can therefore fully deprecate the old syntax for this field