### PR TITLE
Pedigree info validation clean up

### DIFF
--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -4,6 +4,7 @@ import time
 from datetime import datetime
 from functools import wraps
 from collections import defaultdict
+from random import sample
 
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.views import redirect_to_login
@@ -14,7 +15,6 @@ from reference_data.models import GENOME_VERSION_LOOKUP
 from seqr.models import Project, CAN_EDIT, Sample, Individual, IgvSample
 from seqr.views.react_app import render_app_html
 from seqr.views.utils.airtable_utils import AirtableSession, ANVIL_REQUEST_TRACKING_TABLE
-from seqr.utils.search.utils import get_search_samples
 from seqr.views.utils.airflow_utils import trigger_airflow_data_loading
 from seqr.views.utils.json_to_orm_utils import create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
@@ -184,7 +184,7 @@ def create_project_from_workspace(request, namespace, name):
         error = 'Field(s) "{}" are required'.format(', '.join(missing_fields))
         return create_json_response({'error': error}, status=400, reason=error)
 
-    pedigree_records = _parse_uploaded_pedigree(request_json)
+    pedigree_records = _parse_uploaded_pedigree(request_json)[0]
 
     # Create a new Project in seqr
     project_args = {
@@ -225,61 +225,66 @@ def add_workspace_data(request, project_guid):
         error = 'Field(s) "{}" are required'.format(', '.join(missing_fields))
         return create_json_response({'error': error}, status=400, reason=error)
 
-    pedigree_records = _parse_uploaded_pedigree(request_json, project=project)
+    pedigree_records, loaded_individual_ids, sample_type = _parse_uploaded_pedigree(request_json, project=project, search_dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
 
-    previous_samples = get_search_samples([project]).filter(dataset_type=Sample.DATASET_TYPE_VARIANT_CALLS)
-    sample = previous_samples.first()
-    if not sample:
-        return create_json_response({
-            'error': 'New data cannot be added to this project until the previously requested data is loaded',
-        }, status=400)
-    sample_type = sample.sample_type
+    pedigree_json = _trigger_add_workspace_data(
+        project, pedigree_records, request.user, request_json['fullDataPath'], sample_type,
+        previous_loaded_ids=loaded_individual_ids, get_pedigree_json=True)
 
-    families = {record[JsonConstants.FAMILY_ID_COLUMN] for record in pedigree_records}
-    previous_loaded_individuals = previous_samples.filter(
-        individual__family__family_id__in=families,
-    ).values_list('individual_id', 'individual__individual_id', 'individual__family__family_id')
+    return create_json_response(pedigree_json)
+
+
+def _parse_uploaded_pedigree(request_json, project=None, search_dataset_type=None):
+    loaded_sample_type = None
+    loaded_individual_ids = []
+    def validate_expected_samples(record_family_ids, previous_loaded_individuals, sample_type):
+        errors, loaded_ids = _validate_expected_samples(
+            request_json['vcfSamples'], search_dataset_type, record_family_ids, previous_loaded_individuals, sample_type,
+        )
+        nonlocal loaded_individual_ids
+        loaded_individual_ids += loaded_ids
+        nonlocal loaded_sample_type
+        loaded_sample_type = sample_type
+        return errors
+
+    json_records = load_uploaded_file(request_json['uploadedFileId'])
+    pedigree_records = parse_basic_pedigree_table(
+        project, json_records, 'uploaded pedigree file', update_features=True, required_columns=[
+            JsonConstants.SEX_COLUMN, JsonConstants.AFFECTED_COLUMN,
+        ], search_dataset_type=search_dataset_type, validate_expected_samples=validate_expected_samples)
+
+    return pedigree_records, loaded_individual_ids, loaded_sample_type
+
+
+def _validate_expected_samples(vcf_samples, search_dataset_type, record_family_ids, previous_loaded_individuals, sample_type):
+    errors = []
+    if search_dataset_type and not sample_type:
+        errors.append('New data cannot be added to this project until the previously requested data is loaded')
+
+    missing_samples = set(record_family_ids.keys()) - set(vcf_samples)
+    if missing_samples:
+        errors.append('The following samples are included in the pedigree file but are missing from the VCF: {}'.format(
+            ', '.join(missing_samples)))
+
+    families = set(record_family_ids.values())
     missing_samples_by_family = defaultdict(list)
-    for _, individual_id, family_id in previous_loaded_individuals:
-        if individual_id not in request_json['vcfSamples']:
+    for loaded_individual in previous_loaded_individuals:
+        individual_id = loaded_individual[JsonConstants.INDIVIDUAL_ID_COLUMN]
+        family_id = loaded_individual[JsonConstants.FAMILY_ID_COLUMN]
+        if family_id in families and individual_id not in vcf_samples:
             missing_samples_by_family[family_id].append(individual_id)
     if missing_samples_by_family:
         missing_family_sample_messages = [
             f'Family {family_id}: {", ".join(sorted(individual_ids))}'
             for family_id, individual_ids in missing_samples_by_family.items()
         ]
-        return create_json_response({
-            'error': 'In order to load data for families with previously loaded data, new family samples must be joint called in a single VCF with all previously loaded samples.'
-                     ' The following samples were previously loaded in this project but are missing from the VCF:\n{}'.format(
-                '\n'.join(sorted(missing_family_sample_messages)))}, status=400)
+        errors.append(
+            'In order to load data for families with previously loaded data, new family samples must be joint called in a single VCF with all previously loaded samples.'
+            ' The following samples were previously loaded in this project but are missing from the VCF:\n' +
+            '\n'.join(sorted(missing_family_sample_messages))
+        )
 
-    pedigree_json = _trigger_add_workspace_data(
-        project, pedigree_records, request.user, request_json['fullDataPath'], sample_type,
-        previous_loaded_ids=[i[0] for i in previous_loaded_individuals], get_pedigree_json=True)
-
-    return create_json_response(pedigree_json)
-
-
-def _parse_uploaded_pedigree(request_json, project=None):
-    # Parse families/individuals in the uploaded pedigree file
-    json_records = load_uploaded_file(request_json['uploadedFileId'])
-    pedigree_records = parse_basic_pedigree_table(
-        project, json_records, 'uploaded pedigree file', update_features=True, required_columns=[
-            JsonConstants.SEX_COLUMN, JsonConstants.AFFECTED_COLUMN,
-        ])
-
-    missing_samples = [record['individualId'] for record in pedigree_records
-                       if record['individualId'] not in request_json['vcfSamples']]
-
-    errors = []
-    if missing_samples:
-        errors.append('The following samples are included in the pedigree file but are missing from the VCF: {}'.format(
-                ', '.join(missing_samples)))
-
-    if errors:
-        raise ErrorsWarningsException(errors, [])
-
-    return pedigree_records
+    return errors, [i['individual_id'] for i in previous_loaded_individuals]
 
 
 def _trigger_add_workspace_data(project, pedigree_records, user, data_path, sample_type, previous_loaded_ids=None, get_pedigree_json=False):

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -261,7 +261,7 @@ def _validate_expected_samples(vcf_samples, search_dataset_type, record_family_i
     if search_dataset_type and not sample_type:
         errors.append('New data cannot be added to this project until the previously requested data is loaded')
 
-    missing_samples = set(record_family_ids.keys()) - set(vcf_samples)
+    missing_samples = sorted(set(record_family_ids.keys()) - set(vcf_samples))
     if missing_samples:
         errors.append('The following samples are included in the pedigree file but are missing from the VCF: {}'.format(
             ', '.join(missing_samples)))

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -286,7 +286,10 @@ def _validate_expected_samples(vcf_samples, search_dataset_type, record_family_i
 
     validate_affected_families(affected_status_by_family, errors)
 
-    return errors, [i['individual_id'] for i in previous_loaded_individuals]
+    loaded_individual_ids = [
+        i['individual_id'] for i in previous_loaded_individuals if i[JsonConstants.FAMILY_ID_COLUMN] in families
+    ]
+    return errors, loaded_individual_ids
 
 
 def _trigger_add_workspace_data(project, pedigree_records, user, data_path, sample_type, previous_loaded_ids=None, get_pedigree_json=False):

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -263,7 +263,7 @@ def add_workspace_data(request, project_guid):
 def _parse_uploaded_pedigree(request_json, project=None):
     # Parse families/individuals in the uploaded pedigree file
     json_records = load_uploaded_file(request_json['uploadedFileId'])
-    pedigree_records, _ = parse_basic_pedigree_table(
+    pedigree_records = parse_basic_pedigree_table(
         project, json_records, 'uploaded pedigree file', update_features=True, required_columns=[
             JsonConstants.SEX_COLUMN, JsonConstants.AFFECTED_COLUMN,
         ])

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -264,7 +264,7 @@ def _validate_expected_samples(vcf_samples, search_dataset_type, record_family_i
     missing_samples = sorted(set(record_family_ids.keys()) - set(vcf_samples))
     if missing_samples:
         errors.append('The following samples are included in the pedigree file but are missing from the VCF: {}'.format(
-            ', '.join(missing_samples)))
+                ', '.join(missing_samples)))
 
     families = set(record_family_ids.values())
     missing_samples_by_family = defaultdict(list)

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -662,8 +662,8 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_EMPTY_FAMILY))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['errors'],[
-            'The following families have no affected individuals and can not be loaded to seqr: F000005_5',
-        ])  # TODO - add all VCF samples to validation, not just the pedigree samples
+            'The following families do not have any affected individuals: F000005_5',
+        ])  # TODO - add all VCF samples to validation, not just the pedigree samples, use human friendly family ID
 
         # Test a valid operation
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_ADD_DATA))

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -703,17 +703,20 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         self.assertEqual(response.status_code, 400)
         response_json = response.json()
         self.assertListEqual(response_json['errors'], [
+            'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
             'NA19674 is affected but has no HPO terms',
             'NA19681 has invalid HPO terms: HP:0100258',
             'The following samples are included in the pedigree file but are missing from the VCF: NA19674, NA19681',
-            'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
         ])
 
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA_NO_AFFECTED
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
         self.assertEqual(response.status_code, 400)
         response_json = response.json()
