### PR TITLE
use bulk update for updating project variants

### DIFF
--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -426,7 +426,7 @@ class CheckNewSamplesTest(object):
                 ('update 3 Familys', {'dbUpdate': mock.ANY}),
                 ('Reloading saved variants in 2 projects', None),
                 ('Updated 0 variants in 2 families for project Test Reprocessed Project', None),
-                ('update SavedVariant SV0000006_1248367227_r0004_non', {'dbUpdate': mock.ANY}),
+                ('update 1 SavedVariants', {'dbUpdate': mock.ANY}),
                 ('Updated 1 variants in 1 families for project Non-Analyst Project', None),
                 ('Reload Summary: ', None),
                 ('  Non-Analyst Project: Updated 1 variants', None),

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -106,8 +106,9 @@ def update_project_saved_variant_json(project_id, genome_version, family_guids=N
         for family_guid in var['familyGuids']:
             saved_variant = saved_variants_map.get((var['variantId'], family_guid))
             if saved_variant:
-                update_model_from_json(saved_variant, {'saved_variant_json': var}, user)
+                saved_variant.saved_variant_json = var
                 updated_saved_variants[saved_variant.guid] = saved_variant
+    SavedVariant.bulk_update_models(user, list(updated_saved_variants.values()), ['saved_variant_json'])
 
     return updated_saved_variants
 


### PR DESCRIPTION
Improved performance in the check samples job and elsewhere by using a bulk update instead of saving each model individually