### PR TITLE
handle email error log issue

### DIFF
--- a/seqr/utils/communication_utils.py
+++ b/seqr/utils/communication_utils.py
@@ -70,10 +70,9 @@ def send_project_notification(project, notification, subject, email_template=Non
         email_body=BASE_EMAIL_TEMPLATE.format(email),
         to=list(users.values_list('email', flat=True)),
         subject=subject,
-        process_message=_set_bulk_notification_stream,
     )
     try:
-        send_html_email(**email_kwargs)
+        send_html_email(**email_kwargs, process_message=_set_bulk_notification_stream)
     except Exception as e:
         logger.error(f'Error sending project email for {project.guid}: {e}', extra={'detail': email_kwargs})
 

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -248,15 +248,19 @@ class AuthenticationTestCase(TestCase):
         self._log_stream.truncate(0)
         self._log_stream.seek(0)
 
-    def assert_json_logs(self, user, expected):
+    def assert_json_logs(self, user, expected, offset=0):
         logs = self._log_stream.getvalue().split('\n')
+        if offset:
+            logs = logs[offset:]
         for i, (message, extra) in enumerate(expected):
             extra = extra or {}
             validate = extra.pop('validate', None)
             log_value = json.loads(logs[i])
             expected_log = {
-                'timestamp': mock.ANY, 'severity': 'INFO', 'user': user.email, **extra,
+                'timestamp': mock.ANY, 'severity': 'INFO', **extra,
             }
+            if user:
+                expected_log['user'] = user.email
             if message is not None:
                 expected_log['message'] = message
             self.assertDictEqual(log_value, expected_log)


### PR DESCRIPTION
When we tried to add extra detail to the error log on email failure it caused an error to be re-raised because it could not properly json serialize the log. We were missing this in our tests because we were mocking the logger. Our tests by default log to a captured stream so you can test what is actually logged without mocking the logger at all, and changing the test to no longer mock the logger caused the bug to replicate in our tests