### PR TITLE
Fix multi data type comp het bug

### DIFF
--- a/hail_search/test_search.py
+++ b/hail_search/test_search.py
@@ -1022,7 +1022,7 @@ class HailSearchTestCase(AioHTTPTestCase):
             [[MULTI_DATA_TYPE_COMP_HET_VARIANT2, missing_gt_gcnv_variant]],
             inheritance_mode='compound_het', pathogenicity=pathogenicity,
             annotations=gcnv_annotations_2, annotations_secondary=selected_transcript_annotations,
-            sample_data={**EXPECTED_SAMPLE_DATA, 'SV_WES': [EXPECTED_SAMPLE_DATA['SV_WES'][0], EXPECTED_SAMPLE_DATA['SV_WES'][2]]}
+            sample_data={**EXPECTED_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA['SV_WES'][:1] + SV_WES_SAMPLE_DATA['SV_WES'][2:]}
 
         )
 


### PR DESCRIPTION
There is a bug for multi-family multi-data-type comp het searches where the sample data within a family differed between data types. This has potentially always been a bug in this backend, its just a really rare search case. We were not catching it in tests because while we did have a test that covered almost this exact case we were only multi-family for SNV_INDEL data but only including a single family for SV data