### PR TITLE
add error handling for reload annotations failure

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -81,9 +81,12 @@ class Command(BaseCommand):
         reset_cached_search_results(project=None)
 
         for data_type_key, updated_families in updated_families_by_data_type.items():
-            self._reload_shared_variant_annotations(
-                *data_type_key, updated_variants_by_data_type[data_type_key], exclude_families=updated_families,
-            )
+            try:
+                self._reload_shared_variant_annotations(
+                    *data_type_key, updated_variants_by_data_type[data_type_key], exclude_families=updated_families,
+                )
+            except Exception as e:
+                logger.error(f'Error reloading shared annotations for {data_type_key.join("/")}: {e}')
 
         logger.info('DONE')
 


### PR DESCRIPTION
When reloading saved variant annotations fails at the end of the check samples job we report that the whole jb failed which is not true. Its i  more accurate to have the job succeed but log an error which will alert developers that this step failed and needs to be re-run. Inspired by this failure: https://the-tgg.slack.com/archives/G01EEU8PR35/p1737044853064989