### PR TITLE
show gene search links for variants that were tagged on the lookup page

### DIFF
--- a/ui/shared/components/panel/variants/VariantGene.jsx
+++ b/ui/shared/components/panel/variants/VariantGene.jsx
@@ -626,7 +626,9 @@ export const BaseVariantGene = React.memo(({
           size="tiny"
         />
         &nbsp; | &nbsp;
-        {!variant.lookupFamilyGuids && <GeneSearchLinkWithPopup location={geneId} familyGuids={variant.familyGuids} />}
+        {variant.familyGuids?.length > 0 && (
+          <GeneSearchLinkWithPopup location={geneId} familyGuids={variant.familyGuids} />
+        )}
       </GeneLinks>
     )
   }


### PR DESCRIPTION
If a variant is tagged from the lookup page it will have `lookupFamilyGuids` in the saved variant json. When that saved variant is then rendered on the saved variant page the conditional logic designed to disable the gene search link from the lookup page fails. This fixes the logic to require the presence of `familyGuids` instead of the absence of  `lookupFamilyGuids` 