### PR TITLE
Reorder genes in flapping test

### DIFF
--- a/hail_search/test_search.py
+++ b/hail_search/test_search.py
@@ -634,7 +634,7 @@ class HailSearchTestCase(AioHTTPTestCase):
 
         await self._assert_expected_search(
             [SELECTED_TRANSCRIPT_MULTI_FAMILY_VARIANT],  omit_data_type='SV_WES',
-            intervals=LOCATION_SEARCH['intervals'][-1:], gene_ids=LOCATION_SEARCH['gene_ids'][:1]
+            intervals=[LOCATION_SEARCH['intervals'][-2]], gene_ids=[LOCATION_SEARCH['gene_ids'][1]],
         )
 
         await self._assert_expected_search(

--- a/hail_search/test_utils.py
+++ b/hail_search/test_utils.py
@@ -1034,8 +1034,8 @@ MITO_VARIANT3 = {
 }
 
 LOCATION_SEARCH = {
-    'gene_ids': ['ENSG00000177000', 'ENSG00000097046'],
-    'intervals': [['2', 1234, 5678], ['7', 1, 11100], ['1', 11785723, 11806455], ['1', 91500851, 91525764]],
+    'gene_ids': ['ENSG00000097046', 'ENSG00000177000'],
+    'intervals': [['2', 1234, 5678], ['7', 1, 11100], ['1', 91500851, 91525764], ['1', 11785723, 11806455]],
 }
 EXCLUDE_LOCATION_SEARCH = {'intervals': LOCATION_SEARCH['intervals'], 'exclude_intervals': True}
 VARIANT_ID_SEARCH = {'variant_ids': [['1', 10439, 'AC', 'A'], ['1', 91511686, 'TCA', 'G']], 'rs_ids': []}


### PR DESCRIPTION
I think this doesn't actually fix the issue... I think there's non-determinism baked into `parse_locus_list_items`?