### PR TITLE
Check samples test logs

### DIFF
--- a/seqr/views/utils/airtable_utils.py
+++ b/seqr/views/utils/airtable_utils.py
@@ -98,7 +98,7 @@ Desired update:
     def safe_patch_records_by_id(self, record_type, record_ids, update, error_detail=None):
         self._safe_bulk_update_records(
             'patch', record_type, [{'id': record_id, 'fields': update} for record_id in sorted(record_ids)],
-            error_detail=error_detail or {'record_ids': record_ids, 'update': update},
+            error_detail=error_detail or {'record_ids': sorted(record_ids), 'update': update},
         )
 
     def _safe_bulk_update_records(self, update_type, record_type, records, error_detail=None):


### PR DESCRIPTION
The check samples test currently mocks out several different loggers and then tests them independantly. This removes those mocks and instead uses the built in test case log capturing to test that all logs look as expected. This makes the test more maintainable (when making a feature change I was really struggling to get the log tests to work again). As a bonus, it caught an edge case where error detail could not be properly json encoded and in a real world case would not have logged properly!