### PR TITLE
Report loading validation failure to anvil

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -170,7 +170,7 @@ class Command(BaseCommand):
         ] + error_list + [
             'These errors often occur when a joint called VCF is not created in a supported manner. Please see our '
             '<a href=https://storage.googleapis.com/seqr-reference-data/seqr-vcf-info.pdf>documentation</a> for more '
-            'information about supported calling pipelines and file formats. If you believe this error is incorrect'
+            'information about supported calling pipelines and file formats. If you believe this error is incorrect '
             'and would like to request a manual review, please respond to this email.',
         ])
         recipients = send_project_email(project, email_body, 'Error loading seqr data')

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
             f'*Projects:* {project_guids or "MISSING FROM ERROR REPORT"}',
             f'*Reference Genome:* {run_details["genome_version"]}',
             f'*Dataset Type:* {run_details["dataset_type"]}',
-            f'*Run ID: {run_details["run_version"]}',
+            f'*Run ID:* {run_details["run_version"]}',
             f'*Validation Errors:* {error_messages}',
         ]
         if is_google_bucket_file_path(file_path):
@@ -178,7 +178,7 @@ class Command(BaseCommand):
         slack_message = '\n'.join([
             f'Request to load data from *{workspace_name}* failed with the following error(s):',
         ] + error_list + [
-            f'The following users have been notified: {", ".join(recipients.values_list('email', flat=True))}'
+            f'The following users have been notified: {", ".join(recipients.values_list("email", flat=True))}'
         ])
         safe_post_to_slack(SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL, slack_message)
 

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -8,10 +8,10 @@ import logging
 import re
 
 from reference_data.models import GENOME_VERSION_LOOKUP
-from seqr.models import Family, Sample, SavedVariant
-from seqr.utils.communication_utils import safe_post_to_slack
+from seqr.models import Family, Sample, SavedVariant, Project
+from seqr.utils.communication_utils import safe_post_to_slack, send_project_email
 from seqr.utils.file_utils import file_iter, list_files, is_google_bucket_file_path
-from seqr.utils.search.add_data_utils import notify_search_data_loaded
+from seqr.utils.search.add_data_utils import notify_search_data_loaded, update_airtable_loading_tracking_status
 from seqr.utils.search.utils import parse_valid_variant_id
 from seqr.utils.search.hail_search_utils import hail_variant_multi_lookup, search_data_type
 from seqr.views.utils.airtable_utils import AirtableSession, LOADABLE_PDO_STATUSES, AVAILABLE_PDO_STATUS, LOADING_PDO_STATUS
@@ -20,7 +20,8 @@ from seqr.views.utils.export_utils import write_multiple_files
 from seqr.views.utils.permissions_utils import is_internal_anvil_project, project_has_anvil
 from seqr.views.utils.variant_utils import reset_cached_search_results, update_projects_saved_variant_json, \
     get_saved_variants
-from settings import SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL, HAIL_SEARCH_DATA_DIR
+from settings import SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL, HAIL_SEARCH_DATA_DIR, ANVIL_UI_URL, \
+    SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL
 
 logger = logging.getLogger(__name__)
 
@@ -124,10 +125,8 @@ class Command(BaseCommand):
             **{field: get_field_format(field) for field in RUN_PATH_FIELDS}
         )
 
-    @staticmethod
-    def _report_validation_errors(runs) -> None:
-        messages = []
-        reported_runs = []
+    @classmethod
+    def _report_validation_errors(cls, runs) -> None:
         for run_dir, run_details in sorted(runs.items()):
             files = run_details['files']
             if ERRORS_REPORTED_FILE_NAME in files:
@@ -135,25 +134,57 @@ class Command(BaseCommand):
             if VALIDATION_ERRORS_FILE_NAME in files:
                 file_path = os.path.join(run_dir, VALIDATION_ERRORS_FILE_NAME)
                 error_summary = json.loads(next(line for line in file_iter(file_path)))
