### PR TITLE
Fix parse Omim record with no position

### DIFF
--- a/reference_data/management/tests/update_omim_tests.py
+++ b/reference_data/management/tests/update_omim_tests.py
@@ -20,6 +20,7 @@ OMIM_DATA = [
     '# comment line\n',
     'chr1	1	123400000	1p		606788		Anorexia nervosa, susceptibility to, 1		171514			{Anorexia nervosa, susceptibility to, 1}, 606788 (2)	\n',
     'chr1	1	567800000	1p36		605462	BCC1	Basal cell carcinoma, susceptibility to, 1		100307118		associated with rs7538876	{Basal cell carcinoma, susceptibility to, 1}, 605462 (2)	\n',
+    'chr6			6p13		621133	OGFRl1	Opioid growth factor receptor-like protein 1						\n',
 ]
 
 CACHED_OMIM_DATA = "ensembl_gene_id\tmim_number\tgene_description\tcomments\tphenotype_description\tphenotype_mim_number\tphenotype_map_method\tphenotype_inheritance\tchrom\tstart\tend\nENSG00000235249\t607413\tAlzheimer disease neuronal thread protein\t\t\t\t\t\t1\t1\t27600000\nENSG00000186092\t612367\tAlkaline phosphatase, plasma level of, QTL 2\tlinkage with rs1780324\tAlkaline phosphatase, plasma level of, QTL 2\t612367\t2\t\t1\t1\t27600000\n\t606788\tAnorexia nervosa, susceptibility to, 1\t\tAnorexia nervosa, susceptibility to, 1\t606788\t2\t\t1\t1\t123400000\n\t605462\tBasal cell carcinoma, susceptibility to, 1\tassociated with rs7538876\tBasal cell carcinoma, susceptibility to, 1\t605462\t2\t\t1\t1\t567800000"

--- a/reference_data/models.py
+++ b/reference_data/models.py
@@ -565,17 +565,7 @@ class Omim(LoadableModel):
         else:
             gene_symbol = record['approved_gene_symbol'].strip() or record['gene/locus_and_other_related_symbols'].split(",")[0]
             ensembl_gene_id = record['ensembl_gene_id'] or gene_symbols_to_gene.get(gene_symbol)
-
-            output_record = {
-                'gene_id': gene_ids_to_gene.get(ensembl_gene_id),
-                'ensembl_gene_id': ensembl_gene_id,
-                'mim_number': int(record['mim_number']),
-                'chrom': record['#_chromosome'].replace('chr', ''),
-                'start': int(record['genomic_position_start']),
-                'end': int(record['genomic_position_end']),
-                'gene_description': record['gene_name'],
-                'comments': record['comments'],
-            }
+            gene_id = gene_ids_to_gene.get(ensembl_gene_id)
 
             phenotype_field = record['phenotypes'].strip()
 
@@ -583,21 +573,39 @@ class Omim(LoadableModel):
             for phenotype_match in re.finditer("[\[{ ]*(.+?)[ }\]]*(, (\d{4,}))? \(([1-4])\)(, ([^;]+))?;?",
                                                phenotype_field):
                 # Phenotypes example: "Langer mesomelic dysplasia, 249700 (3), Autosomal recessive; Leri-Weill dyschondrosteosis, 127300 (3), Autosomal dominant"
-
-                record_with_phenotype = dict(output_record)  # copy
-                record_with_phenotype["phenotype_description"] = phenotype_match.group(1)
-                record_with_phenotype["phenotype_mim_number"] = int(phenotype_match.group(3)) if phenotype_match.group(
-                    3) else None
-                record_with_phenotype["phenotype_map_method"] = phenotype_match.group(4)
-                record_with_phenotype["phenotype_inheritance"] = phenotype_match.group(6) or None
-
+                record_with_phenotype = cls._get_parsed_record(record, gene_id, ensembl_gene_id, phenotype_match)
                 yield record_with_phenotype
 
             if record_with_phenotype is None:
                 if len(phenotype_field) > 0:
                     raise ValueError("No phenotypes found: {}".format(json.dumps(record)))
+                elif not gene_id:
+                    # OMIM record requires either gene or phenotype
+                    yield None
                 else:
-                    yield output_record
+                    yield cls._get_parsed_record(record, gene_id, ensembl_gene_id)
+
+    @staticmethod
+    def _get_parsed_record(record, gene_id, ensembl_gene_id, phenotype_match=None):
+        output_record = {
+            'gene_id': gene_id,
+            'ensembl_gene_id': ensembl_gene_id,
+            'mim_number': int(record['mim_number']),
+            'chrom': record['#_chromosome'].replace('chr', ''),
+            'start': int(record['genomic_position_start']),
+            'end': int(record['genomic_position_end']),
+            'gene_description': record['gene_name'],
+            'comments': record['comments'],
+        }
+        if phenotype_match:
+            output_record.update({
+                'phenotype_description': phenotype_match.group(1),
+                'phenotype_mim_number': int(phenotype_match.group(3)) if phenotype_match.group(3) else None,
+                'phenotype_map_method': phenotype_match.group(4),
+                'phenotype_inheritance': phenotype_match.group(6) or None,
+            })
+
+        return output_record
 
     @classmethod
     def get_record_models(cls, records, omim_key=None, **kwargs):


### PR DESCRIPTION
A record was added to OMIM last week that broke our parsing script. Since we only use OMIM records in seqr that have either a gene or phenotype associated with them, I updated the logic to skip rows with neither and avoid parsing this row. 

Note that to prevent merge conflicts I have branched this off of my open reference data refactor PR, so that will need to be merged before this fix can be released: https://github.com/broadinstitute/seqr/pull/4706