### PR TITLE
Sv gene search

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -369,14 +369,17 @@ class BaseHailTableQuery(object):
             all_project_hts.append((ht, sample_data))
         return all_project_hts
 
-    def import_filtered_table(self, project_samples: dict, num_families: int, **kwargs):
+    def _import_families_tables(self, project_samples: dict, num_families: int, **kwargs):
         if num_families == 1 or len(project_samples) == 1:
             project_guid, project_sample_type_data = list(project_samples.items())[0]
-            families_ht, comp_het_families_ht = self._import_and_filter_entries_ht(
+            return self._import_and_filter_entries_ht(
                 project_guid, num_families, project_sample_type_data, **kwargs
             )
         else:
-            families_ht, comp_het_families_ht = self._import_and_filter_multiple_project_hts(project_samples, **kwargs)
+            return self._import_and_filter_multiple_project_hts(project_samples, **kwargs)
+
+    def import_filtered_table(self, project_samples: dict, num_families: int, **kwargs):
+        families_ht, comp_het_families_ht = self._import_families_tables(project_samples, num_families, **kwargs)
 
         if comp_het_families_ht is not None:
             self._comp_het_ht = self._query_table_annotations(comp_het_families_ht, self._get_table_path('annotations.ht'))

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -889,7 +889,7 @@ class BaseHailTableQuery(object):
                 secondary_annotation_overrides = self._get_annotation_override_fields(
                     annotations_secondary, override_fields=self.SECONDARY_ANNOTATION_OVERRIDE_FIELDS, **kwargs)
                 has_data_type_secondary_annotations |= bool(secondary_annotation_overrides)
-                has_different_secondary &= secondary_annotation_overrides != annotation_overrides
+                has_different_secondary |= secondary_annotation_overrides != annotation_overrides
 
             if not has_data_type_primary_annotations:
                 allowed_consequence_ids = secondary_allowed_consequence_ids

--- a/hail_search/queries/mito.py
+++ b/hail_search/queries/mito.py
@@ -360,12 +360,6 @@ class MitoHailTableQuery(BaseHailTableQuery):
         self._has_both_sample_types = False
         super().__init__(*args, **kwargs)
 
-    def _parse_intervals(self, intervals, exclude_intervals=False, **kwargs):
-        parsed_intervals = super()._parse_intervals(intervals,**kwargs)
-        if parsed_intervals and not exclude_intervals and len(parsed_intervals) < MAX_LOAD_INTERVALS:
-            self._load_table_kwargs = {'_intervals': parsed_intervals, '_filter_intervals': True}
-        return parsed_intervals
-
     def _get_family_passes_quality_filter(self, quality_filter, ht, pathogenicity=None, **kwargs):
         passes_quality = super()._get_family_passes_quality_filter(quality_filter, ht)
         clinvar_path_ht = False if passes_quality is None else self._get_loaded_clinvar_prefilter_ht(pathogenicity)

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -53,6 +53,13 @@ class SvHailTableQuery(BaseHailTableQuery):
         )],
     }
 
+    def __init__(self, *args, **kwargs):
+        self._is_interval_filtered = False
+        super().__init__(*args, **kwargs)
+
+    def _set_interval_prefilter(self, *args, **kwargs):
+        self._is_interval_filtered = True
+
     @classmethod
     def _get_sample_type(cls, *args):
         return cls.DATA_TYPE.split('_')[-1]

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -79,7 +79,7 @@ class SvHailTableQuery(BaseHailTableQuery):
         families_ht, comp_het_families_ht = self._import_families_tables(*args, **kwargs)
 
         if comp_het_families_ht is not None:
-            self._comp_het_ht = comp_het_families_ht.annotate(**ht[families_ht.key])
+            self._comp_het_ht = comp_het_families_ht.annotate(**ht[comp_het_families_ht.key])
             self._comp_het_ht = self._filter_compound_hets()
 
         if families_ht is not None:

--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -74,8 +74,8 @@ class SvHailTableQuery(BaseHailTableQuery):
 
         ht = self._read_table('annotations.ht')
         ht = self._filter_annotated_table(ht, is_comp_het=self._has_comp_het_search, **kwargs)
-        self._load_table_kwargs['variant_ht'] = ht.select()
 
+        self._load_table_kwargs['variant_ht'] = ht.select()
         families_ht, comp_het_families_ht = self._import_families_tables(*args, **kwargs)
 
         if comp_het_families_ht is not None:

--- a/hail_search/test_search.py
+++ b/hail_search/test_search.py
@@ -977,6 +977,13 @@ class HailSearchTestCase(AioHTTPTestCase):
             annotations={**annotations_1, **gcnv_annotations_1}, annotations_secondary={**annotations_2, **gcnv_annotations_2},
         )
 
+        await self._assert_expected_search(
+            [MULTI_DATA_TYPE_COMP_HET_VARIANT2, [MULTI_DATA_TYPE_COMP_HET_VARIANT2, GCNV_VARIANT4], [GCNV_VARIANT3, GCNV_VARIANT4]],
+            inheritance_mode='recessive',
+            annotations={**annotations_1, 'structural': ['gCNV_DEL']}, annotations_secondary={**annotations_2, **gcnv_annotations_1},
+            gene_ids=['ENSG00000277258', 'ENSG00000275023'], intervals=[['1', 38717636, 38724781], ['17', 38717636, 38724781]],
+        )
+
         sv_annotations_1 = {'structural': ['INS', 'LOF']}
         sv_annotations_2 = {'structural': ['DEL', 'gCNV_DUP'], 'structural_consequence': ['INTRONIC']}
 


### PR DESCRIPTION
SV search is no longer working for an all-project single gene search. This is because unlike with other data types we can not prefilter the project tables to a single gene. However, the full SV_WGS is only ~500,000 rows (roughly the same size as a SNV_INDEL WGS project table) and can be fully read into hail. This therefore refactors SV gene searches to first read in the annotations table and prefilter the project tables on that, instead of vice-versa