-        self.assertEqual(response_json['errors'],['The following families do not have any affected individuals: 22'])
+        self.assertEqual(response_json['errors'],[
+            'The following samples are included in the pedigree file but are missing from the VCF: HG00736',
+            'The following families do not have any affected individuals: 22',
+        ])
 
     def _assert_valid_operation(self, project, test_add_data=True):
         genome_version = 'GRCh37' if test_add_data else 'GRCh38'

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -705,8 +705,8 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         self.assertListEqual(response_json['errors'], [
             'NA19674 is affected but has no HPO terms',
             'NA19681 has invalid HPO terms: HP:0100258',
-            'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
             'The following samples are included in the pedigree file but are missing from the VCF: NA19674, NA19681',
+            'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
         ])
 
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA_NO_AFFECTED

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -26,8 +26,6 @@ INVALID_ADDED_SAMPLE_DATA = [['22', 'HG00731', 'HG00731', '', '', 'Female', 'Aff
 
 MISSING_REQUIRED_SAMPLE_DATA = [["21", "HG00736", "", "", "", "", "", "", "", ""]]
 
-LOAD_SAMPLE_DATA_EXTRA_SAMPLE = LOAD_SAMPLE_DATA + [["1", "NA19678", "", "", "", "Male", "Affected", "HP:0011675", "", ""]]
-
 LOAD_SAMPLE_DATA_NO_AFFECTED = LOAD_SAMPLE_DATA + [["22", "HG00736", "", "", "", "Unknown", "Unknown", "", "", ""]]
 
 FILE_DATA = [
@@ -699,7 +697,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         response_json = response.json()
         self.assertListEqual(response_json['errors'], ['Missing Sex in row #4', 'Missing Affected in row #4'])
 
-        # test sample data error
+        # test sample data error and missing samples
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA + BAD_SAMPLE_DATA
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
         self.assertEqual(response.status_code, 400)
@@ -708,15 +706,8 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
             'NA19674 is affected but has no HPO terms',
             'NA19681 has invalid HPO terms: HP:0100258',
             'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
+            'The following samples are included in the pedigree file but are missing from the VCF: NA19674, NA19681',
         ])
-
-        # test missing samples
-        self.mock_load_file.return_value = LOAD_SAMPLE_DATA_EXTRA_SAMPLE
-        response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
-        self.assertEqual(response.status_code, 400)
-        response_json = response.json()
-        self.assertEqual(response_json['errors'],
-                         ['The following samples are included in the pedigree file but are missing from the VCF: NA19678'])
 
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA_NO_AFFECTED
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -646,11 +646,11 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         self.assertEqual(response.status_code, 400)
         response_json = response.json()
         self.assertListEqual(response_json['errors'], [
-            'HG00731 already has loaded data and cannot be moved to a different family',
             'The following samples are included in the pedigree file but are missing from the VCF: HG00731',
             'In order to load data for families with previously loaded data, new family samples must be joint called in a single VCF with all previously'
             ' loaded samples. The following samples were previously loaded in this project but are missing from the VCF:'
             '\nFamily 1: NA19678',
+            'HG00731 already has loaded data and cannot be moved to a different family',
         ])
 
         # Test a valid operation
@@ -697,23 +697,19 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
         self.assertEqual(response.status_code, 400)
         response_json = response.json()
-        errors = [
-            'NA19674 is affected but has no HPO terms',
-            'NA19681 has invalid HPO terms: HP:0100258',
-            'The following samples are included in the pedigree file but are missing from the VCF: NA19674, NA19681',
-        ]
         missing_vcf_sample_error = (
             'In order to load data for families with previously loaded data, new family samples must be joint called in '
             'a single VCF with all previously loaded samples. The following samples were previously loaded in this '
             'project but are missing from the VCF:\nFamily 1: NA19678'
         )
-        if has_existing_data:
-            errors.append(missing_vcf_sample_error)
-        else:
-            errors.insert(
-                0, 'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID',
-            )
-        self.assertListEqual(response_json['errors'], errors)
+        missing_row_error = missing_vcf_sample_error if has_existing_data else \
+            'NA19678 is the father of NA19674 but is not included. Make sure to create an additional record with NA19678 as the Individual ID'
+        self.assertListEqual(response_json['errors'], [
+            'The following samples are included in the pedigree file but are missing from the VCF: NA19674, NA19681',
+            missing_row_error,
+            'NA19674 is affected but has no HPO terms',
+            'NA19681 has invalid HPO terms: HP:0100258',
+        ])
 
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA_NO_AFFECTED
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -67,7 +67,7 @@ TEMP_PATH = '/temp_path/temp_filename'
 
 MOCK_AIRTABLE_URL = 'http://testairtable'
 
-PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA19679', 'NA20870', 'HG00732', 'NA19675_1', 'HG00733', 'HG00731']
+PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA19679', 'NA20870', 'HG00732', 'NA19675_1', 'HG00733', 'HG00731', 'NA20874']
 PROJECT2_SAMPLES = ['NA20885', 'NA19675_1', 'NA19679', 'HG00735']
 PROJECT2_SAMPLE_DATA = [
     {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000016_1', 'Family_ID': '1', 'Individual_ID': 'NA19675_1', 'Paternal_ID': None, 'Maternal_ID': 'NA19679', 'Sex': 'F'},
@@ -80,9 +80,6 @@ NEW_PROJECT_SAMPLE_DATA = [
     {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_1_workspace2', 'Family_ID': '1', 'Individual_ID': 'NA19679', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'F'},
     {'Project_GUID': 'P_anvil-no-project-workspace2', 'Family_GUID': 'F_21_workspace2', 'Family_ID': '21', 'Individual_ID': 'HG00735', 'Paternal_ID': None, 'Maternal_ID': None, 'Sex': 'U'},
 ]
-
-REQUEST_BODY_EMPTY_FAMILY = deepcopy(REQUEST_BODY)
-REQUEST_BODY_EMPTY_FAMILY['vcfSamples'] = PROJECT1_SAMPLES + ['NA20874']
 
 REQUEST_BODY_ADD_DATA = deepcopy(REQUEST_BODY)
 REQUEST_BODY_ADD_DATA['vcfSamples'] = PROJECT1_SAMPLES
@@ -656,16 +653,9 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
             '\nFamily 1: NA19678',
         ])
 
-        # Test family with no affected individuals in reloaded data
+        # Test a valid operation
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA
         mock_compute_indiv_guid.return_value = 'I0000020_hg00735'
-        response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_EMPTY_FAMILY))
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['errors'],[
-            'The following families do not have any affected individuals: F000005_5',
-        ])  # TODO - add all VCF samples to validation, not just the pedigree samples, use human friendly family ID
-
-        # Test a valid operation
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_ADD_DATA))
         self.assertEqual(response.status_code, 200)
         response_json = response.json()

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -67,7 +67,7 @@ TEMP_PATH = '/temp_path/temp_filename'
 
 MOCK_AIRTABLE_URL = 'http://testairtable'
 
-PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA19679', 'NA20870', 'HG00732', 'NA19675_1', 'HG00733', 'HG00731', 'NA20874']
+PROJECT1_SAMPLES = ['HG00735', 'NA19678', 'NA19679', 'NA20870', 'HG00732', 'NA19675_1', 'NA20874', 'HG00733', 'HG00731']
 PROJECT2_SAMPLES = ['NA20885', 'NA19675_1', 'NA19679', 'HG00735']
 PROJECT2_SAMPLE_DATA = [
     {'Project_GUID': 'R0003_test', 'Family_GUID': 'F000016_1', 'Family_ID': '1', 'Individual_ID': 'NA19675_1', 'Paternal_ID': None, 'Maternal_ID': 'NA19679', 'Sex': 'F'},

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1627,7 +1627,7 @@ class DataManagerAPITest(AirtableTest):
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {
-            'errors': ['The following families have no affected individuals and can not be loaded to seqr: F000005_5'],
+            'errors': ['The following families do not have any affected individuals: F000005_5'],
             'warnings': None,
         })
         Individual.objects.filter(guid='I000009_na20874').update(affected='A')

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -181,7 +181,7 @@ def edit_individuals_handler(request, project_guid):
     related_individuals_json = _get_json_for_individuals(related_individuals, project_guid=project_guid, family_fields=['family_id'])
     individuals_list = modified_individuals_list + list(related_individuals_json)
 
