### PR TITLE
do not use query_table for variant id queries

### DIFF
--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -394,7 +394,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
             variant_id_q = ht.alleles == [variant_ids[0][2], variant_ids[0][3]]
         else:
             variant_id_q = hl.any([
-                (ht.locus == hl.locus(chrom, pos, reference_genome=self.GENOME_VERSION)) &
+                (ht.locus == hl.locus(f'chr{chrom}' if self._should_add_chr_prefix() else chrom, pos, reference_genome=self.GENOME_VERSION)) &
                 (ht.alleles == [ref, alt])
                 for chrom, pos, ref, alt in variant_ids
             ])


### PR DESCRIPTION
When building the VLM I discovered that the approach we were using to look up variants in the hail backend, which is to  create a key-table of locus-alleles and then use `query_table` to just read in the relevant rows, is actually substantially slower than reading in the table directly with the intervals set to the one base pair interval of the variant itself and then filtering for matching alleles. Testing on an GRCh37 lookup the time went from 32 seconds to 16 seconds, and GrCh38 is actually a bit slower the 37

The `query_table` approach is still needed for SV lookup, as SV tables are not keyed by locus