### PR TITLE
hide gene search link on variant lookup page

### DIFF
--- a/ui/shared/components/panel/variants/VariantGene.jsx
+++ b/ui/shared/components/panel/variants/VariantGene.jsx
@@ -626,7 +626,7 @@ export const BaseVariantGene = React.memo(({
           size="tiny"
         />
         &nbsp; | &nbsp;
-        <GeneSearchLinkWithPopup location={geneId} familyGuids={variant.familyGuids} />
+        {!variant.lookupFamilyGuids && <GeneSearchLinkWithPopup location={geneId} familyGuids={variant.familyGuids} />}
       </GeneLinks>
     )
   }


### PR DESCRIPTION
The gene search link on the variant lookup page causes errors, analysts agreed its confusing to have there and would rather it was removed. 
Search error: https://console.cloud.google.com/errors/detail/CL2Ln7jdy_jwLw;locations=global;time=P30D?project=seqr-project&utm_source=error-reporting-notification&utm_medium=slack&utm_content=resolved-error