### PR TITLE
shared notification url formatting

### DIFF
--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -44,12 +44,12 @@ ANVIL_HTML_EMAIL = f'Dear seqr user,<br /><br />' \
                    f'<br />Let us know if you have any questions.<br /><br />All the best,<br />The seqr team'
 INTERNAL_TEXT_EMAIL = """Dear seqr user,
 
-This is to notify you that 2 new WES samples have been loaded in seqr project Test Reprocessed Project
+This is to notify you that data for 2 new WES samples has been loaded in seqr project Test Reprocessed Project
 
 All the best,
 The seqr team"""
 INTERNAL_HTML_EMAIL = f'Dear seqr user,<br /><br />' \
-                      f'This is to notify you that 2 new WES samples have been loaded in seqr project ' \
+                      f'This is to notify you that data for 2 new WES samples has been loaded in seqr project ' \
                       f'<a href=https://seqr.broadinstitute.org/project/{PROJECT_GUID}/project_page>Test Reprocessed Project</a>' \
                       f'<br /><br />All the best,<br />The seqr team'
 
@@ -195,7 +195,7 @@ def mock_metadata_file(index):
 @mock.patch('seqr.utils.file_utils.os.path.isfile', lambda *args: True)
 @mock.patch('seqr.utils.search.hail_search_utils.HAIL_BACKEND_SERVICE_HOSTNAME', MOCK_HAIL_HOST)
 @mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_URL', 'http://testairtable')
-@mock.patch('seqr.utils.search.add_data_utils.BASE_URL', SEQR_URL)
+@mock.patch('seqr.utils.communication_utils.BASE_URL', SEQR_URL)
 @mock.patch('seqr.utils.search.add_data_utils.SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL', 'anvil-data-loading')
 @mock.patch('seqr.utils.search.add_data_utils.SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL', 'seqr-data-loading')
 class CheckNewSamplesTest(AnvilAuthenticationTestCase):
@@ -548,11 +548,11 @@ class CheckNewSamplesTest(AnvilAuthenticationTestCase):
         self.mock_send_slack.assert_has_calls([
             mock.call(
                 'seqr-data-loading',
-                f'2 new WES samples are loaded in {SEQR_URL}project/{PROJECT_GUID}/project_page\n```NA20888, NA20889```',
+                f'2 new WES samples are loaded in <{SEQR_URL}project/{PROJECT_GUID}/project_page|Test Reprocessed Project>\n```NA20888, NA20889```',
             ),
             mock.call(
                 'anvil-data-loading',
-                f'1 new WES samples are loaded in {SEQR_URL}project/{EXTERNAL_PROJECT_GUID}/project_page',
+                f'1 new WES samples are loaded in <{SEQR_URL}project/{EXTERNAL_PROJECT_GUID}/project_page|Non-Analyst Project>',
             ),
             mock.call(
                 'seqr_loading_notifications',
@@ -592,10 +592,10 @@ The following 1 families failed sex check:
             ),
             mock.call(
                 'seqr-data-loading',
-                f'1 new WES SV samples are loaded in {SEQR_URL}project/R0001_1kg/project_page\n```NA20872```',
+                f'1 new WES SV samples are loaded in <{SEQR_URL}project/R0001_1kg/project_page|1kg project nåme with uniçøde>\n```NA20872```',
             ), mock.call(
                 'seqr-data-loading',
-                f'1 new WES SV samples are loaded in {SEQR_URL}project/{PROJECT_GUID}/project_page\n```NA20889```',
+                f'1 new WES SV samples are loaded in <{SEQR_URL}project/{PROJECT_GUID}/project_page|Test Reprocessed Project>\n```NA20889```',
             ),
         ])
 

--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -7,6 +7,7 @@ from django.utils.html import strip_tags
 from notifications.signals import notify
 
 BASE_EMAIL_TEMPLATE = 'Dear seqr user,\n\n{}\n\nAll the best,\nThe seqr team'
