### PR TITLE
Improve status designation for in-progress DAG

### DIFF
--- a/seqr/views/utils/airflow_utils.py
+++ b/seqr/views/utils/airflow_utils.py
@@ -68,7 +68,7 @@ def _check_dag_running_state():
     endpoint = f'dags/{DAG_NAME}/dagRuns'
     resp = _make_airflow_api_request(endpoint, method='GET')
     dag_runs = resp['dag_runs']
-    if dag_runs and dag_runs[-1]['state'] == 'running':
+    if dag_runs and dag_runs[-1]['state'] not in {'success', 'failed'}:
         raise DagRunningException(f'{DAG_NAME} DAG is running and cannot be triggered again.')
 
 


### PR DESCRIPTION
We encountered a bug in this connection between the UI and airflow resulting in an in-progress DAG being over-written because it was in a "queued"/"scheduled" state rather than "running".  This expands the check to include all non-completed airflow statuses.  