### PR TITLE
separate agg for variant lookup project data

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -1238,7 +1238,7 @@ class BaseHailTableQuery(object):
 
     def _import_variant_projects_ht(self, project_samples, variant_id):
         projects_ht, _ = self._import_and_filter_multiple_project_hts(project_samples, n_partitions=1)
-        return projects_ht.key_by()
+        return self._filter_variant_ids(projects_ht, [variant_id]).key_by()
 
     def lookup_variant(self, variant_id, sample_data):
         variants = self.lookup_variants([variant_id])

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -1236,17 +1236,17 @@ class BaseHailTableQuery(object):
 
         return formatted.aggregate(hl.agg.take(formatted.row, len(variant_ids)))
 
-    def _import_variant_projects_ht(self, project_samples, variant_id):
+    def _import_variant_projects_ht(self, variant_id, project_samples=None, **kwargs):
         projects_ht, _ = self._import_and_filter_multiple_project_hts(project_samples, n_partitions=1)
         return self._filter_variant_ids(projects_ht, [variant_id]).key_by()
 
-    def lookup_variant(self, variant_id, sample_data):
+    def lookup_variant(self, variant_id, sample_data=None):
         variants = self.lookup_variants([variant_id])
         if not variants:
             raise HTTPNotFound()
         variant = dict(variants[0])
 
-        projects_ht = self._import_variant_projects_ht(sample_data, variant_id)
+        projects_ht = self._import_variant_projects_ht(variant_id, sample_data=sample_data)
         project_data = projects_ht.aggregate(hl.agg.take(projects_ht.row, 1))
         if project_data:
             variant.update(project_data[0])

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -508,7 +508,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
     def _gene_rank_sort(cls, r, gene_ranks):
         return [gene_ranks.get(r.selected_transcript.gene_id)] + super()._gene_rank_sort(r, gene_ranks)
 
-    def _import_variant_projects_ht(self, variant_id, **kwargs):
+    def _import_variant_projects_ht(self, variant_id, *args, **kwargs):
         # Get all the project-families for the looked up variant formatted as a dict of dicts:
         # {<project_guid>: {<sample_type>: {<family_guid>: True}, <sample_type_2>: {<family_guid_2>: True}}, <project_guid_2>: ...}
         lookup_ht = self._read_table('lookup.ht', skip_missing_field='project_stats')

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -508,7 +508,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
     def _gene_rank_sort(cls, r, gene_ranks):
         return [gene_ranks.get(r.selected_transcript.gene_id)] + super()._gene_rank_sort(r, gene_ranks)
 
-    def _import_variant_projects_ht(self, project_samples, variant_id):
+    def _import_variant_projects_ht(self, variant_id, **kwargs):
         # Get all the project-families for the looked up variant formatted as a dict of dicts:
         # {<project_guid>: {<sample_type>: {<family_guid>: True}, <sample_type_2>: {<family_guid_2>: True}}, <project_guid_2>: ...}
         lookup_ht = self._read_table('lookup.ht', skip_missing_field='project_stats')
@@ -542,7 +542,7 @@ class MitoHailTableQuery(BaseHailTableQuery):
         self._has_both_sample_types = True
         logger.info(f'Looking up {self.DATA_TYPE} variant in {len(variant_projects)} projects')
 
-        projects_ht = super()._import_variant_projects_ht(variant_projects, variant_id)
+        projects_ht = super()._import_variant_projects_ht(variant_id, project_samples=variant_projects)
         return projects_ht.select(familyGenotypes=hl.dict(projects_ht.family_entries.map(
             lambda entries: (entries.first().familyGuid, self._get_sample_genotype(entries.filter(hl.is_defined)))
         )))

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -508,11 +508,11 @@ class MitoHailTableQuery(BaseHailTableQuery):
     def _gene_rank_sort(cls, r, gene_ranks):
         return [gene_ranks.get(r.selected_transcript.gene_id)] + super()._gene_rank_sort(r, gene_ranks)
 
-    def _add_project_lookup_data(self, ht, annotation_fields, *args, variant_ids=None, **kwargs):
+    def _import_variant_projects_ht(self, project_samples, variant_id):
         # Get all the project-families for the looked up variant formatted as a dict of dicts:
         # {<project_guid>: {<sample_type>: {<family_guid>: True}, <sample_type_2>: {<family_guid_2>: True}}, <project_guid_2>: ...}
         lookup_ht = self._read_table('lookup.ht', skip_missing_field='project_stats')
