### PR TITLE
use smaller batch size for updated annotations query

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -28,7 +28,7 @@ RUN_PATH_FIELDS = ['genome_version', 'dataset_type', 'run_version']
 
 DATASET_TYPE_MAP = {'GCNV': Sample.DATASET_TYPE_SV_CALLS}
 USER_EMAIL = 'manage_command'
-MAX_LOOKUP_VARIANTS = 5000
+MAX_LOOKUP_VARIANTS = 1000
 RELATEDNESS_CHECK_NAME = 'relatedness_check'
 
 PDO_COPY_FIELDS = [


### PR DESCRIPTION
Reloading 5000 variants at a time is causing the hail backend to timeout and restart the pod, it seems more stable to use a smaller chunk size