-    validate_fam_file_records(project, individuals_list, fail_on_warnings=True, errors=errors)
+    validate_fam_file_records(project, individuals_list, errors=errors)
 
     return _update_and_parse_individuals_and_families(
         project, modified_individuals_list, user=request.user

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -166,22 +166,7 @@ def edit_individuals_handler(request, project_guid):
         if modified_ind.get('maternalGuid'):
             parent_guids.add(modified_ind['maternalGuid'])
 
-    errors = []
-    if parent_guids:
-        related_individuals = Individual.objects.filter(guid__in=parent_guids)
-        parents_by_guid = {i.guid: i for i in related_individuals}
-        for modified_ind in modified_individuals_list:
-            _set_parent_relationships(modified_ind, parents_by_guid, 'paternalGuid', 'father', 'paternalId', errors)
-            _set_parent_relationships(modified_ind, parents_by_guid, 'maternalGuid', 'mother', 'maternalId', errors)
-    else:
-        modified_family_ids = {ind.get('familyId') or ind['family']['familyId'] for ind in modified_individuals_list}
-        modified_family_ids.update({ind.family.family_id for ind in update_individual_models.values()})
-        related_individuals = Individual.objects.filter(family__family_id__in=modified_family_ids, family__project=project)
-    related_individuals = related_individuals.exclude(guid__in=update_individuals.keys())
-    related_individuals_json = _get_json_for_individuals(related_individuals, project_guid=project_guid, family_fields=['family_id'])
-    individuals_list = modified_individuals_list + list(related_individuals_json)
-
-    validate_fam_file_records(project, individuals_list, errors=errors)
+    validate_fam_file_records(project, modified_individuals_list, related_guids=parent_guids)
 
     return _update_and_parse_individuals_and_families(
         project, modified_individuals_list, user=request.user
@@ -341,18 +326,6 @@ def save_individuals_table_handler(request, project_guid, upload_file_id):
 def _update_and_parse_individuals_and_families(project, individual_records, user):
     pedigree_json = add_or_update_individuals_and_families(project, individual_records, user)
     return create_json_response(pedigree_json)
-
-
-def _set_parent_relationships(record, parents_by_guid, guid_key, parent_key, parent_id_key, errors):
-    parent_guid = record.get(guid_key)
-    new_parent = parents_by_guid.get(parent_guid)
-    if parent_guid and not new_parent:
-        errors.append(f'Invalid parental guid {parent_guid}')
-        return
-    record.update({
-        parent_key: new_parent,
-        parent_id_key: new_parent.individual_id if new_parent else None,
-    })
 
 
 FAMILY_ID_COL = 'family_id'

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -183,11 +183,10 @@ class IndividualAPITest(object):
             'individuals': [INDIVIDUAL_IDS_UPDATE_DATA]
         }))
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json(), {'errors': [
+        self.assertListEqual(response.json()['errors'], [
             'NA19678 already has loaded data and cannot update the ID',
-        ], 'warnings': [
             "NA20870 is the mother of NA19678_1 but is not included. Make sure to create an additional record with NA20870 as the Individual ID",
-        ]})
+        ])
 
         response = self.client.post(edit_individuals_url, content_type='application/json', data=json.dumps({
             'individuals': [INDIVIDUAL_IDS_UPDATE_DATA, INDIVIDUAL_FAMILY_UPDATE_DATA]
@@ -421,7 +420,8 @@ class IndividualAPITest(object):
                 'NA19675_1 already has loaded data and cannot be moved to a different family',
                 'NA19675_1 already has loaded data and cannot be moved to a different family',
                 'NA19675_1 is included as 2 separate records, but must be unique within the project',
-            ], 'warnings': ['The following families do not have any affected individuals: 1']
+                'The following families do not have any affected individuals: 1',
+            ], 'warnings': []
         })
 
         response = self.client.post(individuals_url, {'f': SimpleUploadedFile(
@@ -471,8 +471,9 @@ class IndividualAPITest(object):
                 'NA19675_1 is recorded as the father of NA19675_2 but they have different family ids: 1 and 2',
                 'NA19675_2 is recorded as XXX sex and also as the father of NA19677',
                 'NA19675_1 is included as 2 separate records, but must be unique within the project',
+                missing_entry_warning,
             ],
-            'warnings': [missing_entry_warning],
+            'warnings': [],
         })
 
         rows = [rows[0], '"new_fam_1"	"NA19677"	""	"M"	""	"unaffected"']
