### PR TITLE
Validation reporting resliancy

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -197,13 +197,16 @@ class Command(BaseCommand):
             user=None,
         )
 
-        # Send loading notifications and update Airtable PDOs
         new_sample_data_by_project = {
             s['individual__family__project']: s for s in updated_samples.filter(id__in=new_samples).values('individual__family__project').annotate(
                 samples=ArrayAgg('sample_id', distinct=True),
                 family_guids=ArrayAgg('individual__family__guid', distinct=True),
             )
         }
+        return cls._report_sample_updates(dataset_type, sample_type, metadata, samples_by_project, new_sample_data_by_project)
+
+    @classmethod
+    def _report_sample_updates(cls, dataset_type, sample_type, metadata, samples_by_project, new_sample_data_by_project):
         updated_project_families = []
         updated_families = set()
         split_project_pdos = {}

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -82,7 +82,6 @@ class Command(BaseCommand):
         for run_dir, run_details in new_runs.items():
             try:
                 metadata_path = os.path.join(run_dir, 'metadata.json')
-                del run_details['files']
                 data_type, updated_families, updated_variants_by_id = self._load_new_samples(metadata_path, **run_details)
                 data_type_key = (data_type, run_details['genome_version'])
                 updated_families_by_data_type[data_type_key].update(updated_families)
@@ -157,7 +156,7 @@ class Command(BaseCommand):
             write_multiple_files([(ERRORS_REPORTED_FILE_NAME, [], [])], run_dir, user=None, file_format=None)
 
     @classmethod
-    def _load_new_samples(cls, metadata_path, genome_version, dataset_type, run_version):
+    def _load_new_samples(cls, metadata_path, genome_version, dataset_type, run_version, **kwargs):
         dataset_type = DATASET_TYPE_MAP.get(dataset_type, dataset_type)
 
         logger.info(f'Loading new samples from {genome_version}/{dataset_type}: {run_version}')

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -156,6 +156,8 @@ RUN_PATHS = [
     b'gs://seqr-hail-search-data/v3.1/GRCh38/GCNV/runs/auto__2024-09-14/',
     b'gs://seqr-hail-search-data/v3.1/GRCh38/GCNV/runs/auto__2024-09-14/_SUCCESS',
     b'gs://seqr-hail-search-data/v3.1/GRCh38/GCNV/runs/auto__2024-09-14/README.txt',
+    b'gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/',
+    b'gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json',
 ]
 OPENED_RUN_JSON_FILES = [{
     'callsets': ['1kg.vcf.gz', 'new_samples.vcf.gz'],
@@ -197,6 +199,8 @@ OPENED_RUN_JSON_FILES = [{
 }, {
     'project_guids': ['R0003_test'],
     'error_messages': ['Missing the following expected contigs:chr17'],
+}, {
+    'error': 'An unhandled error occurred during VCF ingestion',
 }]
 
 def mock_opened_file(index):
@@ -252,7 +256,7 @@ class CheckNewSamplesTest(object):
         self.mock_subprocess.reset_mock()
         self.mock_subprocess.side_effect = [self.mock_ls_process] + [
             mock_opened_file(i) for i in range(len(OPENED_RUN_JSON_FILES))
-        ] + [self.mock_mv_process]
+        ] + [self.mock_mv_process, self.mock_mv_process]
 
         call_command('check_for_new_samples_from_pipeline')
 
@@ -263,7 +267,9 @@ class CheckNewSamplesTest(object):
             ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/MITO/runs/auto__2024-08-12/metadata.json', -2),
             ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/GCNV/runs/auto__2024-09-14/metadata.json', -2),
             ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/validation_errors.json', -2),
+            ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json', -2),
             ('gsutil mv /mock/tmp/* gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/', -2),
+            ('gsutil mv /mock/tmp/* gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/', -2),
         ]])
 
         loading_logs = []
@@ -356,6 +362,7 @@ class CheckNewSamplesTest(object):
             '/seqr/seqr-hail-search-data/GRCh37/SNV_INDEL/runs/manual__2023-11-02/_SUCCESS',
             '/seqr/seqr-hail-search-data/GRCh38/MITO/runs/auto__2024-08-12/_SUCCESS',
             '/seqr/seqr-hail-search-data/GRCh38/GCNV/runs/auto__2024-09-14/_SUCCESS',
+            '/seqr/seqr-hail-search-data/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json',
         ]
         self.mock_glob.return_value = local_files
         self.mock_open.return_value.__enter__.return_value.__iter__.side_effect = [
@@ -370,8 +377,11 @@ class CheckNewSamplesTest(object):
             mock.call(local_files[2], 'r'),
             *[mock.call(path.replace('_SUCCESS', 'metadata.json'), 'r') for path in local_files[3:]]
         ], any_order=True)
-        mock_mkdir.assert_called_once()
-        self.assertEqual(list(mock_written_files.keys()), [local_files[2].replace('validation_errors.json', '_ERRORS_REPORTED')])
+        self.assertEqual(mock_mkdir.call_count, 2)
+        self.assertEqual(list(mock_written_files.keys()), [
+            file.replace('validation_errors.json', '_ERRORS_REPORTED')
+            for file in [local_files[2], local_files[7]]
+        ])
         self.mock_subprocess.assert_not_called()
         error_logs = [
             'Error loading auto__2023-08-09: Data has genome version GRCh38 but the following projects have conflicting versions: R0003_test (GRCh37)',
@@ -532,7 +542,7 @@ class CheckNewSamplesTest(object):
         ])
 
         # Test notifications
-        self.assertEqual(self.mock_send_slack.call_count, 6 + len(self.ADDITIONAL_SLACK_CALLS))
+        self.assertEqual(self.mock_send_slack.call_count, 7 + len(self.ADDITIONAL_SLACK_CALLS))
         self.mock_send_slack.assert_has_calls([
             mock.call(
                 'seqr-data-loading',
@@ -575,6 +585,14 @@ Dataset Type: SNV_INDEL
 Run ID: manual__2025-01-14
 Validation Errors: ['Missing the following expected contigs:chr17']
 See more at https://storage.cloud.google.com/seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/validation_errors.json"""
+        ), mock.call('seqr_loading_notifications',
+                      f"""Callset Validation Failed
+Projects: MISSING FROM ERROR REPORT
+Reference Genome: GRCh38
+Dataset Type: SNV_INDEL
+Run ID: manual__2025-01-24
+Validation Errors: {{"error": "An unhandled error occurred during VCF ingestion"}}
+See more at https://storage.cloud.google.com/seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json"""
         ),
         ])
 


### PR DESCRIPTION
This moves the reporting for validation errors to after the checking for successful samples so issues with validation n the future will not block data loading, and also adds some resiliency for malformed validation error json