### PR TITLE
Local install - postgres init

### DIFF
--- a/deploy/LOCAL_INSTALL.md
+++ b/deploy/LOCAL_INSTALL.md
@@ -30,6 +30,8 @@ The steps below describe how to create a new empty seqr instance with a single A
 SEQR_DIR=$(pwd)
 
 wget https://raw.githubusercontent.com/broadinstitute/seqr/master/docker-compose.yml
+wget https://raw.githubusercontent.com/broadinstitute/seqr/master/deploy/postgres/initdb.sql
+mv initdb.sql ./data/postgres_init/initdb.sql
 
 docker compose up -d seqr   # start up the seqr docker image in the background after also starting other components it depends on (postgres, redis, elasticsearch). This may take 10+ minutes.
 docker compose logs -f seqr  # (optional) continuously print seqr logs to see when it is done starting up or if there are any errors. Type Ctrl-C to exit from the logs. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - PGPORT=5433
       - POSTGRES_PASSWORD=docker-compose-postgres-password
     volumes:
-      - ./deploy/postgres/initdb.sql:/docker-entrypoint-initdb.d/initdb.sql
+      - ./data/postgres_init/initdb.sql:/docker-entrypoint-initdb.d/initdb.sql
       - ./data/postgres:/var/lib/postgresql/data
     healthcheck:
       test: pg_isready -h postgres -U postgres


### PR DESCRIPTION
The init script we added for postgres is not actually available for local installs unless they clone the whole seqr repo which is not the recommended approach. While a little messy this adds a couple of lines to the manual instructions to make sure the file is available locally