@@ -634,16 +635,17 @@ class IndividualAPITest(object):
                            'Make sure to create an additional record with SCO_PED073A_GA0338_1 as the Individual ID'
         missing_columns_error = 'SCO_PED073B_GA0339_1 is missing the following required columns: MONDO ID, MONDO Label, Tissue Affected Status'
         response = _send_request_data(data)
-        self.assertDictEqual(response.json(), {'warnings': [expected_warning], 'errors': [
-            missing_columns_error, 'Multiple consent codes specified in manifest: GMB, HMB',
+        self.assertDictEqual(response.json(), {'warnings': [], 'errors': [
+            missing_columns_error, 'Multiple consent codes specified in manifest: GMB, HMB', expected_warning,
         ]})
 
         data[4][-2] = 'GMB'
         mock_no_validate_categories.resolve_expression.return_value = ['Not-used category']
         response = _send_request_data(data)
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json(), {'warnings': [expected_warning], 'errors': [
+        self.assertDictEqual(response.json(), {'warnings': [], 'errors': [
             missing_columns_error, 'Consent code in manifest "GMB" does not match project consent code "HMB"',
+            expected_warning,
         ]})
 
         data[3][12] = 'Maybe'

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -418,8 +418,9 @@ class IndividualAPITest(object):
         self.assertDictEqual(response.json(), {
             'errors': [
                 'NA19675_1 already has loaded data and cannot be moved to a different family',
+                'NA19675_1 already has loaded data and cannot be moved to a different family',
                 'NA19675_1 is included as 2 separate records, but must be unique within the project',
-            ], 'warnings': []
+            ], 'warnings': ['The following families do not have any affected individuals: 1']
         })
 
         response = self.client.post(individuals_url, {'f': SimpleUploadedFile(
@@ -470,7 +471,7 @@ class IndividualAPITest(object):
                 'NA19675_2 is recorded as XXX sex and also as the father of NA19677',
                 'NA19675_1 is included as 2 separate records, but must be unique within the project',
             ],
-            'warnings': [missing_entry_warning, 'The following families do not have any affected individuals: 2'],
+            'warnings': [missing_entry_warning],
         })
 
         rows = [rows[0], '"new_fam_1"	"NA19677"	""	"M"	""	"unaffected"']

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -75,8 +75,8 @@ EXTERNAL_WORKSPACE_INDIVIDUAL_UPDATE_DATA = {
     'individualId': 'NA21987',
     'paternalGuid': 'I000018_na21234',
     'maternalGuid': 'I000020_na65432',
-    'maternalId': '',
-    'paternalId': 'foobar',
+    'maternalId': 'foobar',
+    'paternalId': '',
     'sex': 'U',
     'affected': 'N',
 }
@@ -183,10 +183,11 @@ class IndividualAPITest(object):
             'individuals': [INDIVIDUAL_IDS_UPDATE_DATA]
         }))
         self.assertEqual(response.status_code, 400)
-        self.assertListEqual(response.json()['errors'], [
+        self.assertDictEqual(response.json(), {'errors': [
             'NA19678 already has loaded data and cannot update the ID',
+        ], 'warnings': [
             "NA20870 is the mother of NA19678_1 but is not included. Make sure to create an additional record with NA20870 as the Individual ID",
-        ])
+        ]})
 
         response = self.client.post(edit_individuals_url, content_type='application/json', data=json.dumps({
             'individuals': [INDIVIDUAL_IDS_UPDATE_DATA, INDIVIDUAL_FAMILY_UPDATE_DATA]
@@ -282,10 +283,10 @@ class IndividualAPITest(object):
             return
 
         self.assertEqual(response.status_code, 400)
-        self.assertListEqual(response.json()['errors'], [
-            'Invalid parental guid I000020_na65432',
+        self.assertDictEqual(response.json(), {'errors': [
             'NA21234 is recorded as Female sex and also as the father of NA21987',
-        ])
+            'Invalid parental guid I000020_na65432',
+        ], 'warnings': []})
 
         update_json = deepcopy(EXTERNAL_WORKSPACE_INDIVIDUAL_UPDATE_DATA)
         update_json['maternalGuid'] = update_json.pop('paternalGuid')

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -463,6 +463,7 @@ class IndividualAPITest(object):
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {
             'errors': [
+                missing_entry_warning,
                 'Invalid proband relationship "Father" for NA19675_1 with given gender Female',
                 'NA19675_1 is recorded as their own father',
                 'NA19675_1 is recorded as Female sex and also as the father of NA19675_1',
@@ -471,7 +472,6 @@ class IndividualAPITest(object):
                 'NA19675_1 is recorded as the father of NA19675_2 but they have different family ids: 1 and 2',
                 'NA19675_2 is recorded as XXX sex and also as the father of NA19677',
                 'NA19675_1 is included as 2 separate records, but must be unique within the project',
-                missing_entry_warning,
             ],
             'warnings': [],
         })

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -417,15 +417,15 @@ class IndividualAPITest(object):
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {
             'errors': [
+                'The following families do not have any affected individuals: 1',
                 'NA19675_1 already has loaded data and cannot be moved to a different family',
                 'NA19675_1 already has loaded data and cannot be moved to a different family',
                 'NA19675_1 is included as 2 separate records, but must be unique within the project',
-                'The following families do not have any affected individuals: 1',
             ], 'warnings': []
         })
 
         response = self.client.post(individuals_url, {'f': SimpleUploadedFile(
-            'test.tsv', 'Family ID	Individual ID	Previous Individual ID\n"1"	"NA19675_1"	"NA19675"'.encode('utf-8'))})
+            'test.tsv', 'Family ID	Individual ID	Previous Individual ID	Affected\n"1"	"NA19675_1"	"NA19675"	"A"'.encode('utf-8'))})
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {
             'errors': ['Could not find individuals with the following previous IDs: NA19675'], 'warnings': []
@@ -463,6 +463,7 @@ class IndividualAPITest(object):
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {
             'errors': [
+                'The following families do not have any affected individuals: 1',
                 missing_entry_warning,
                 'Invalid proband relationship "Father" for NA19675_1 with given gender Female',
                 'NA19675_1 is recorded as their own father',
@@ -554,7 +555,7 @@ class IndividualAPITest(object):
 
         self.login_pm_user()
         response = self.client.post(receive_url, {
-            'f': SimpleUploadedFile('individuals.tsv', 'Family ID	Individual ID\n1	2'.encode('utf-8'))})
+            'f': SimpleUploadedFile('individuals.tsv', 'Family ID	Individual ID	Affected\n1	2	A'.encode('utf-8'))})
         self.assertEqual(response.status_code, 200)
         save_url = reverse(save_individuals_table_handler, args=[
             PM_REQUIRED_PROJECT_GUID, response.json()['uploadedFileId']])

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -369,8 +369,8 @@ def validate_fam_file_records(project, records, errors=None, clear_invalid_value
     if no_affected_families:
         warnings.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))
 
