### PR TITLE
Disable local dataset support

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -452,9 +452,9 @@ def loading_vcfs(request):
 @pm_or_data_manager_required
 def validate_callset(request):
     request_json = json.loads(request.body)
-    dataset_type = request_json.get('datasetType', Sample.DATASET_TYPE_VARIANT_CALLS)
+    allowed_exts = DATA_TYPE_FILE_EXTS.get(request_json['datasetType']) if anvil_enabled() else None
     validate_vcf_exists(
-        _callset_path(request_json), request.user, allowed_exts=DATA_TYPE_FILE_EXTS.get(dataset_type),
+        _callset_path(request_json), request.user, allowed_exts=allowed_exts,
         path_name=request_json['filePath'],
     )
     return create_json_response({'success': True})

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1471,7 +1471,6 @@ class DataManagerAPITest(AirtableTest):
         self.login_data_manager_user()
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
-        return url
 
     @mock.patch('seqr.views.utils.permissions_utils.INTERNAL_NAMESPACES', ['my-seqr-billing', 'ext-data'])
     @mock.patch('seqr.views.utils.airtable_utils.BASE_URL', 'https://seqr.broadinstitute.org/')

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1521,7 +1521,7 @@ class DataManagerAPITest(AirtableTest):
         responses.add(responses.GET, 'https://api.airtable.com/v0/app3Y97xtbbaOopVR/Samples', json=AIRTABLE_SAMPLE_RECORDS, status=200)
         responses.add(responses.POST, PIPELINE_RUNNER_URL)
         mock_temp_dir.return_value.__enter__.return_value = '/mock/tmp'