-                summary = [
-                    'Callset Validation Failed',
-                    f'Projects: {error_summary.get("project_guids", "MISSING FROM ERROR REPORT")}',
-                    f'Reference Genome: {run_details["genome_version"]}',
-                    f'Dataset Type: {run_details["dataset_type"]}',
-                    f'Run ID: {run_details["run_version"]}',
-                    f'Validation Errors: {error_summary.get("error_messages", json.dumps(error_summary))}',
-                ]
-                if is_google_bucket_file_path(file_path):
-                    summary.append(f'See more at https://storage.cloud.google.com/{file_path[5:]}')
-                messages.append('\n'.join(summary))
-                reported_runs.append(run_dir)
+                error_messages = error_summary.get('error_messages')
+                project_guids = error_summary.get('project_guids') or []
+                project = Project.objects.filter(guid__in=project_guids).first() if len(project_guids) == 1 else None
+                if error_messages and project and not cls._is_internal_project(project):
+                    cls._report_anvil_project_validation_error(project, error_messages)
+                else:
+                    cls._report_internal_validation_error(
+                        run_details, file_path, project_guids, error_messages or json.dumps(error_summary),
+                    )
+                write_multiple_files([(ERRORS_REPORTED_FILE_NAME, [], [])], run_dir, user=None, file_format=None)
 
-        for message in messages:
-            safe_post_to_slack(
-                SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL, message,
-            )
-        for run_dir in reported_runs:
-            write_multiple_files([(ERRORS_REPORTED_FILE_NAME, [], [])], run_dir, user=None, file_format=None)
+    @classmethod
+    def _report_internal_validation_error(cls, run_details, file_path, project_guids, error_messages):
+        summary = [
+            'Callset Validation Failed',
+            f'*Projects:* {project_guids or "MISSING FROM ERROR REPORT"}',
+            f'*Reference Genome:* {run_details["genome_version"]}',
+            f'*Dataset Type:* {run_details["dataset_type"]}',
+            f'*Run ID: {run_details["run_version"]}',
+            f'*Validation Errors:* {error_messages}',
+        ]
+        if is_google_bucket_file_path(file_path):
+            summary.append(f'See more at https://storage.cloud.google.com/{file_path[5:]}')
+        safe_post_to_slack(SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL, '\n'.join(summary))
+
+    @classmethod
+    def _report_anvil_project_validation_error(cls, project, error_messages):
+        workspace_name = f'{project.workspace_namespace}/{project.workspace_name}'
+        error_list = [f'- {error}' for error in error_messages]
+        email_body = '\n'.join([
+            f'We are following up on the request to load data from AnVIL workspace '
+            f'<a href={ANVIL_UI_URL}#workspaces/{workspace_name}>{workspace_name}</a> on {project.created_date.date().strftime("%B %d, %Y")}. '
+            f'This request could not be loaded due to the following error(s):'
+        ] + error_list + [
+            'These errors often occur when a joint called VCF is not created in a supported manner. Please see our '
+            '<a href=https://storage.googleapis.com/seqr-reference-data/seqr-vcf-info.pdf>documentation</a> for more '
+            'information about supported calling pipelines and file formats. If you believe this error is incorrect'
+            'and would like to request a manual review, please respond to this email.',
+        ])
+        recipients = send_project_email(project, email_body, 'Error loading seqr data')
+
+        slack_message = '\n'.join([
+            f'Request to load data from *{workspace_name}* failed with the following error(s):',
+        ] + error_list + [
+            f'The following users have been notified: {", ".join(recipients.values_list('email', flat=True))}'
+        ])
+        safe_post_to_slack(SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL, slack_message)
+
+        update_airtable_loading_tracking_status(project, 'Loading request canceled', {
+            'Notes': 'Callset validation failed',
+        })
 
     @classmethod
     def _load_new_samples(cls, metadata_path, genome_version, dataset_type, run_version, **kwargs):
@@ -206,6 +237,10 @@ class Command(BaseCommand):
         return cls._report_sample_updates(dataset_type, sample_type, metadata, samples_by_project, new_sample_data_by_project)
 
     @classmethod
+    def _is_internal_project(cls, project):
+        return not project_has_anvil(project) or is_internal_anvil_project(project)
+
+    @classmethod
     def _report_sample_updates(cls, dataset_type, sample_type, metadata, samples_by_project, new_sample_data_by_project):
         updated_project_families = []
         updated_families = set()
@@ -213,7 +248,7 @@ class Command(BaseCommand):
         session = AirtableSession(user=None, no_auth=True) if AirtableSession.is_airtable_enabled() else None
         for project, sample_ids in samples_by_project.items():
             project_sample_data = new_sample_data_by_project[project.id]
