### PR TITLE
update github actions/cache version

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
           java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
           architecture: x64 # (x64 or x86) - defaults to x64
       - name: Use pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('**/requirements*.txt') }}


### PR DESCRIPTION
Looks like we missed this notice that we had to update by February 1 😨 
https://github.com/actions/cache/discussions/1510https://github.com/actions/cache/discussions/1510