### PR TITLE
Check sample reload only bug

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -237,9 +237,8 @@ class Command(BaseCommand):
             )
         }
 
-        split_project_pdos = {}
-        cls._report_loading_success(
-            dataset_type, sample_type, run_version, samples_by_project, new_sample_data_by_project, split_project_pdos,
+        split_project_pdos = cls._report_loading_success(
+            dataset_type, sample_type, run_version, samples_by_project, new_sample_data_by_project,
         )
         try:
             cls._report_loading_failures(metadata, split_project_pdos)
@@ -258,7 +257,8 @@ class Command(BaseCommand):
         return not project_has_anvil(project) or is_internal_anvil_project(project)
 
     @classmethod
-    def _report_loading_success(cls, dataset_type, sample_type, run_version, samples_by_project, new_sample_data_by_project, split_project_pdos):
+    def _report_loading_success(cls, dataset_type, sample_type, run_version, samples_by_project, new_sample_data_by_project):
+        split_project_pdos = {}
         session = AirtableSession(user=None, no_auth=True) if AirtableSession.is_airtable_enabled() else None
         for project, sample_ids in samples_by_project.items():
             try:
@@ -272,6 +272,8 @@ class Command(BaseCommand):
                     split_project_pdos[project.name] = cls._update_pdos(session, project.guid, sample_ids)
             except Exception as e:
                 logger.error(f'Error reporting loading success for project {project.name} in {run_version}: {e}')
+
+        return split_project_pdos
 
     @classmethod
     def _report_loading_failures(cls, metadata, split_project_pdos):

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -233,6 +233,8 @@ class Command(BaseCommand):
                 family_guids=ArrayAgg('individual__family__guid', distinct=True),
             )
         }
+        if not new_samples:
+            import pdb; pdb.set_trace()
         return cls._report_sample_updates(dataset_type, sample_type, metadata, samples_by_project, new_sample_data_by_project)
 
     @classmethod

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -233,8 +233,6 @@ class Command(BaseCommand):
                 family_guids=ArrayAgg('individual__family__guid', distinct=True),
             )
         }
-        if not new_samples:
-            import pdb; pdb.set_trace()
         return cls._report_sample_updates(dataset_type, sample_type, metadata, samples_by_project, new_sample_data_by_project)
 
     @classmethod
@@ -248,13 +246,13 @@ class Command(BaseCommand):
         split_project_pdos = {}
         session = AirtableSession(user=None, no_auth=True) if AirtableSession.is_airtable_enabled() else None
         for project, sample_ids in samples_by_project.items():
-            project_sample_data = new_sample_data_by_project[project.id]
+            project_sample_data = new_sample_data_by_project.get(project.id, {})
             is_internal = cls._is_internal_project(project)
             notify_search_data_loaded(
-                project, is_internal, dataset_type, sample_type, project_sample_data['samples'],
+                project, is_internal, dataset_type, sample_type, project_sample_data.get('samples', []),
                 num_samples=len(sample_ids),
             )