-    if not clear_invalid_values and not errors:
-        errors = warnings
+    if not clear_invalid_values:
+        errors += warnings
         warnings = []
     if errors:
         raise ErrorsWarningsException(errors, warnings)

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -367,11 +367,9 @@ def validate_fam_file_records(project, records, errors=None, clear_invalid_value
     # TODO or statement and include with other validation
     no_affected_families = get_no_affected_families(affected_status_by_family)
     if no_affected_families:
-        warnings.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))
+        message_list = warnings if clear_invalid_values else errors
+        message_list.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))
 
-    if not clear_invalid_values:
-        errors += warnings
-        warnings = []
     if errors:
         raise ErrorsWarningsException(errors, warnings)
     return warnings
@@ -410,9 +408,9 @@ def _validate_parent(row, parent_id_type, parent_id_field, parent_guid_field, ex
         warning = f'{parent_id} is the {parent_id_type} of {individual_id} but is not included'
         if clear_invalid_values:
             row[parent_id_field] = None
+            warnings.append(warning)
         else:
-            warning += f'. Make sure to create an additional record with {parent_id} as the Individual ID'
-        warnings.append(warning)
+            errors.append(f'{warning}. Make sure to create an additional record with {parent_id} as the Individual ID')
         return
 
     # is the parent the same individuals

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -308,9 +308,6 @@ def validate_fam_file_records(project, records, errors=None, clear_invalid_value
     hpo_terms = get_valid_hpo_terms(records) if update_features else None
 
     errors = errors or []
-    if validate_expected_samples:
-        errors += validate_expected_samples(record_family_ids, previous_loaded_individuals.values(), sample_type)
-
     warnings = []
     individual_id_counts = defaultdict(int)
     for r in records:
@@ -364,6 +361,10 @@ def validate_fam_file_records(project, records, errors=None, clear_invalid_value
         for individual_id, count in individual_id_counts.items() if count > 1
     ]
 
+    if validate_expected_samples:
+        errors += validate_expected_samples(record_family_ids, previous_loaded_individuals.values(), sample_type)
+
+    # TODO or statement and include with other validation
     no_affected_families = get_no_affected_families(affected_status_by_family)
     if no_affected_families:
         warnings.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -362,24 +362,24 @@ def validate_fam_file_records(project, records, errors=None, clear_invalid_value
     ]
 
     if validate_expected_samples:
-        errors += validate_expected_samples(record_family_ids, previous_loaded_individuals.values(), sample_type)
-
-    # TODO or statement and include with other validation
-    no_affected_families = get_no_affected_families(affected_status_by_family)
-    if no_affected_families:
-        message_list = warnings if clear_invalid_values else errors
-        message_list.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))
+        errors += validate_expected_samples(record_family_ids, affected_status_by_family, previous_loaded_individuals.values(), sample_type)
+    else:
+        validate_affected_families(affected_status_by_family, warnings if clear_invalid_values else errors)
 
     if errors:
         raise ErrorsWarningsException(errors, warnings)
     return warnings
 
 