-            is_internal = not project_has_anvil(project) or is_internal_anvil_project(project)
+            is_internal = cls._is_internal_project(project)
             notify_search_data_loaded(
                 project, is_internal, dataset_type, sample_type, project_sample_data['samples'],
                 num_samples=len(sample_ids),

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -65,6 +65,7 @@ class Command(BaseCommand):
                 logger.info('No loaded data available')
 
         self._report_validation_errors(runs)
+        logger.info('DONE')
 
 
     def _load_success_runs(self, runs, success_run_dirs):
@@ -100,8 +101,6 @@ class Command(BaseCommand):
                 )
             except Exception as e:
                 logger.error(f'Error reloading shared annotations for {"/".join(data_type_key)}: {e}')
-
-        logger.info('DONE')
 
     def _get_runs(self, **kwargs):
         path = self._run_path(lambda field: kwargs.get(field, '*') or '*')

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -213,6 +213,7 @@ def mock_opened_file(index):
 @mock.patch('seqr.utils.search.hail_search_utils.HAIL_BACKEND_SERVICE_HOSTNAME', MOCK_HAIL_HOST)
 @mock.patch('seqr.views.utils.airtable_utils.AIRTABLE_URL', 'http://testairtable')
 @mock.patch('seqr.utils.communication_utils.BASE_URL', SEQR_URL)
+@mock.patch('seqr.utils.search.add_data_utils.BASE_URL', SEQR_URL)
 @mock.patch('seqr.utils.search.add_data_utils.SEQR_SLACK_ANVIL_DATA_LOADING_CHANNEL', 'anvil-data-loading')
 @mock.patch('seqr.utils.search.add_data_utils.SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL', 'seqr-data-loading')
 class CheckNewSamplesTest(object):

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -813,7 +813,12 @@ The following users have been notified: test_user_manager@test.com""")
 
     def _assert_expected_airtable_calls(self, has_reload_calls):
         # Test request tracking updates for validation errors
-        # TODO
+        update_loading_tracking_request = responses.calls[-1].request
+        self.assertEqual(update_loading_tracking_request.url, self.airtable_loading_tracking_url)
+        self.assertEqual(update_loading_tracking_request.method, 'PATCH')
+        self.assertDictEqual(json.loads(update_loading_tracking_request.body), {'records': [
+            {'id': 'rec12345', 'fields': {'Status': 'Loading request canceled', 'Notes': 'Callset validation failed'}},
+        ]})
         if not has_reload_calls:
             return 0, 2
 

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -197,7 +197,7 @@ OPENED_RUN_JSON_FILES = [{
     'sample_type': 'WES',
     'family_samples': {'F000004_4': ['NA20872'], 'F000012_12': ['NA20889']},
 }, {
-    'project_guids': ['R0003_test'],
+    'project_guids': ['R0004_non_analyst_project'],
     'error_messages': ['Missing the following expected contigs:chr17'],
 }, {
     'error': 'An unhandled error occurred during VCF ingestion',
@@ -580,7 +580,7 @@ The following 1 families failed sex check:
             ),
             mock.call('seqr_loading_notifications',
                       f"""Callset Validation Failed
-*Projects:* ['{PROJECT_GUID}']
+*Projects:* ['{EXTERNAL_PROJECT_GUID}']
 *Reference Genome:* GRCh38
 *Dataset Type:* SNV_INDEL
 *Run ID:* manual__2025-01-14

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -255,8 +255,8 @@ class CheckNewSamplesTest(object):
     def _test_call(self, error_logs, reload_annotations_logs=None, run_loading_logs=None, reload_calls=None):
         self.mock_subprocess.reset_mock()
         self.mock_subprocess.side_effect = [self.mock_ls_process] + [
-            mock_opened_file(i) for i in range(len(OPENED_RUN_JSON_FILES))
-        ] + [self.mock_mv_process, self.mock_mv_process]
+            mock_opened_file(i) for i in range(len(OPENED_RUN_JSON_FILES) - 1)
+        ] + [self.mock_mv_process, mock_opened_file(-1), self.mock_mv_process]
 
         call_command('check_for_new_samples_from_pipeline')
 
@@ -267,8 +267,8 @@ class CheckNewSamplesTest(object):
             ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/MITO/runs/auto__2024-08-12/metadata.json', -2),
             ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/GCNV/runs/auto__2024-09-14/metadata.json', -2),
             ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/validation_errors.json', -2),