-            project_families = project_sample_data['family_guids']
+            project_families = project_sample_data.get('family_guids')
             if project_families:
                 updated_families.update(project_families)
                 updated_project_families.append((project.id, project.name, project.genome_version, project_families))

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -219,7 +219,7 @@ OPENED_RUN_JSON_FILES = [{
 }, {
     'callsets': ['gcnv.bed.gz'],
     'sample_type': 'WES',
-    'family_samples': {'F000004_4': ['NA20872'], 'F000012_12': ['NA20889']},
+    'family_samples': {'F000002_2': ['HG00731', 'HG00732', 'HG00733'], 'F000012_12': ['NA20889']},
 }, {
     'project_guids': ['R0002_empty'],
     'error_messages': ['Missing the following expected contigs:chr17'],
@@ -257,7 +257,7 @@ class CheckNewSamplesTest(object):
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.models.random.randint')
         mock_rand_int = patcher.start()
-        mock_rand_int.side_effect = [GUID_ID, GUID_ID, GUID_ID, GUID_ID, GCNV_GUID_ID, GCNV_GUID_ID]
+        mock_rand_int.side_effect = [GUID_ID, GUID_ID, GUID_ID, GUID_ID, GCNV_GUID_ID, GCNV_GUID_ID, GCNV_GUID_ID, GCNV_GUID_ID]
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.management.commands.check_for_new_samples_from_pipeline.HAIL_SEARCH_DATA_DIR')
         mock_data_dir = patcher.start()
@@ -409,9 +409,10 @@ class CheckNewSamplesTest(object):
             ],
             'GRCh38/MITO': [('Loading 2 WGS MITO samples in 1 projects', None)],
             'GRCh38/SV': [
-                ('Loading 2 WES SV samples in 2 projects', None),
-                ('create 2 Samples', {'dbUpdate': mock.ANY}),
-                ('update 2 Samples', {'dbUpdate': mock.ANY}),
+                ('Loading 4 WES SV samples in 2 projects', None),
+                ('create 4 Samples', {'dbUpdate': mock.ANY}),
+                ('update 4 Samples', {'dbUpdate': mock.ANY}),
+                ('update 3 Samples', {'dbUpdate': mock.ANY}),
                 ('update 1 Familys', {'dbUpdate': mock.ANY}),
                 ('Reloading saved variants in 2 projects', None),
                 (mock.ANY, {'severity': 'ERROR', '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent'}),

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -26,6 +26,7 @@ EXISTING_WGS_SAMPLE_GUID = 'S000144_na20888'
 EXISTING_SV_SAMPLE_GUID = 'S000147_na21234'
 SAMPLE_GUIDS = [ACTIVE_SAMPLE_GUID, REPLACED_SAMPLE_GUID, NEW_SAMPLE_GUID_P3, NEW_SAMPLE_GUID_P4]
 GCNV_SAMPLE_GUID = f'S00000{GCNV_GUID_ID}_na20889'
+EXISTING_GCNV_SAMPLE_GUIDS = ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
 GCNV_SAMPLE_GUIDS = [f'S00000{GCNV_GUID_ID}_hg00731', f'S00000{GCNV_GUID_ID}_hg00732', f'S00000{GCNV_GUID_ID}_hg00733', GCNV_SAMPLE_GUID]
 
 namespace_path = 'ext-data/anvil-non-analyst-project 1000 Genomes Demo'
@@ -448,6 +449,10 @@ class CheckNewSamplesTest(object):
 
         old_data_sample_guid = 'S000143_na20885'
         self.assertFalse(Sample.objects.get(guid=old_data_sample_guid).is_active)
+
+        previous_gcnv_samples = Sample.objects.filter(guid__in=EXISTING_GCNV_SAMPLE_GUIDS)
+        self.assertEqual(len(previous_gcnv_samples), len(EXISTING_GCNV_SAMPLE_GUIDS))
+        self.assertFalse(any(previous_gcnv_samples.values_list('is_active', flat=True)))
 
         # Previously loaded WGS data should be unchanged by loading WES data
         self.assertEqual(

--- a/seqr/utils/search/add_data_utils.py
+++ b/seqr/utils/search/add_data_utils.py
@@ -39,7 +39,7 @@ def add_new_es_search_samples(request_json, project, user, notify=False, expecte
         request_json['mappingFilePath'], user) if request_json.get('mappingFilePath') else {}
     ignore_extra_samples = request_json.get('ignoreExtraSamplesInCallset')
     sample_project_tuples = [(sample_id, project.name) for sample_id in sample_ids]
-    updated_samples, new_samples, inactivated_sample_guids, num_skipped, updated_family_guids = match_and_update_search_samples(
+    new_samples, updated_samples, inactivated_sample_guids, num_skipped, updated_family_guids = match_and_update_search_samples(
         projects=[project],
         user=user,
         sample_project_tuples=sample_project_tuples,
@@ -52,7 +52,7 @@ def add_new_es_search_samples(request_json, project, user, notify=False, expecte
     )
 
     if notify:
-        _basic_notify_search_data_loaded(project, dataset_type, sample_type, new_samples.values())
+        _basic_notify_search_data_loaded(project, dataset_type, sample_type, new_samples.values_list('sample_id'))
 
     return inactivated_sample_guids, updated_family_guids, updated_samples
 

--- a/seqr/views/utils/dataset_utils.py
+++ b/seqr/views/utils/dataset_utils.py
@@ -223,9 +223,9 @@ def match_and_update_search_samples(
         user, {'analysis_status': Family.ANALYSIS_STATUS_ANALYSIS_IN_PROGRESS}, guid__in=family_guids_to_update)
 
     previous_loaded_individuals = set(Sample.objects.filter(guid__in=inactivated_sample_guids).values_list('individual_id', flat=True))
-    new_samples = dict(updated_samples.exclude(individual_id__in=previous_loaded_individuals).values_list('id', 'sample_id'))
+    new_samples = updated_samples.exclude(individual_id__in=previous_loaded_individuals)
 
-    return updated_samples, new_samples, inactivated_sample_guids, len(remaining_sample_keys), family_guids_to_update
+    return new_samples, updated_samples, inactivated_sample_guids, len(remaining_sample_keys), family_guids_to_update
 
 
 def _parse_tsv_row(row):


### PR DESCRIPTION
We ran into a bug in the check samples job when there are no new samples being loaded. This PR does the following:
- Fixes that bug
- Changes the behavior for reloading saved variants to also reload previously loaded families (when adding a unit test to cover this case I discovered this was not happening and we want it to)
- Splits out the logic into more localized try/except blocks with clearer errors so that future errors will be clearer about where they are happening, and also where possible will allow other unrelated steps to run even where some upstream steps fail