### PR TITLE
Annotation reload improvement

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -33,7 +33,7 @@ RUN_PATH_FIELDS = ['genome_version', 'dataset_type', 'run_version', 'file_name']
 
 DATASET_TYPE_MAP = {'GCNV': Sample.DATASET_TYPE_SV_CALLS}
 USER_EMAIL = 'manage_command'
-MAX_LOOKUP_VARIANTS = 2000
+MAX_LOOKUP_VARIANTS = 1000
 RELATEDNESS_CHECK_NAME = 'relatedness_check'
 
 PDO_COPY_FIELDS = [

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -343,7 +343,7 @@ class Command(BaseCommand):
         return sorted(pdos_to_create.keys())
 
     @staticmethod
-    def _reload_shared_variant_annotations(data_type, genome_version, updated_variants_by_id=None, exclude_families=None):
+    def _reload_shared_variant_annotations(data_type, genome_version, updated_variants_by_id=None, exclude_families=None, chromosomes=None):
         dataset_type = data_type.split('_')[0]
         is_sv = dataset_type.startswith(Sample.DATASET_TYPE_SV_CALLS)
         dataset_type = data_type.split('_')[0] if is_sv else data_type
@@ -358,13 +358,14 @@ class Command(BaseCommand):
             updated_annotation_samples = updated_annotation_samples.filter(sample_type=data_type.split('_')[1])
 
         variant_models = get_saved_variants(
-            genome_version, dataset_type=dataset_type,
+            genome_version, dataset_type=dataset_type, chromosomes=chromosomes,
             family_guids=updated_annotation_samples.values_list('individual__family__guid', flat=True).distinct(),
         )
 
         variant_type_summary = f'{data_type} {genome_version} saved variants'
         if not variant_models:
-            logger.info(f'No additional {variant_type_summary} to update')
+            chrom_summary = f' in chromosomes {", ".join(chromosomes)}' if chromosomes else ''
+            logger.info(f'No additional {variant_type_summary} to update{chrom_summary}')
             return
 
         variants_by_id = defaultdict(list)

--- a/seqr/management/commands/reload_saved_variant_annotations.py
+++ b/seqr/management/commands/reload_saved_variant_annotations.py
@@ -15,6 +15,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('data_type', choices=sorted(DATA_TYPE_CHOICES))
         parser.add_argument('genome_version', choices=sorted(GENOME_VERSION_LOOKUP.values()))
+        parser.add_argument('chromosomes', nargs='*', help='Chromosome(s) to reload. If not specified, defaults to all chromosomes.')
 
     def handle(self, *args, **options):
-        reload_shared_variant_annotations(options['data_type'], options['genome_version'])
+        reload_shared_variant_annotations(options['data_type'], options['genome_version'], chromosomes=options['chromosomes'])

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -389,7 +389,7 @@ class CheckNewSamplesTest(object):
                 {'individual_guid': 'I000017_na20889', 'family_guid': 'F000012_12', 'project_guid': 'R0003_test', 'affected': 'A', 'sample_id': 'NA20889', 'sample_type': 'WES'},
             ]}},
         ], reload_annotations_logs=[
-            'Reloading shared annotations for 3 SNV_INDEL GRCh38 saved variants (3 unique)', 'Fetched 1 additional variants in chromosome 1', 'Fetched 1 additional variants in chromosome 1', 'Updated 2 SNV_INDEL GRCh38 saved variants',
+            'Reloading shared annotations for 3 SNV_INDEL GRCh38 saved variants (3 unique)', 'Updated 1 SNV_INDEL GRCh38 saved variants', 'Fetched 1 additional variants in chromosome 1', 'Fetched 1 additional variants in chromosome 1', 'Updated 1 SNV_INDEL GRCh38 saved variants in chromosome 1',
             'No additional SV_WES GRCh38 saved variants to update',
         ], run_loading_logs={
             'GRCh38/SNV_INDEL': [

--- a/seqr/management/tests/reload_saved_variant_annotations_tests.py
+++ b/seqr/management/tests/reload_saved_variant_annotations_tests.py
@@ -40,8 +40,9 @@ class ReloadVariantAnnotationsTest(AnvilAuthenticationTestCase):
         mock_logger.info.assert_has_calls([mock.call(log) for log in [
             'Reloading shared annotations for 3 SNV_INDEL GRCh37 saved variants (3 unique)',
             'Fetched 2 additional variants in chromosome 1',
+            'Updated 2 SNV_INDEL GRCh37 saved variants in chromosome 1',
             'Fetched 2 additional variants in chromosome 21',
-            'Updated 2 SNV_INDEL GRCh37 saved variants',
+            'Updated 2 SNV_INDEL GRCh37 saved variants in chromosome 21',
         ]])
 
         self.assertEqual(len(responses.calls), 2)
@@ -79,7 +80,7 @@ class ReloadVariantAnnotationsTest(AnvilAuthenticationTestCase):
         mock_logger.info.assert_has_calls([mock.call(log) for log in [
             'Reloading shared annotations for 1 SNV_INDEL GRCh37 saved variants (1 unique)',
             'Fetched 2 additional variants in chromosome 21',
-            'Updated 0 SNV_INDEL GRCh37 saved variants',
+            'Updated 0 SNV_INDEL GRCh37 saved variants in chromosome 21',
         ]])
 
         self.assertEqual(len(responses.calls), 1)

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -14,7 +14,7 @@ from seqr.models import SavedVariant, VariantSearchResults, Family, LocusList, L
     RnaSeqTpm, PhenotypePrioritization, Project, Sample, RnaSample, VariantTag, VariantTagType
 from seqr.utils.search.utils import get_variants_for_variant_ids, backend_specific_call
 from seqr.utils.gene_utils import get_genes_for_variants
-from seqr.utils.xpos_utils import get_xpos
+from seqr.utils.xpos_utils import get_xpos, MIN_POS, MAX_POS
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, create_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_discovery_tags, get_json_for_locus_lists, \
     get_json_for_queryset, get_json_for_rna_seq_outliers, get_json_for_saved_variants_with_tags, \
@@ -67,7 +67,7 @@ def update_projects_saved_variant_json(projects, user_email, **kwargs):
     return updated_variants_by_id
 
 
-def get_saved_variants(genome_version, project_id=None, family_guids=None, dataset_type=None):
+def get_saved_variants(genome_version, project_id=None, family_guids=None, dataset_type=None, chromosomes=None):
     saved_variants = SavedVariant.objects.filter(
         Q(saved_variant_json__genomeVersion__isnull=True) |
         Q(saved_variant_json__genomeVersion=genome_version.replace('GRCh', ''))
@@ -78,6 +78,14 @@ def get_saved_variants(genome_version, project_id=None, family_guids=None, datas
         saved_variants = saved_variants.filter(family__guid__in=family_guids)
     if dataset_type:
         saved_variants = saved_variants.filter(**saved_variants_dataset_type_filter(dataset_type))
+    if chromosomes:
+        chrom_filters = [
+            Q(xpos__gte=get_xpos(chrom, MIN_POS), xpos__lte=get_xpos(chrom, MAX_POS)) for chrom in chromosomes
+        ]
+        chrom_filter= chrom_filters[0]
+        for f in chrom_filters[1:]:
+            chrom_filter |= f
+        saved_variants = saved_variants.filter(chrom_filter)
     return saved_variants
 
 


### PR DESCRIPTION
Reloading all variant annotations has been failing. I was playing around with the page size but made it too big. This resets that and also adds better support for incrementally updating saved variants by chromosome instead of trying to load everthing first and then update everything