+EMAIL_MESSAGE_TEMPLATE = 'This is to notify you that data for {notification} has been loaded in seqr project {project_link}'
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +56,16 @@ def send_html_email(email_body, process_message=None, **kwargs):
     email_message.send()
 
 
-def send_project_notification(project, notification, email, subject):
+def send_project_notification(project, notification, subject, notification_prefix='Loaded ', email_template=None, slack_channel=None, slack_detail=None):
     users = project.subscribers.user_set.all()
-    notify.send(project, recipient=users, verb=notification)
+    notify.send(project, recipient=users, verb=f'{notification_prefix}{notification}')
+
+    url = f'{BASE_URL}project/{project.guid}/project_page'
+
+    email = (email_template or EMAIL_MESSAGE_TEMPLATE).format(
+        notification=notification,
+        project_link=f'<a href={url}>{project.name}</a>',
+    )
     email_kwargs = dict(
         email_body=BASE_EMAIL_TEMPLATE.format(email),
         to=list(users.values_list('email', flat=True)),
@@ -68,6 +76,14 @@ def send_project_notification(project, notification, email, subject):
         send_html_email(**email_kwargs)
     except Exception as e:
         logger.error(f'Error sending project email for {project.guid}: {e}', extra={'detail': email_kwargs})
+
+    if slack_channel:
+        slack_message = f'{notification} are loaded in <{url}|{project.name}>'
+        if slack_detail:
+            slack_message += f'\n```{slack_detail}```'
+        safe_post_to_slack(slack_channel, slack_message)
+
+    return url
 
 
 def _set_bulk_notification_stream(message):

--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -56,9 +56,9 @@ def send_html_email(email_body, process_message=None, **kwargs):
     email_message.send()
 
 
-def send_project_notification(project, notification, subject, notification_prefix='Loaded ', email_template=None, slack_channel=None, slack_detail=None):
+def send_project_notification(project, notification, subject, email_template=None, slack_channel=None, slack_detail=None):
     users = project.subscribers.user_set.all()
-    notify.send(project, recipient=users, verb=f'{notification_prefix}{notification}')
+    notify.send(project, recipient=users, verb=f'Loaded {notification}')
 
     url = f'{BASE_URL}project/{project.guid}/project_page'
 

--- a/seqr/utils/search/add_data_utils.py
+++ b/seqr/utils/search/add_data_utils.py
@@ -4,7 +4,7 @@ from django.db.models import F
 
 from reference_data.models import GENOME_VERSION_LOOKUP
 from seqr.models import Sample, Individual, Project
-from seqr.utils.communication_utils import send_project_notification, safe_post_to_slack
+from seqr.utils.communication_utils import send_project_notification
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.utils.middleware import ErrorsWarningsException
 from seqr.utils.search.utils import backend_specific_call
@@ -13,7 +13,7 @@ from seqr.views.utils.airtable_utils import AirtableSession, ANVIL_REQUEST_TRACK
 from seqr.views.utils.dataset_utils import match_and_update_search_samples, load_mapping_file
 from seqr.views.utils.export_utils import write_multiple_files
 from seqr.views.utils.pedigree_info_utils import get_no_affected_families
-from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL, BASE_URL, ANVIL_UI_URL, \
+from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL, ANVIL_UI_URL, \
     SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL
 
 logger = SeqrLogger(__name__)
@@ -58,54 +58,42 @@ def add_new_es_search_samples(request_json, project, user, notify=False, expecte
     return inactivated_sample_guids, updated_family_guids, updated_samples
 
 
-def _format_email(sample_summary, project_link, *args):
-    return f'This is to notify you that {sample_summary} have been loaded in seqr project {project_link}'
-
-
-def _basic_notify_search_data_loaded(project, dataset_type, sample_type, inactivated_sample_guids, updated_samples, format_email=_format_email):
+def _basic_notify_search_data_loaded(project, dataset_type, sample_type, inactivated_sample_guids, updated_samples, format_email=None, slack_channel=None, include_slack_detail=False):
     previous_loaded_individuals = set(Sample.objects.filter(guid__in=inactivated_sample_guids).values_list('individual_id', flat=True))
     new_sample_ids = [sample['sample_id'] for sample in updated_samples if sample['individual_id'] not in previous_loaded_individuals]
 
-    url = f'{BASE_URL}project/{project.guid}/project_page'
     msg_dataset_type = '' if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS else f' {dataset_type}'
     num_new_samples = len(new_sample_ids)
     sample_summary = f'{num_new_samples} new {sample_type}{msg_dataset_type} samples'
 
-    project_link = f'<a href={url}>{project.name}</a>'
-    email = format_email(sample_summary, project_link, num_new_samples)
-
-    send_project_notification(
+    return send_project_notification(
         project,
-        notification=f'Loaded {sample_summary}',
-        email=email,
+        notification=sample_summary,
+        email_template=format_email(num_new_samples) if format_email else None,
         subject='New data available in seqr',
+        slack_channel=slack_channel,
+        slack_detail=', '.join(sorted(new_sample_ids)) if include_slack_detail else None,
     )
-
-    return sample_summary, new_sample_ids, url
 
 
 def notify_search_data_loaded(project, is_internal, dataset_type, sample_type, inactivated_sample_guids, updated_samples, num_samples):
     if is_internal:
-        format_email = _format_email
+        format_email = None
     else:
         workspace_name = f'{project.workspace_namespace}/{project.workspace_name}'
-        def format_email(sample_summary, project_link, num_new_samples):
+        def format_email(num_new_samples):
             reload_summary = f' and {num_samples - num_new_samples} re-loaded samples' if num_samples > num_new_samples else ''
             return '\n'.join([
                 f'We are following up on the request to load data from AnVIL on {project.created_date.date().strftime("%B %d, %Y")}.',
-                f'We have loaded {sample_summary}{reload_summary} from the AnVIL workspace <a href={ANVIL_UI_URL}#workspaces/{workspace_name}>{workspace_name}</a> to the corresponding seqr project {project_link}.',
+                f'We have loaded {{notification}}{reload_summary} from the AnVIL workspace <a href={ANVIL_UI_URL}#workspaces/{workspace_name}>{workspace_name}</a> to the corresponding seqr project {{project_link}}.',
                 'Let us know if you have any questions.',
             ])
 
-    sample_summary, new_sample_ids, url = _basic_notify_search_data_loaded(
+    url = _basic_notify_search_data_loaded(
         project, dataset_type, sample_type, inactivated_sample_guids, updated_samples, format_email=format_email,
+        slack_channel=SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL if is_internal else SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL,
+        include_slack_detail=is_internal,
     )
-
-    sample_id_list = f'\n```{", ".join(sorted(new_sample_ids))}```' if is_internal else ''
-    summary_message = f'{sample_summary} are loaded in {url}{sample_id_list}'
-    safe_post_to_slack(
-        SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL if is_internal else SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL,
-        summary_message)
 
     if not is_internal:
         AirtableSession(user=None, base=AirtableSession.ANVIL_BASE, no_auth=True).safe_patch_records(

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -346,16 +346,9 @@ def load_rna_seq_sample_data(request, sample_guid):
 
 
 def _notify_phenotype_prioritization_loaded(project, tool, num_samples):
-    url = f'{BASE_URL}project/{project.guid}/project_page'
-    project_link = f'<a href={url}>{project.name}</a>'
-    email = (
-        f'This is to notify you that {tool.title()} data for {num_samples} sample(s) '
-        f'has been loaded in seqr project {project_link}'
-    )
     send_project_notification(
         project,
-        notification=f'Loaded {num_samples} {tool.title()} sample(s)',
-        email=email,
+        notification=f'{num_samples} {tool.title()} sample(s)',
         subject=f'New {tool.title()} data available in seqr',
     )
 

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -48,7 +48,7 @@ class DatasetAPITest(object):
     @mock.patch('seqr.models.random.randint')
     @mock.patch('seqr.utils.communication_utils.logger')
     @mock.patch('seqr.utils.communication_utils.send_html_email')
-    @mock.patch('seqr.utils.search.add_data_utils.BASE_URL', 'https://seqr.broadinstitute.org/')
+    @mock.patch('seqr.utils.communication_utils.BASE_URL', 'https://seqr.broadinstitute.org/')
     @urllib3_responses.activate
     def test_add_variants_dataset(self, mock_send_email, mock_logger, mock_random):
         url = reverse(add_variants_dataset_handler, args=[PROJECT_GUID])
@@ -269,7 +269,7 @@ class DatasetAPITest(object):
                                       project_guid=PROJECT_GUID, project_name='1kg project nåme with uniçøde',
                                       recipient='test_user_manager@test.com'):
         if not email_content:
-            email_content = f'This is to notify you that {count} new {sample_type} samples have been loaded in seqr project <a href={SEQR_URL}/project/{project_guid}/project_page>{project_name}</a>'
+            email_content = f'This is to notify you that data for {count} new {sample_type} samples has been loaded in seqr project <a href={SEQR_URL}/project/{project_guid}/project_page>{project_name}</a>'
         mock_send_email.assert_called_once_with(
             email_body=f'Dear seqr user,\n\n{email_content}\n\nAll the best,\nThe seqr team',
             subject='New data available in seqr', to=[recipient], process_message=mock.ANY,

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from tqdm import tqdm
 
 from seqr.models import Sample, Individual, Family, Project, RnaSample, RnaSeqOutlier, RnaSeqTpm, RnaSeqSpliceOutlier
-from seqr.utils.communication_utils import safe_post_to_slack, send_project_notification
+from seqr.utils.communication_utils import send_project_notification
 from seqr.utils.file_utils import file_iter
 from seqr.utils.logging_utils import SeqrLogger
 from seqr.utils.middleware import ErrorsWarningsException
@@ -14,7 +14,7 @@ from seqr.views.utils.file_utils import parse_file
 from seqr.views.utils.permissions_utils import get_internal_projects
 from seqr.views.utils.json_utils import _to_snake_case, _to_camel_case
 from reference_data.models import GeneInfo
-from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL, BASE_URL
+from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL
 
 logger = SeqrLogger(__name__)
 
@@ -558,20 +558,12 @@ def _notify_rna_loading(model_cls, sample_projects, internal_projects):
     data_type = RNA_MODEL_DISPLAY_NAME[model_cls]
     for project_agg in sample_projects:
         new_ids = project_agg["new_sample_ids"]
-        project_link = f'<{BASE_URL}project/{project_agg["guid"]}/project_page|{project_agg["name"]}>'
-        safe_post_to_slack(
-            SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL,
-            f'{len(new_ids)} new RNA {data_type} samples are loaded in {project_link}\n```{", ".join(new_ids)}```'
-        )
-        email = (
-            f'This is to notify you that data for {len(new_ids)} new RNA {data_type} sample(s) '
-            f'has been loaded in seqr project {project_link}'
-        )
         send_project_notification(
             project=projects_by_name[project_agg["name"]],
-            notification=f'Loaded {len(new_ids)} new RNA {data_type} sample(s)',
-            email=email,
+            notification=f'{len(new_ids)} new RNA {data_type} sample(s)',
             subject=f'New RNA {data_type} data available in seqr',
+            slack_channel=SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL,
+            slack_detail=', '.join(new_ids),
         )
 
 


### PR DESCRIPTION
email notification for RNA loading did not include the project name/URL because we were sending it with a url formatted for slack instead of regular html. Since most notification include links to projects and this is an easy mistake to make I updated the `send_project_notification` helper function to handle slack as well as email notification and to handle constructing the URL for each in the helper instead of having the URL passed in by the calling function. This fixes the bug and also means that this is less likely to happen again in the future. In the process of unifying the functionality there are some slight differences to some of the slack/email messages being generatdd by this helper but they should all be either improvements or at worst neutral changes