### PR TITLE
allow vcfs with same name in workspace

### DIFF
--- a/seqr/utils/vcf_utils.py
+++ b/seqr/utils/vcf_utils.py
@@ -148,7 +148,10 @@ def _merge_sharded_vcf(vcf_files):
         if len(files) < 2:
             continue
         prefix = os.path.commonprefix(files)
-        suffix = re.fullmatch(r'{}\d*(?P<suffix>\D.*)'.format(prefix), files[0]).groupdict()['suffix']
+        suffix_match = re.fullmatch(r'{}\d*(?P<suffix>\D.*)'.format(prefix), files[0])
+        if not suffix_match:
+            continue
+        suffix = suffix_match.groupdict()['suffix']
         if all([re.fullmatch(r'{}\d+{}'.format(prefix, suffix), file) for file in files]):
             files_by_path[subfolder_path] = [f'{prefix}*{suffix}']
 

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -431,7 +431,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
     def test_get_anvil_vcf_list(self, *args):
         url = reverse(get_anvil_vcf_list, args=[TEST_WORKSPACE_NAMESPACE, TEST_WORKSPACE_NAME1])
         expected_files = [
-            '/test.vcf', '/data/test.vcf.gz', '/data/test-101.vcf.gz', '/data/test-102.vcf.gz', '/sharded/test-*.vcf.gz',
+            '/test.vcf', '/test.vcf.gz', '/data/test.vcf.gz', '/data/test-101.vcf.gz', '/data/test-102.vcf.gz', '/sharded/test-*.vcf.gz',
         ]
         self._test_get_workspace_files(url, 'dataPathList', expected_files, *args)
 
@@ -460,7 +460,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         mock_file_logger.reset_mock()
         mock_subprocess.return_value.communicate.return_value = b'\n'.join([
             b'Warning: some packages are out of date',
-            b'gs://test_bucket/test.vcf', b'gs://test_bucket/test.tsv',
+            b'gs://test_bucket/test.vcf', b'gs://test_bucket/test.vcf.gz', b'gs://test_bucket/test.tsv',
             b'gs://test_bucket/test.bam', b'gs://test_bucket/test.bam.bai', b'gs://test_bucket/data/test.cram',
             # path with common prefix but not sharded VCFs
             b'gs://test_bucket/data/test.vcf.gz', b'gs://test_bucket/data/test-101.vcf.gz',


### PR DESCRIPTION
Fixes a bug submitted by an AnVIl user trying to load data with the .vcf and .vcf.gz file in the same folder with the same filename