### PR TITLE
Require affected family members

### DIFF
--- a/seqr/utils/search/add_data_utils.py
+++ b/seqr/utils/search/add_data_utils.py
@@ -12,6 +12,7 @@ from seqr.utils.search.elasticsearch.es_utils import validate_es_index_metadata_
 from seqr.views.utils.airtable_utils import AirtableSession, ANVIL_REQUEST_TRACKING_TABLE
 from seqr.views.utils.dataset_utils import match_and_update_search_samples, load_mapping_file
 from seqr.views.utils.export_utils import write_multiple_files
+from seqr.views.utils.pedigree_info_utils import get_no_affected_families
 from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL, BASE_URL, ANVIL_UI_URL, \
     SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL
 
@@ -156,10 +157,7 @@ def _upload_data_loading_files(projects: list[Project], user: User, file_path: s
         data_by_project[row.pop('project')].append(row)
         affected_by_family[row['Family_GUID']].append(row.pop('affected_status'))
 
-    no_affected_families = [
-        family_id for family_id, affected_statuses in affected_by_family.items()
-        if all(affected != Individual.AFFECTED_STATUS_AFFECTED for affected in affected_statuses)
-    ]
+    no_affected_families =get_no_affected_families(affected_by_family)
     if no_affected_families:
         families = ', '.join(sorted(no_affected_families))
         raise ErrorsWarningsException(errors=[

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -331,10 +331,7 @@ def validate_fam_file_records(project, records, fail_on_warnings=False, errors=N
         for individual_id, count in individual_id_counts.items() if count > 1
     ]
 
-    no_affected_families = [
-        family_id for family_id, affected_statuses in affected_status_by_family.items()
-        if all(affected is not None and affected != Individual.AFFECTED_STATUS_AFFECTED for affected in affected_statuses)
-    ]
+    no_affected_families = get_no_affected_families(affected_status_by_family)
     if no_affected_families:
         warnings.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))
 
@@ -344,6 +341,13 @@ def validate_fam_file_records(project, records, fail_on_warnings=False, errors=N
     if errors:
         raise ErrorsWarningsException(errors, warnings)
     return warnings
+
+
+def get_no_affected_families(affected_status_by_family: dict[str, list[str]]) -> list[str]:
+    return [
+        family_id for family_id, affected_statuses in affected_status_by_family.items()
+        if all(affected is not None and affected != Individual.AFFECTED_STATUS_AFFECTED for affected in affected_statuses)
+    ]
 
 
 def get_valid_hpo_terms(records, additional_feature_columns=None):

--- a/ui/pages/Project/components/edit-families-and-individuals/BulkEditForm.jsx
+++ b/ui/pages/Project/components/edit-families-and-individuals/BulkEditForm.jsx
@@ -75,12 +75,11 @@ const FAMILY_CORE_EXPORT_DATA = FAMILY_BULK_EDIT_EXPORT_DATA.slice(1, 5)
 const FamiliesBulkForm = React.memo(({ user, ...props }) => (
   <EditBulkForm
     name="families"
-    actionDescription="bulk-add or edit families"
+    actionDescription="bulk edit families"
     details={
       <div>
-        If the Family ID in the table matches those of an existing family in the project,
-        the matching families&apos;s data will be updated with values from the table. Otherwise, a new family
-        will be created. To edit an existing families&apos;s ID include a &nbsp;
+        The Family ID in the table must match those of an existing family in the project.
+        To edit an existing families&apos;s ID include a &nbsp;
         <b>Previous Family ID</b>
         &nbsp; column.
       </div>


### PR DESCRIPTION
Updates seqr in a few places to try and reduce instances of families with no affected individuals:
- when  bulk editing individuals, validate at least one individual in family is affected
- disable ability to create empty families (families are already created by creating individuals for them)
- add additional check when generating loading pipeline to fail loading request when attempted with an unaffected family