-def get_no_affected_families(affected_status_by_family: dict[str, list[str]]) -> list[str]:
-    return [
+def validate_affected_families(affected_status_by_family: dict[str, list[str]], error_list: list[str]) -> None:
+    no_affected_families = [
         family_id for family_id, affected_statuses in affected_status_by_family.items()
         if all(affected is not None and affected != Individual.AFFECTED_STATUS_AFFECTED for affected in affected_statuses)
     ]
+    if no_affected_families:
+        error_list.append(
+            f'The following families do not have any affected individuals: {", ".join(sorted(no_affected_families))}'
+        )
 
 
 def get_valid_hpo_terms(records, additional_feature_columns=None):

--- a/seqr/views/utils/pedigree_info_utils.py
+++ b/seqr/views/utils/pedigree_info_utils.py
@@ -124,7 +124,7 @@ def _parse_pedigree_table_json(project, rows, header=None, column_map=None, erro
     else:
         json_records = rows
 
-    validate_fam_file_records(project, json_records, fail_on_warnings=True, errors=errors, update_features=update_features)
+    validate_fam_file_records(project, json_records, errors=errors, update_features=update_features)
     return json_records
 
 
@@ -254,7 +254,7 @@ def _format_value(value, column):
     return value
 
 
-def validate_fam_file_records(project, records, fail_on_warnings=False, errors=None, clear_invalid_values=False, update_features=False):
+def validate_fam_file_records(project, records, errors=None, clear_invalid_values=False, update_features=False):
     """Basic validation such as checking that parents have the same family id as the child, etc.
 
     Args:
@@ -353,7 +353,7 @@ def validate_fam_file_records(project, records, fail_on_warnings=False, errors=N
     if no_affected_families:
         warnings.append('The following families do not have any affected individuals: {}'.format(', '.join(no_affected_families)))
 
-    if fail_on_warnings and not errors:
+    if not clear_invalid_values and not errors:
         errors = warnings
         warnings = []
     if errors:


### PR DESCRIPTION
The helper functions we use to validate pedigrees involve a lot of code duplication, in particular in the way that they look up potential existing individuals in the database. In order to implement https://github.com/broadinstitute/seqr/issues/4580 we need better shared utilities for validating samples which was hard to do with the existing mess of validation. This cleans up the validation code and also abstracts out the logic used for validating the search sample subset into a single helper function.
This PR contains essentially no behavior changes- the only exception is that previously we did 2 steps to validate AnVIL loading requests and thats now done in one step, so certain requests now include more validation falures on the first pass instead of some failures and then more failures on the subsequent request after those are fixed 