-        body = {'filePath': f'{self.CALLSET_DIR}/mito_callset.mt', 'datasetType': 'MITO', 'sampleType': 'WES', 'genomeVersion': '38', 'projects': [
+        body = {'filePath': f'{self.CALLSET_DIR}/callset.vcf', 'datasetType': 'SNV_INDEL', 'sampleType': 'WES', 'genomeVersion': '38', 'projects': [
             json.dumps(option) for option in self.PROJECT_OPTIONS + [{'projectGuid': 'R0005_not_project'}]
         ], 'skipValidation': True}
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
@@ -1539,16 +1539,16 @@ class DataManagerAPITest(AirtableTest):
         self.assertDictEqual(response.json(), {'success': True})
 
         self._assert_expected_load_data_requests(sample_type='WES', skip_validation=True)
-        self._has_expected_ped_files(mock_open, mock_mkdir, 'MITO', sample_type='WES')
+        self._has_expected_ped_files(mock_open, mock_mkdir, 'SNV_INDEL', sample_type='WES')
 
         dag_json = {
             'projects_to_run': [
                 'R0001_1kg',
                 'R0004_non_analyst_project'
             ],
-            'dataset_type': 'MITO',
+            'dataset_type': 'SNV_INDEL',
             'reference_genome': 'GRCh38',
-            'callset_path': f'{self.TRIGGER_CALLSET_DIR}/mito_callset.mt',
+            'callset_path': f'{self.TRIGGER_CALLSET_DIR}/callset.vcf',
             'sample_type': 'WES',
             'skip_validation': True,
         }
@@ -1681,14 +1681,14 @@ class LocalDataManagerAPITest(AuthenticationTestCase, DataManagerAPITest):
     def _assert_expected_get_projects_requests(self):
         self.assertEqual(len(responses.calls), 0)
 
-    def _assert_expected_load_data_requests(self, dataset_type='MITO', sample_type='WGS', trigger_error=False, skip_project=False, skip_validation=False):
+    def _assert_expected_load_data_requests(self, dataset_type='SNV_INDEL', sample_type='WGS', trigger_error=False, skip_project=False, skip_validation=False):
         self.assertEqual(len(responses.calls), 1)
         projects = [PROJECT_GUID, NON_ANALYST_PROJECT_GUID]
         if skip_project:
             projects = projects[1:]
         body = {
             'projects_to_run': projects,
-            'callset_path': '/local_datasets/sv_callset.vcf' if trigger_error else '/local_datasets/mito_callset.mt',
+            'callset_path': '/local_datasets/sv_callset.vcf' if trigger_error else '/local_datasets/callset.vcf',
             'sample_type': sample_type,
             'dataset_type': dataset_type,
             'reference_genome': 'GRCh38',
@@ -1731,7 +1731,7 @@ class LocalDataManagerAPITest(AuthenticationTestCase, DataManagerAPITest):
 
     def _test_load_single_project(self, *args, **kwargs):
         super()._test_load_single_project(*args, **kwargs)
-        self._assert_expected_load_data_requests(dataset_type='SNV_INDEL', skip_project=True, trigger_error=True)
+        self._assert_expected_load_data_requests(skip_project=True, trigger_error=True)
 
     def _assert_write_pedigree_error(self, response):
         self.assertEqual(response.status_code, 500)
@@ -1840,22 +1840,23 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
     @staticmethod
     def _get_dag_variable_overrides(*args, **kwargs):
         return {
-            'callset_path': 'mito_callset.mt',
+            'callset_path': 'callset.vcf',
             'sample_source': 'Broad_Internal',
             'sample_type': 'WES',
             'dataset_type': 'MITO',
             'skip_validation': True,
         }
 
-    def _assert_expected_load_data_requests(self, dataset_type='MITO', **kwargs):
-        required_sample_field = 'MITO_WES_CallsetPath' if dataset_type == 'MITO' else 'gCNV_CallsetPath'
+    def _assert_expected_load_data_requests(self, dataset_type='SNV_INDEL', **kwargs):
+        required_sample_field = 'gCNV_CallsetPath' if dataset_type == 'GCNV' else None
         self._assert_expected_airtable_call(required_sample_field, 'R0001_1kg')
         self.assert_airflow_loading_calls(offset=1, dataset_type=dataset_type, **kwargs)
 
     def _assert_expected_airtable_call(self, required_sample_field, project_guid):
+        required_field_expression = f'LEN({{{required_sample_field}}})>0,' if required_sample_field else ''
         self.assert_expected_airtable_call(
             call_index=0,
-            filter_formula=f"AND(SEARCH('https://seqr.broadinstitute.org/project/{project_guid}/project_page',ARRAYJOIN({{SeqrProject}},';')),LEN({{PassingCollaboratorSampleIDs}})>0,LEN({{{required_sample_field}}})>0,OR(SEARCH('Available in seqr',ARRAYJOIN(PDOStatus,';')),SEARCH('Historic',ARRAYJOIN(PDOStatus,';'))))",
+            filter_formula=f"AND(SEARCH('https://seqr.broadinstitute.org/project/{project_guid}/project_page',ARRAYJOIN({{SeqrProject}},';')),LEN({{PassingCollaboratorSampleIDs}})>0,{required_field_expression}OR(SEARCH('Available in seqr',ARRAYJOIN(PDOStatus,';')),SEARCH('Historic',ARRAYJOIN(PDOStatus,';'))))",
             fields=['CollaboratorSampleID', 'SeqrCollaboratorSampleID', 'PDOStatus', 'SeqrProject'],
         )
 
@@ -1866,9 +1867,9 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
     def _assert_success_notification(self, dag_json):
         dag_json['sample_source'] = 'Broad_Internal'
 
-        message = f"""*test_data_manager@broadinstitute.org* triggered loading internal WES MITO data for 2 projects
+        message = f"""*test_data_manager@broadinstitute.org* triggered loading internal WES SNV_INDEL data for 2 projects
 
-        Pedigree files have been uploaded to gs://seqr-loading-temp/v3.1/GRCh38/MITO/pedigrees/WES
+        Pedigree files have been uploaded to gs://seqr-loading-temp/v3.1/GRCh38/SNV_INDEL/pedigrees/WES
 
         DAG LOADING_PIPELINE is triggered with following:
         ```{json.dumps(dag_json, indent=4)}```
@@ -1886,8 +1887,8 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
         for error in errors:
             self.assertRegex(error, '400 Client Error: Bad Request')
 
-        dag_json = json.dumps(dag_json, indent=4).replace('mito_callset.mt', 'sv_callset.vcf').replace(
-            'WGS', 'WES').replace('MITO', 'GCNV').replace('v01', 'v3.1')
+        dag_json = json.dumps(dag_json, indent=4).replace('callset.vcf', 'sv_callset.vcf').replace(
+            'WGS', 'WES').replace('SNV_INDEL', 'GCNV').replace('v01', 'v3.1')
         error_message = f"""ERROR triggering internal WES SV loading: {errors[0]}
         
         DAG LOADING_PIPELINE should be triggered with following: 


### PR DESCRIPTION
We currently do not allow local installs to specify a dataset type in the loading UI, but we have never reflected that difference in the backend. For the upcoming callset validation changes it helps to simplify the cases we need to support to those that are actually possible in the app, so this restricts the code path for local installs to only be able to load VCFs. This also updates the tests to be mroe representative of the actual request data thats possible