-            ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json', -2),
             ('gsutil mv /mock/tmp/* gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/', -2),
+            ('gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json', -2),
             ('gsutil mv /mock/tmp/* gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/', -2),
         ]])
 
@@ -579,19 +579,19 @@ The following 1 families failed sex check:
             ),
             mock.call('seqr_loading_notifications',
                       f"""Callset Validation Failed
-Projects: ['{PROJECT_GUID}']
-Reference Genome: GRCh38
-Dataset Type: SNV_INDEL
-Run ID: manual__2025-01-14
-Validation Errors: ['Missing the following expected contigs:chr17']
+*Projects:* ['{PROJECT_GUID}']
+*Reference Genome:* GRCh38
+*Dataset Type:* SNV_INDEL
+*Run ID:* manual__2025-01-14
+*Validation Errors:* ['Missing the following expected contigs:chr17']
 See more at https://storage.cloud.google.com/seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/validation_errors.json"""
         ), mock.call('seqr_loading_notifications',
                       f"""Callset Validation Failed
-Projects: MISSING FROM ERROR REPORT
-Reference Genome: GRCh38
-Dataset Type: SNV_INDEL
-Run ID: manual__2025-01-24
-Validation Errors: {{"error": "An unhandled error occurred during VCF ingestion"}}
+*Projects:* MISSING FROM ERROR REPORT
+*Reference Genome:* GRCh38
+*Dataset Type:* SNV_INDEL
+*Run ID:* manual__2025-01-24
+*Validation Errors:* {{"error": "An unhandled error occurred during VCF ingestion"}}
 See more at https://storage.cloud.google.com/seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json"""
         ),
         ])

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -289,9 +289,8 @@ class CheckNewSamplesTest(object):
                 ))
         logs.append(('Reset 2 cached results', None))
         logs += [(log, None) for log in reload_annotations_logs or []]
+        logs += [(log, None) for log in self.VALIDATION_LOGS]
         logs.append(('DONE', None))
-        if run_loading_logs:
-            import pdb; pdb.set_trace()
         self.assert_json_logs(user=None, expected=logs)
 
         self.mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*')
@@ -611,6 +610,7 @@ class LocalCheckNewSamplesTest(AuthenticationTestCase, CheckNewSamplesTest):
 
     LIST_FILE_LOGS = []
     AIRTABLE_LOGS = []
+    VALIDATION_LOGS = []
     ADDITIONAL_SLACK_CALLS = [
         mock.call(
             'seqr-data-loading',
@@ -702,6 +702,14 @@ class AirtableCheckNewSamplesTest(AnvilAuthenticationTestCase, CheckNewSamplesTe
         ('Fetched 1 PDO records from airtable', None),
         ('Fetching AnVIL Seqr Loading Requests Tracking records 0-2 from airtable', None),
         ('Fetched 2 AnVIL Seqr Loading Requests Tracking records from airtable', None),
+    ]
+    VALIDATION_LOGS = [
+        '==> gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/validation_errors.json',
+        'Fetching AnVIL Seqr Loading Requests Tracking records 0-2 from airtable',
+        'Fetched 1 AnVIL Seqr Loading Requests Tracking records from airtable',
+        '==> gsutil mv /mock/tmp/* gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-14/',
+        '==> gsutil cat gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/validation_errors.json',
+        '==> gsutil mv /mock/tmp/* gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-01-24/',
     ]
     ADDITIONAL_SLACK_CALLS = [
         mock.call(

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -290,6 +290,8 @@ class CheckNewSamplesTest(object):
         logs.append(('Reset 2 cached results', None))
         logs += [(log, None) for log in reload_annotations_logs or []]
         logs.append(('DONE', None))
+        if run_loading_logs:
+            import pdb; pdb.set_trace()
         self.assert_json_logs(user=None, expected=logs)
 
         self.mock_redis.return_value.delete.assert_called_with('search_results__*', 'variant_lookup_results__*')


### PR DESCRIPTION
When an anvil project fails validation, seqr will automatically email the project owner with the list of failures. It will also post a message to our slack channel and update our airtable loading tracker. This means that when validation fails our team does not need to do *anything* to resolve it until/unless the user emails us back to follow up on those errors!