### PR TITLE
Anvil allow partial project loading

### DIFF
--- a/seqr/utils/search/add_data_utils.py
+++ b/seqr/utils/search/add_data_utils.py
@@ -116,7 +116,7 @@ def notify_search_data_loaded(project, is_internal, dataset_type, sample_type, i
 
 def prepare_data_loading_request(projects: list[Project], sample_type: str, dataset_type: str, genome_version: str,
                                  data_path: str, user: User, pedigree_dir: str,  raise_pedigree_error: bool = False,
-                                 individual_ids: list[str] = None, skip_validation: bool = False):
+                                 individual_ids: list[int] = None, skip_validation: bool = False):
     project_guids = sorted([p.guid for p in projects])
     variables = {
         'projects_to_run': project_guids,
@@ -137,7 +137,7 @@ def _dag_dataset_type(sample_type: str, dataset_type: str):
         else dataset_type
 
 
-def _upload_data_loading_files(projects: list[Project], user: User, file_path: str, individual_ids: list[str], raise_error: bool):
+def _upload_data_loading_files(projects: list[Project], user: User, file_path: str, individual_ids: list[int], raise_error: bool):
     file_annotations = OrderedDict({
         'Project_GUID': F('family__project__guid'), 'Family_GUID': F('family__guid'),
         'Family_ID': F('family__family_id'),

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -314,7 +314,7 @@ def _trigger_add_workspace_data(project, pedigree_records, user, data_path, samp
     trigger_success = trigger_airflow_data_loading(
         [project], sample_type, Sample.DATASET_TYPE_VARIANT_CALLS, project.genome_version, data_path, user=user, success_message=success_message,
         success_slack_channel=SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL, error_message=f'ERROR triggering AnVIL loading for project {project.guid}',
-        individual_ids=individual_ids,  # TODO update function signature for trigger_airflow_data_loading
+        individual_ids=individual_ids,
     )
     AirtableSession(user, base=AirtableSession.ANVIL_BASE).safe_create_records(
         ANVIL_REQUEST_TRACKING_TABLE, [{

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -241,7 +241,7 @@ def add_workspace_data(request, project_guid):
 
     previous_loaded_individuals = previous_samples.filter(
         individual__family__family_id__in=records_by_family,
-    ).values_list('individual_id', 'individual__family__family_id', 'individual__individual_id')
+    ).values_list('individual_id', 'individual__individual_id', 'individual__family__family_id')
     missing_samples_by_family = defaultdict(list)
     for _, individual_id, family_id in previous_loaded_individuals:
         if individual_id not in request_json['vcfSamples']:
@@ -253,7 +253,7 @@ def add_workspace_data(request, project_guid):
         ]
         return create_json_response({
             'error': 'In order to load data for families with previously loaded data, new family samples must be joint called in a single VCF with all previously loaded samples.'
-                     ' The following samples were previously loaded in this project but are missing from the VCF: {}'.format(
+                     ' The following samples were previously loaded in this project but are missing from the VCF:\n{}'.format(
                 '\n'.join(sorted(missing_family_sample_messages)))}, status=400)
 
     pedigree_json = _trigger_add_workspace_data(

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -16,8 +16,8 @@ from settings import SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL, SEQR_SLACK_LOADING_N
 LOAD_SAMPLE_DATA = [
     ["Family ID", "Individual ID", "Previous Individual ID", "Paternal ID", "Maternal ID", "Sex", "Affected Status",
      "HPO Terms", "Notes", "familyNotes"],
-    ["1", " NA19675_1 ", "NA19675_1 ", "NA19678 ", "", "Female", "Affected", "HP:0012469 (Infantile spasms); HP:0011675 (Arrhythmia)", "A affected individual, test1-zsf", ""],
-    ["1", "NA19678", "", "", "", "Male", "Unaffected", "", "a individual note", ""],
+    ["1", " NA19675_1 ", "NA19675_1 ", "", "NA19679 ", "Female", "Affected", "HP:0012469 (Infantile spasms); HP:0011675 (Arrhythmia)", "A affected individual, test1-zsf", ""],
+    ["1", "NA19679", "", "", "", "Female", "Unaffected", "", "a individual note", ""],
     ["21", " HG00735", "", "", "", "Unknown", "Affected", "HP:0001508,HP:0001508", "", "a new family"]]
 
 BAD_SAMPLE_DATA = [["1", "NA19674", "NA19674_1", "NA19678", "NA19679", "Female", "Affected", "", "A affected individual, test1-zsf", ""],
@@ -26,12 +26,12 @@ INVALID_ADDED_SAMPLE_DATA = [['22', 'HG00731', 'HG00731', '', '', 'Female', 'Aff
 
 MISSING_REQUIRED_SAMPLE_DATA = [["21", "HG00736", "", "", "", "", "", "", "", ""]]
 
-LOAD_SAMPLE_DATA_EXTRA_SAMPLE = LOAD_SAMPLE_DATA + [["1", "NA19679", "", "", "", "Male", "Affected", "HP:0011675", "", ""],
+LOAD_SAMPLE_DATA_EXTRA_SAMPLE = LOAD_SAMPLE_DATA + [["1", "NA19678", "", "", "", "Male", "Affected", "HP:0011675", "", ""],
                                                     ["22", "HG00736", "", "", "", "Unknown", "Unknown", "", "", ""]]
 
 FILE_DATA = [
     '##fileformat=VCFv4.2\n',
-    '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA19675_1	NA19678	HG00735\n',
+    '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA19675_1	NA19679	HG00735\n',
     'chr1	1000	test\n',
 ]
 
@@ -52,7 +52,7 @@ REQUEST_BODY_SHARDED_DATA_PATH = deepcopy(VALIDATE_VCF_BODY)
 REQUEST_BODY_SHARDED_DATA_PATH['dataPath'] = '/test_path-*.vcf.gz'
 
 VALIDATE_VFC_RESPONSE = {
-    'vcfSamples': ['HG00735', 'NA19675_1', 'NA19678'],
+    'vcfSamples': ['HG00735', 'NA19675_1', 'NA19679'],
     'fullDataPath': 'gs://test_bucket/test_path.vcf',
 }
 
@@ -68,21 +68,17 @@ TEMP_PATH = '/temp_path/temp_filename'
 
 MOCK_AIRTABLE_URL = 'http://testairtable'
 
-PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA20870', 'HG00732', 'NA19675_1', 'NA20874', 'HG00733', 'HG00731']
-PROJECT2_SAMPLES = ['NA20885', 'NA19675_1', 'NA19678', 'HG00735']
+PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA19679', 'NA20870', 'HG00732', 'NA19675_1', 'NA20874', 'HG00733', 'HG00731']
+PROJECT2_SAMPLES = ['NA20885', 'NA19675_1', 'NA19679', 'HG00735']
 PROJECT2_SAMPLE_DATA = [
-    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000011_11', 'Family_ID': '11', 'Individual_ID': 'NA20885', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'M'},
-    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000012_12', 'Family_ID': '12', 'Individual_ID': 'NA20870', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'M'},
-    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000012_12', 'Family_ID': '12', 'Individual_ID': 'NA20888', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'M'},
-    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000012_12', 'Family_ID': '12', 'Individual_ID': 'NA20889', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'F'},
-    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000016_1', 'Family_ID': '1', 'Individual_ID': 'NA19675_1', 'Paternal_ID': 'NA19678', 'Maternal_ID': None, 'Sex': 'F'},
-    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000016_1', 'Family_ID': '1', 'Individual_ID': 'NA19678', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'M'},
+    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000016_1', 'Family_ID': '1', 'Individual_ID': 'NA19675_1', 'Paternal_ID': None, 'Maternal_ID': 'NA19679', 'Sex': 'F'},
+    {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000016_1', 'Family_ID': '1', 'Individual_ID': 'NA19679', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'F'},
     {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000017_21', 'Family_ID': '21', 'Individual_ID': 'HG00735', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'U'},
 ]
 
 NEW_PROJECT_SAMPLE_DATA = [
-    {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_1_workspace2', 'Family_ID': '1', 'Individual_ID': 'NA19675_1', 'Paternal_ID': 'NA19678', 'Maternal_ID': None, 'Sex': 'F'},
-    {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_1_workspace2', 'Family_ID': '1', 'Individual_ID': 'NA19678', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'M'},
+    {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_1_workspace2', 'Family_ID': '1', 'Individual_ID': 'NA19675_1', 'Paternal_ID': None, 'Maternal_ID': 'NA19679', 'Sex': 'F'},
+    {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_1_workspace2', 'Family_ID': '1', 'Individual_ID': 'NA19679', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'F'},
     {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_21_workspace2', 'Family_ID': '21', 'Individual_ID': 'HG00735', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'U'},
 ]
 
@@ -136,7 +132,7 @@ REFERENCE_META = [
 
 BAD_HEADER_LINE = [b'#CHROM\tID\tREF\tALT\tQUAL\n']
 NO_SAMPLE_HEADER_LINE = [b'#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\n']
-HEADER_LINE = [b'#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG00735\tNA19675_1\tNA19678\n']
+HEADER_LINE = [b'#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG00735\tNA19675_1\tNA19679\n']
 
 DATA_LINES = [
     b'chr1\t10333\t.\tCT\tC\t1895\tPASS\tAC=5;AF=0.045;AN=112;DP=22546\tGT:AD:DP:GQ\t./.:63,0:63\t./.:44,0:44\t./.:44,0:44\n'
@@ -403,7 +399,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         mock_get_header_subproc.stdout = BASIC_META + INFO_META + FORMAT_META + HEADER_LINE + DATA_LINES
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_SHARDED_DATA_PATH))
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {'fullDataPath': 'gs://test_bucket/test_path-*.vcf.gz', 'vcfSamples': ['HG00735', 'NA19675_1', 'NA19678']})
+        self.assertEqual(response.json(), {'fullDataPath': 'gs://test_bucket/test_path-*.vcf.gz', 'vcfSamples': ['HG00735', 'NA19675_1', 'NA19679']})
         mock_subprocess.assert_has_calls([
             mock.call('gsutil ls gs://test_bucket/test_path-*.vcf.gz', stdout=-1, stderr=-1, shell=True),  # nosec
             mock.call('gsutil cat -r 0-65536 gs://test_bucket/test_path-001.vcf.gz | gunzip -c -q - ', stdout=-1, stderr=-2, shell=True),  # nosec
@@ -651,13 +647,12 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         # Test missing loaded samples
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
-        import pdb; pdb.set_trace()
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()['error'],
             'In order to load data for families with previously loaded data, new family samples must be joint called in a single VCF with all previously'
             ' loaded samples. The following samples were previously loaded in this project but are missing from the VCF:'
-            '\n Family 1: NA19675_1,  NA19678')
+            '\nFamily 1: NA19678')
 
         # Test a valid operation
         mock_compute_indiv_guid.return_value = 'I0000020_hg00735'
@@ -665,7 +660,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertSetEqual(set(response_json.keys()), {'familiesByGuid', 'familyNotesByGuid', 'individualsByGuid'})
-        self.assertSetEqual(set(response_json['individualsByGuid'].keys()), {'I0000020_hg00735', 'I000001_na19675', 'I000002_na19678'})
+        self.assertSetEqual(set(response_json['individualsByGuid'].keys()), {'I0000020_hg00735', 'I000001_na19675', 'I000003_na19679'})
         self.assertSetEqual(set(response_json['familiesByGuid'].keys()), {'F000001_1', 'F000015_21'})
         self.assertEqual(list(response_json['familyNotesByGuid'].keys()), ['FAN000004_21_c_a_new_family'])
 
@@ -674,8 +669,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         mock_compute_indiv_guid.side_effect = ['I0000021_na19675_1', 'I0000022_na19678', 'I0000023_hg00735']
         url = reverse(add_workspace_data, args=[PROJECT2_GUID])
         self._test_mv_file_and_triggering_dag_exception(
-            url, {'guid': PROJECT2_GUID}, PROJECT2_SAMPLE_DATA, 'GRCh37', REQUEST_BODY_ADD_DATA2,
-            num_samples=len(PROJECT2_SAMPLES))
+            url, {'guid': PROJECT2_GUID}, PROJECT2_SAMPLE_DATA, 'GRCh37', REQUEST_BODY_ADD_DATA2)
 
     def _test_errors(self, url, fields, workspace_name):
         # Test missing required fields in the request body
@@ -706,7 +700,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         self.assertListEqual(response_json['errors'], [
             'NA19674 is affected but has no HPO terms',
             'NA19681 has invalid HPO terms: HP:0100258',
-            'NA19679 is the mother of NA19674 but is not included. Make sure to create an additional record with NA19679 as the Individual ID',
+            'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
         ])
 
         # test missing samples
@@ -715,7 +709,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         self.assertEqual(response.status_code, 400)
         response_json = response.json()
         self.assertEqual(response_json['errors'],
-                         ['The following samples are included in the pedigree file but are missing from the VCF: NA19679, HG00736',
+                         ['The following samples are included in the pedigree file but are missing from the VCF: NA19678, HG00736',
                           'The following families do not have any affected individuals: 22'])
 
     def _assert_valid_operation(self, project, test_add_data=True):
@@ -728,26 +722,15 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         header = ['Project_GUID', 'Family_GUID', 'Family_ID', 'Individual_ID', 'Paternal_ID', 'Maternal_ID', 'Sex']
         if test_add_data:
             rows = [
-                ['R0001_1kg', 'F000001_1', '1', 'NA19675_1', 'NA19678', '', 'F'],
+                ['R0001_1kg', 'F000001_1', '1', 'NA19675_1', '', 'NA19679', 'F'],
                 ['R0001_1kg', 'F000001_1', '1', 'NA19678', '', '', 'M'],
                 ['R0001_1kg', 'F000001_1', '1', 'NA19679', '', '', 'F'],
-                ['R0001_1kg', 'F000002_2', '2', 'HG00731', 'HG00732', 'HG00733', 'X0'],
-                ['R0001_1kg', 'F000002_2', '2', 'HG00732', '', '', 'M'],
-                ['R0001_1kg', 'F000002_2', '2', 'HG00733', '', '', 'F'],
-                ['R0001_1kg', 'F000003_3', '3', 'NA20870', '', '', 'M'],
-                ['R0001_1kg', 'F000004_4', '4', 'NA20872', '', '', 'M'],
-                ['R0001_1kg', 'F000005_5', '5', 'NA20874', '', '', 'M'],
-                ['R0001_1kg', 'F000006_6', '6', 'NA20875', '', '', 'M'],
-                ['R0001_1kg', 'F000007_7', '7', 'NA20876', '', '', 'M'],
-                ['R0001_1kg', 'F000008_8', '8', 'NA20888', '', '', 'F'],
-                ['R0001_1kg', 'F000009_9', '9', 'NA20878', '', '', 'M'],
-                ['R0001_1kg', 'F000010_10', '10', 'NA20881', '', '', 'M'],
                 ['R0001_1kg', 'F000015_21', '21', 'HG00735', '', '', 'U']
             ]
         else:
             rows = [
-                ['P_anvil-no-project-workspace1', 'F_1_workspace1', '1', 'NA19675_1', 'NA19678', '', 'F'],
-                ['P_anvil-no-project-workspace1', 'F_1_workspace1', '1', 'NA19678', '', '', 'M'],
+                ['P_anvil-no-project-workspace1', 'F_1_workspace1', '1', 'NA19675_1', '', 'NA19679', 'F'],
+                ['P_anvil-no-project-workspace1', 'F_1_workspace1', '1', 'NA19679', '', '', 'F'],
                 ['P_anvil-no-project-workspace1', 'F_21_workspace1', '21', 'HG00735', '', '', 'U'],
             ]
         self.mock_temp_open.return_value.__enter__.return_value.write.assert_called_with(
@@ -767,7 +750,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
             'Requester Email': 'test_user_manager@test.com',
             'AnVIL Project URL': f'http://testserver/project/{project.guid}/project_page',
             'Initial Request Date': '2021-03-01',
-            'Number of Samples': 8 if test_add_data else 3,
+            'Number of Samples': 4 if test_add_data else 3,
             'Status': 'Loading',
         }}]})
         self.assert_expected_airtable_headers(-1)
@@ -782,7 +765,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         }
         sample_summary = '3 new'
         if test_add_data:
-            sample_summary += ' and 7 re-loaded'
+            sample_summary += ' and 2 re-loaded'
         slack_message = """
         *test_user_manager@test.com* requested to load {sample_summary} WES samples ({version}) from AnVIL workspace *my-seqr-billing/{workspace_name}* at 
         gs://test_bucket/test_path.vcf to seqr project <http://testserver/project/{guid}/project_page|*{project_name}*> (guid: {guid})
@@ -819,13 +802,13 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
             'father__individual_id': None, 'sex': 'U', 'affected': 'A', 'notes': None, 'features': [{'id': 'HP:0001508'}],
         }, individual_model_data)
         self.assertIn({
-            'family__family_id': '1', 'individual_id': 'NA19675_1', 'mother__individual_id': None,
-            'father__individual_id': 'NA19678', 'sex': 'F', 'affected': 'A', 'notes': 'A affected individual, test1-zsf',
+            'family__family_id': '1', 'individual_id': 'NA19675_1', 'mother__individual_id': 'NA19679',
+            'father__individual_id': None, 'sex': 'F', 'affected': 'A', 'notes': 'A affected individual, test1-zsf',
             'features': [{'id': 'HP:0011675'}, {'id': 'HP:0012469'}],
         }, individual_model_data)
         self.assertIn({
-            'family__family_id': '1', 'individual_id': 'NA19678', 'mother__individual_id': None,
-            'father__individual_id': None, 'sex': 'M', 'affected': 'N', 'notes': 'a individual note', 'features': [],
+            'family__family_id': '1', 'individual_id': 'NA19679', 'mother__individual_id': None,
+            'father__individual_id': None, 'sex': 'F', 'affected': 'N', 'notes': 'a individual note', 'features': [],
         }, individual_model_data)
 
     def _test_mv_file_and_triggering_dag_exception(self, url, workspace, sample_data, genome_version, request_body, num_samples=None):

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -651,12 +651,13 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         # Test missing loaded samples
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
+        import pdb; pdb.set_trace()
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
             response.json()['error'],
-            'In order to add new data to this project, new samples must be joint called in a single VCF with all previously'
+            'In order to load data for families with previously loaded data, new family samples must be joint called in a single VCF with all previously'
             ' loaded samples. The following samples were previously loaded in this project but are missing from the VCF:'
-            ' HG00731, HG00732, HG00733, NA20870, NA20874')
+            '\n Family 1: NA19675_1,  NA19678')
 
         # Test a valid operation
         mock_compute_indiv_guid.return_value = 'I0000020_hg00735'

--- a/seqr/views/utils/airflow_utils.py
+++ b/seqr/views/utils/airflow_utils.py
@@ -19,12 +19,12 @@ class DagRunningException(Exception):
     pass
 
 
-def trigger_airflow_data_loading(*args, user: User, success_message: str, success_slack_channel: str,
+def trigger_airflow_data_loading(*args, user: User, individual_ids: list[int], success_message: str, success_slack_channel: str,
                                  error_message: str, is_internal: bool = False, **kwargs):
 
     success = True
     updated_variables, gs_path = prepare_data_loading_request(
-        *args, user, pedigree_dir=SEQR_V3_PEDIGREE_GS_PATH, **kwargs,
+        *args, user, individual_ids=individual_ids, pedigree_dir=SEQR_V3_PEDIGREE_GS_PATH, **kwargs,
     )
     updated_variables['sample_source'] = 'Broad_Internal' if is_internal else 'AnVIL'
     upload_info = [f'Pedigree files have been uploaded to {gs_path}']

--- a/seqr/views/utils/individual_utils.py
+++ b/seqr/views/utils/individual_utils.py
@@ -22,7 +22,7 @@ def _get_record_individual_id(record):
     return record.get(JsonConstants.PREVIOUS_INDIVIDUAL_ID_COLUMN) or record[JsonConstants.INDIVIDUAL_ID_COLUMN]
 
 
-def add_or_update_individuals_and_families(project, individual_records, user, get_update_json=True, get_updated_individual_ids=False, get_created_counts=False, allow_features_update=False):
+def add_or_update_individuals_and_families(project, individual_records, user, get_update_json=True, get_updated_individual_db_ids=False, get_created_counts=False, allow_features_update=False):
     """
     Add or update individual and family records in the given project.
 
@@ -88,8 +88,8 @@ def add_or_update_individuals_and_families(project, individual_records, user, ge
     if get_update_json:
         pedigree_json = _get_updated_pedigree_json(updated_individuals, updated_family_models, updated_note_ids, user)
 
-    if get_updated_individual_ids:
-        return pedigree_json, {i.individual_id for i in updated_individuals}
+    if get_updated_individual_db_ids:
+        return pedigree_json, {i.id for i in updated_individuals}
 
     if get_created_counts:
         return pedigree_json, num_created_families, num_created_individuals


### PR DESCRIPTION
Updates the validation logic for AnVIL loading so only families with new/updated samples are loaded and complete families can be skipped for data loading