### PR TITLE
do not reset gencode from update_all_reference_data

### DIFF
--- a/reference_data/management/commands/update_all_reference_data.py
+++ b/reference_data/management/commands/update_all_reference_data.py
@@ -14,6 +14,7 @@ from reference_data.management.commands.update_gene_cn_sensitivity import CNSens
 from reference_data.management.commands.update_gencc import GenCCReferenceDataHandler
 from reference_data.management.commands.update_clingen import ClinGenReferenceDataHandler
 from reference_data.management.commands.update_refseq import RefseqReferenceDataHandler
+from reference_data.models import GeneInfo
 
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,9 @@ class Command(BaseCommand):
         update_failed = []
 
         if not options["skip_gencode"]:
+            if GeneInfo.objects.count() > 0:
+                logger.info('Skipping update_all_reference_data because GeneInfo is already loaded')
+                return
             # Download latest version first, and then add any genes from old releases not included in the latest release
             # Old gene ids are used in the gene constraint table and other datasets, as well as older sequencing data
             update_gencode(LATEST_GENCODE_RELEASE, reset=True)

--- a/reference_data/management/tests/update_all_reference_data_tests.py
+++ b/reference_data/management/tests/update_all_reference_data_tests.py
@@ -11,6 +11,7 @@ from reference_data.management.commands.update_gene_cn_sensitivity import CNSens
 from reference_data.management.commands.update_gencc import GenCCReferenceDataHandler
 from reference_data.management.commands.update_clingen import ClinGenReferenceDataHandler
 from reference_data.management.commands.update_refseq import RefseqReferenceDataHandler
+from reference_data.models import GeneInfo
 
 
 def omim_exception(omim_key):
@@ -78,7 +79,15 @@ class UpdateAllReferenceDataTest(TestCase):
             call_command('update_all_reference_data')
         self.assertEqual(str(err.exception), 'Error: one of the arguments --omim-key --use-cached-omim --skip-omim is required')
 
+        # Test update is skipped when data is already loaded
+        self.mock_update_gencode.assert_not_called()
+        self.mock_omim.assert_not_called()
+        self.mock_cached_omim.assert_not_called()
+        self.mock_update_records.assert_not_called()
+        self.mock_update_hpo.assert_not_called()
+
         # Test update all gencode, no skips, fail primate_ai and mgi
+        GeneInfo.objects.all().delete()
         call_command('update_all_reference_data', '--omim-key=test_key')
 
         calls = [


### PR DESCRIPTION
This change means the first time update_all_reference_data is run it will fully populate the reference data db, but on subsequent runs it will be skipped. This means if it runs after kubernetes install it will work correctly the first time and then for all future times nothing bad happens