### PR TITLE
DB migration for PanelApp AU domain name change

### DIFF
--- a/panelapp/migrations/0003_panelapp_aus_domain_migration.py
+++ b/panelapp/migrations/0003_panelapp_aus_domain_migration.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def update_urls(apps, schema_editor):
+    PaLocusList = apps.get_model('panelapp', 'PaLocusList')
+
+    # Replace the old domain with the new domain in the url field
+    for entry in PaLocusList.objects.filter(url__startswith='https://panelapp.agha.umccr.org'):
+        entry.url = entry.url.replace('https://panelapp.agha.umccr.org', 'https://panelapp-aus.org')
+        entry.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('panelapp', '0002_auto_20210915_1049'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_urls),
+    ]

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -2406,7 +2406,7 @@
     "status": "public",
     "version": "1.0",
     "version_created": "2018-04-28T00:03:25.347Z",
-    "url": "https://panelapp.agha.umccr.org/api/v1/panels/254/genes"
+    "url": "https://panelapp-aus.org/api/v1/panels/254/genes"
   }
 },
 {

--- a/ui/shared/utils/panelAppUtils.test.ts
+++ b/ui/shared/utils/panelAppUtils.test.ts
@@ -55,15 +55,15 @@ describe('Test moiToMoiInitials()', () => {
 })
 
 const panelAppData = [{
-  url: 'https://panelapp.agha.umccr.org/api/v1/panels/40/genes',
+  url: 'https://panelapp-aus.org/api/v1/panels/40/genes',
   panel: 40,
   gene: 'SLC2A1',
-  result: 'https://panelapp.agha.umccr.org/panels/40/gene/SLC2A1',
+  result: 'https://panelapp-aus.org/panels/40/gene/SLC2A1',
 }, {
-  url: 'https://panelapp.agha.umccr.org/api/v1/panels/40/genes',
+  url: 'https://panelapp-aus.org/api/v1/panels/40/genes',
   panel: 40,
   gene: 'SLC1A3',
-  result: 'https://panelapp.agha.umccr.org/panels/40/gene/SLC1A3',
+  result: 'https://panelapp-aus.org/panels/40/gene/SLC1A3',
 }, {
   url: 'https://panelapp.genomicsengland.co.uk/api/v1',
   panel: 486,


### PR DESCRIPTION
Reference discussion: https://github.com/broadinstitute/seqr/discussions/4623

This script bulk replaces domain name in table field `panelapp_palocuslist.url` from `https://panelapp.agha.umccr.org` to `https://panelapp-aus.org`.  This allows subsequent runs of [import_all_panels.py](https://github.com/broadinstitute/seqr/blob/master/panelapp/management/commands/import_all_panels.py) script to not create new panels.

To run this script: `python manage.py migrate panelapp`

The Django admin script [import_all_panels.py](https://github.com/broadinstitute/seqr/blob/master/panelapp/management/commands/import_all_panels.py) should be run with new url from Tue, 25th Feb onwards.

`python manage.py import_all_panels --label AU https://panelapp-aus.org/api/v1`
