### PR TITLE
use interval prefilter logic for search with padded interval

### DIFF
--- a/hail_search/queries/sv.py
+++ b/hail_search/queries/sv.py
@@ -53,9 +53,9 @@ class SvHailTableQuery(BaseHailTableQuery):
         )],
     }
 
-    def __init__(self, *args, **kwargs):
-        self._is_interval_filtered = False
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, padded_interval=None, **kwargs):
+        self._is_interval_filtered = bool(padded_interval)
+        super().__init__(*args, padded_interval=padded_interval, **kwargs)
 
     def _set_interval_prefilter(self, *args, **kwargs):
         self._is_interval_filtered = True


### PR DESCRIPTION
SV variant lookup performs a search with the padded_interval filter and not the standard interval filter. Because of this, the optimized flow for filtering annotation first was not being properly triggered. This tweaks setting the flag for the optimized flow to also factor in padded_interval