### PR TITLE
Do not reload shared variant annotations for all GRCh38 SNV_INDEL variants

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -388,12 +388,6 @@ class Command(BaseCommand):
 
             variant_models = variant_models.exclude(variant_id__in=updated_variants_by_id.keys())
 
-        if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
-            if not chromosomes:
-                pass
-        else:
-            chromosomes = [None]
-
         chromosomes = cls._get_chroms_to_reload(chromosomes, dataset_type, genome_version, variant_models)
         if chromosomes is None:
             return

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 
-from reference_data.models import GENOME_VERSION_LOOKUP
+from reference_data.models import GENOME_VERSION_LOOKUP, GENOME_VERSION_GRCh38
 from seqr.models import Family, Sample, SavedVariant, Project
 from seqr.utils.communication_utils import safe_post_to_slack, send_project_email
 from seqr.utils.file_utils import file_iter, list_files, is_google_bucket_file_path
@@ -35,6 +35,7 @@ RUN_PATH_FIELDS = ['genome_version', 'dataset_type', 'run_version', 'file_name']
 DATASET_TYPE_MAP = {'GCNV': Sample.DATASET_TYPE_SV_CALLS}
 USER_EMAIL = 'manage_command'
 MAX_LOOKUP_VARIANTS = 1000
+MAX_RELOAD_VARIANTS = 100000
 RELATEDNESS_CHECK_NAME = 'relatedness_check'
 
 PDO_COPY_FIELDS = [
@@ -387,9 +388,32 @@ class Command(BaseCommand):
 
             variant_models = variant_models.exclude(variant_id__in=updated_variants_by_id.keys())
 
-        chromosomes = (chromosomes or CHROMOSOMES) if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS else [None]
+        if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS:
+            if not chromosomes:
+                pass
+        else:
+            chromosomes = [None]
+
+        chromosomes = cls._get_chroms_to_reload(chromosomes, dataset_type, genome_version, variant_models)
+        if chromosomes is None:
+            return
+
         for chrom in chromosomes:
             cls._reload_shared_variant_annotations_by_chrom(chrom, variant_models, data_type, genome_version, variant_type_summary)
+
+    @staticmethod
+    def _get_chroms_to_reload(chromosomes, dataset_type, genome_version, variant_models):
+        if dataset_type != Sample.DATASET_TYPE_VARIANT_CALLS:
+            return [None]
+        if chromosomes:
+            return chromosomes
+
+        num_reload = variant_models.count()
+        if genome_version == GENOME_VERSION_LOOKUP[GENOME_VERSION_GRCh38] and num_reload > MAX_RELOAD_VARIANTS:
+            logger.info(f'Skipped reloading all {num_reload} saved variant annotations for {dataset_type} {genome_version}')
+            return None
+
+        return CHROMOSOMES
 
     @classmethod
     def _reload_shared_variant_annotations_by_chrom(cls, chrom, variant_models, data_type, genome_version, variant_type_summary):


### PR DESCRIPTION
there are over 100,000 saved variants for this dataset/genome build category and reloading shared annotations is not even close to succeeding. I do not think we can actually get reasonable performance for this many variants with the existing hail search infrastructure, so instead of running this sync every time new variants are loaded I am moving the reload out of the job here, and will add a weekly cron job for this dataset type instead