### PR TITLE
Data manager test cleanup

### DIFF
--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1457,7 +1457,7 @@ class DataManagerAPITest(AirtableTest):
             response.json()['errors'], [f'Data file or path {self.CALLSET_DIR}/sharded_vcf/part0*.vcf is not found.'],
         )
 
-        self._add_file_list('sharded_vcf/part001.vcf', 'sharded_vcf/part002.vcf')
+        self._add_file_list(['sharded_vcf/part001.vcf', 'sharded_vcf/part002.vcf'])
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'success': True})
@@ -1781,7 +1781,7 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
     def _add_file_iter(self, stdout):
         self.mock_does_file_exist.wait.return_value = 0
         self.mock_file_iter.stdout += stdout
-        self.mock_subprocess.side_effect = [self.mock_file_iter, self.mock_file_iter]
+        self.mock_subprocess.side_effect = [self.mock_does_file_exist, self.mock_file_iter]
 
     def _add_file_list(self, file_list):
         self.mock_does_file_exist.wait.return_value = 0

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1674,7 +1674,8 @@ class LocalDataManagerAPITest(AuthenticationTestCase, DataManagerAPITest):
         self.mock_file_iter.return_value += stdout
 
     def _add_file_list(self, file_list):
-        self.mock_glob.return_value = [f'{self.TRIGGER_CALLSET_DIR}/{file}' for file in file_list]
+        self.mock_does_file_exist.return_value = True
+        self.mock_glob.return_value = [f'/local_dir/{file}' for file in file_list]
 
     def _assert_expected_get_projects_requests(self):
         self.assertEqual(len(responses.calls), 0)


### PR DESCRIPTION
We were explicitly mocking file interactions separately for gs and local files in some of the data loading tests instead of using the shared helper functions in the class to correctly mock file interactions for the given test. This makes updating these tests when those interactions change difficult, so before I do that I decided to clean up the tests