-        lookup_ht = self._filter_variant_ids(lookup_ht, variant_ids)
+        lookup_ht = self._filter_variant_ids(lookup_ht, [variant_id])
         if lookup_ht is None:
             raise HTTPNotFound()
         variant_projects = lookup_ht.aggregate(hl.agg.take(
@@ -540,15 +540,12 @@ class MitoHailTableQuery(BaseHailTableQuery):
         variant_projects = variant_projects[0]
 
         self._has_both_sample_types = True
-        annotation_fields.update({
-            'familyGenotypes': lambda r: hl.dict(r.family_entries.map(
-                lambda entries: (entries.first().familyGuid, self._get_sample_genotype(entries.filter(hl.is_defined)))
-            )),
-        })
-
         logger.info(f'Looking up {self.DATA_TYPE} variant in {len(variant_projects)} projects')
 
-        return super()._add_project_lookup_data(ht, annotation_fields, project_samples=variant_projects, **kwargs)
+        projects_ht = super()._import_variant_projects_ht(variant_projects, variant_id)
+        return projects_ht.select(familyGenotypes=hl.dict(projects_ht.family_entries.map(
+            lambda entries: (entries.first().familyGuid, self._get_sample_genotype(entries.filter(hl.is_defined)))
+        )))
 
     @staticmethod
     def _stat_has_non_ref(s):

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -1,7 +1,8 @@
 import hail as hl
 
 
-from hail_search.constants import CONSEQUENCE_SORT, NEW_SV_FIELD, STRUCTURAL_ANNOTATION_FIELD
+from hail_search.constants import CONSEQUENCE_SORT, NEW_SV_FIELD, STRUCTURAL_ANNOTATION_FIELD, FAMILY_GUID_FIELD, \
+    GENOTYPES_FIELD
 from hail_search.queries.base import BaseHailTableQuery, PredictionPath
 
 
@@ -132,8 +133,9 @@ class SvHailTableQuery(BaseHailTableQuery):
             )),
         }
 
-    def _add_project_lookup_data(self, *args, sample_data=None, **kwargs):
-        project_samples, _ = self._parse_sample_data(sample_data)
-        return super()._add_project_lookup_data(
-            *args, include_sample_annotations=True, project_samples=project_samples, **kwargs,
-        )
+    def _import_variant_projects_ht(self, project_samples, variant_id):
+        parsed_project_samples, _ = self._parse_sample_data(project_samples)
+        projects_ht = super()._import_variant_projects_ht(parsed_project_samples, variant_id)
+
+        annotation_fields = self.annotation_fields(include_genotype_overrides=False)
+        return projects_ht.select(**{k: annotation_fields[k](projects_ht) for k in [FAMILY_GUID_FIELD, GENOTYPES_FIELD]})

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -133,9 +133,9 @@ class SvHailTableQuery(BaseHailTableQuery):
             )),
         }
 
-    def _import_variant_projects_ht(self, project_samples, variant_id):
-        parsed_project_samples, _ = self._parse_sample_data(project_samples)
-        projects_ht = super()._import_variant_projects_ht(parsed_project_samples, variant_id)
+    def _import_variant_projects_ht(self, variant_id, sample_data=None, **kwargs):
+        project_samples, _ = self._parse_sample_data(sample_data)
+        projects_ht = super()._import_variant_projects_ht(variant_id, project_samples=project_samples)
 
         annotation_fields = self.annotation_fields(include_genotype_overrides=False)
         return projects_ht.select(**{k: annotation_fields[k](projects_ht) for k in [FAMILY_GUID_FIELD, GENOTYPES_FIELD]})


### PR DESCRIPTION
This refactors how we add the genotype-level data from all seqr projects. Previously we were joining all the project tables to the annotation table and then doing a single take aggregation, this changes the behavior to separately aggregate the annotation data and genotype data and then combine them after the fact. This change does make lookup a couple seconds slower (although nowhere near undoing the performance gains from https://github.com/broadinstitute/seqr/pull/4518) but is a necessary precursor to the VLM-related feature of including genotypes from projects on different genome builds