### PR TITLE
SV multi project comp het performance

### DIFF
--- a/hail_search/test_utils.py
+++ b/hail_search/test_utils.py
@@ -56,11 +56,11 @@ FAMILY_5_SAMPLE = {
     'sample_id': 'NA20874', 'individual_guid': 'I000009_na20874', 'family_guid': 'F000005_5', 'project_guid': 'R0001_1kg', 'affected': 'N', 'sample_type': 'WES',
 }
 ALL_AFFECTED_SAMPLE_DATA['SNV_INDEL'].append(FAMILY_5_SAMPLE)
-FAMILY_11_SAMPLE_WES = {
-    'sample_id': 'NA20885', 'individual_guid': 'I000015_na20885', 'family_guid': 'F000011_11', 'project_guid': 'R0003_test', 'affected': 'A', 'sample_type': 'WES',
+FAMILY_11_SAMPLE_WGS = {
+    'sample_id': 'NA20885', 'individual_guid': 'I000015_na20885', 'family_guid': 'F000011_11', 'project_guid': 'R0003_test', 'affected': 'A', 'sample_type': 'WGS',
 }
 MULTI_PROJECT_SAMPLE_DATA = deepcopy(FAMILY_2_VARIANT_SAMPLE_DATA)
-MULTI_PROJECT_SAMPLE_DATA['SNV_INDEL'].append(FAMILY_11_SAMPLE_WES)
+MULTI_PROJECT_SAMPLE_DATA['SNV_INDEL'].append({**FAMILY_11_SAMPLE_WGS, 'sample_type': 'WES'})
 
 FAMILY_2_BOTH_SAMPLE_TYPE_SAMPLE_DATA = deepcopy(FAMILY_2_VARIANT_SAMPLE_DATA)
 FAMILY_2_BOTH_SAMPLE_TYPE_SAMPLE_DATA['SNV_INDEL'].extend([
@@ -73,13 +73,13 @@ FAMILY_2_BOTH_SAMPLE_TYPE_SAMPLE_DATA_MISSING_PARENTAL_WGS['SNV_INDEL'].extend([
 )
 
 MULTI_PROJECT_SAMPLE_TYPES_SAMPLE_DATA = deepcopy(FAMILY_2_VARIANT_SAMPLE_DATA)
-MULTI_PROJECT_SAMPLE_TYPES_SAMPLE_DATA['SNV_INDEL'].append(FAMILY_11_SAMPLE_WES)
-MULTI_PROJECT_SAMPLE_TYPES_SAMPLE_DATA['SNV_INDEL'].append({**FAMILY_11_SAMPLE_WES, 'sample_type': 'WGS'})
+MULTI_PROJECT_SAMPLE_TYPES_SAMPLE_DATA['SNV_INDEL'].append(FAMILY_11_SAMPLE_WGS)
+MULTI_PROJECT_SAMPLE_TYPES_SAMPLE_DATA['SNV_INDEL'].append({**FAMILY_11_SAMPLE_WGS, 'sample_type': 'WES'})
 
 MULTI_PROJECT_MISSING_SAMPLE_DATA = deepcopy(FAMILY_2_MISSING_SAMPLE_DATA)
-MULTI_PROJECT_MISSING_SAMPLE_DATA['SNV_INDEL'].append(FAMILY_11_SAMPLE_WES)
+MULTI_PROJECT_MISSING_SAMPLE_DATA['SNV_INDEL'].append(FAMILY_11_SAMPLE_WGS)
 
-SV_WGS_SAMPLE_DATA_WITH_SEX = {'SV_WGS': [{'is_male': True, **FAMILY_11_SAMPLE_WES, 'sample_type': 'WGS'}, {
+SV_WGS_SAMPLE_DATA_WITH_SEX = {'SV_WGS': [{'is_male': True, **FAMILY_11_SAMPLE_WGS}, {
     'sample_id': 'NA20884', 'individual_guid': 'I000025_na20884', 'family_guid': 'F000011_11', 'project_guid': 'R0003_test', 'affected': 'N', 'sample_type': 'WGS', 'is_male': True,
 }, {
     'sample_id': 'NA20883', 'individual_guid': 'I000035_na20883', 'family_guid': 'F000011_11', 'project_guid': 'R0003_test', 'affected': 'N', 'sample_type': 'WGS', 'is_male': False,

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -1145,7 +1145,7 @@
         "last_modified_date": "2020-03-13T09:07:50.247Z",
         "elasticsearch_index": "test_index_second",
         "sample_id": "NA20885",
-        "sample_type": "WES",
+        "sample_type": "WGS",
         "is_active": true,
         "individual": 15,
         "dataset_type": "SNV_INDEL",

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -28,6 +28,7 @@ SAMPLE_GUIDS = [ACTIVE_SAMPLE_GUID, REPLACED_SAMPLE_GUID, NEW_SAMPLE_GUID_P3, NE
 GCNV_SAMPLE_GUID = f'S00000{GCNV_GUID_ID}_na20889'
 EXISTING_GCNV_SAMPLE_GUIDS = ['S000145_hg00731', 'S000146_hg00732', 'S000148_hg00733']
 GCNV_SAMPLE_GUIDS = [f'S00000{GCNV_GUID_ID}_hg00731', f'S00000{GCNV_GUID_ID}_hg00732', f'S00000{GCNV_GUID_ID}_hg00733', GCNV_SAMPLE_GUID]
+OLD_DATA_SAMPLE_GUID = 'S000143_na20885'
 
 namespace_path = 'ext-data/anvil-non-analyst-project 1000 Genomes Demo'
 anvil_link = f'<a href=https://anvil.terra.bio/#workspaces/{namespace_path}>{namespace_path}</a>'
@@ -315,6 +316,7 @@ class CheckNewSamplesTest(object):
         mock_data_dir = patcher.start()
         mock_data_dir.__str__.return_value = self.MOCK_DATA_DIR
         self.addCleanup(patcher.stop)
+        Sample.objects.filter(guid=OLD_DATA_SAMPLE_GUID).update(sample_type='WES')
 
     def _test_call(self, error_logs=None, reload_annotations_logs=None, run_loading_logs=None, reload_calls=None, num_runs=4):
         self._set_loading_files()
@@ -550,8 +552,7 @@ class CheckNewSamplesTest(object):
         self.assertSetEqual({'SV'}, set(gcnv_samples.values_list('dataset_type', flat=True)))
         self.assertSetEqual({'gcnv.bed.gz'}, set(gcnv_samples.values_list('elasticsearch_index', flat=True)))
 
-        old_data_sample_guid = 'S000143_na20885'
-        self.assertFalse(Sample.objects.get(guid=old_data_sample_guid).is_active)
+        self.assertFalse(Sample.objects.get(guid=OLD_DATA_SAMPLE_GUID).is_active)
 
         previous_gcnv_samples = Sample.objects.filter(guid__in=EXISTING_GCNV_SAMPLE_GUIDS)
         self.assertEqual(len(previous_gcnv_samples), len(EXISTING_GCNV_SAMPLE_GUIDS))
@@ -569,7 +570,7 @@ class CheckNewSamplesTest(object):
         # Test Individual models properly associated with Samples
         self.assertSetEqual(
             set(Individual.objects.get(guid='I000015_na20885').sample_set.values_list('guid', flat=True)),
-            {REPLACED_SAMPLE_GUID, old_data_sample_guid}
+            {REPLACED_SAMPLE_GUID, OLD_DATA_SAMPLE_GUID}
         )
         self.assertSetEqual(
             set(Individual.objects.get(guid='I000016_na20888').sample_set.values_list('guid', flat=True)),

--- a/seqr/utils/search/elasticsearch/es_utils_tests.py
+++ b/seqr/utils/search/elasticsearch/es_utils_tests.py
@@ -1323,6 +1323,7 @@ class EsUtilsTest(TestCase):
 
     def setUp(self):
         Sample.objects.filter(sample_id='NA19678').update(is_active=False)
+        Sample.objects.filter(sample_id='NA20885').update(sample_type='WES')
         self.families = Family.objects.filter(guid__in=['F000003_3', 'F000002_2', 'F000005_5'])
 
     def assertExecutedSearch(self, filters=None, start_index=0, size=2, index=INDEX_NAME, expected_source_fields=SOURCE_FIELDS, call_index=-1, **kwargs):

--- a/seqr/utils/search/hail_search_utils.py
+++ b/seqr/utils/search/hail_search_utils.py
@@ -79,8 +79,8 @@ def _execute_multi_sample_types_searches(sv_data_types, search_body, user):
 
     total = 0
     results = []
-    for sample_type, sample_data in sample_data_by_sample_data_type.items():
-        search_body['sample_data'] = sample_data
+    for sample_type in sorted(sample_data_by_sample_data_type.keys()):
+        search_body['sample_data'] = sample_data_by_sample_data_type[sample_type]
         sample_response_json = _execute_search(search_body, user)
         total += sample_response_json['total']
         results += sample_response_json['results']

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -14,6 +14,7 @@ from hail_search.test_utils import get_hail_search_body, EXPECTED_SAMPLE_DATA, F
     LOCATION_SEARCH, EXCLUDE_LOCATION_SEARCH, VARIANT_ID_SEARCH, RSID_SEARCH, GENE_COUNTS, FAMILY_2_VARIANT_SAMPLE_DATA, \
     FAMILY_2_MITO_SAMPLE_DATA, EXPECTED_SAMPLE_DATA_WITH_SEX, VARIANT_LOOKUP_VARIANT, MULTI_PROJECT_SAMPLE_DATA, \
     GCNV_VARIANT4, SV_VARIANT2
+
 MOCK_HOST = 'test-hail-host'
 MOCK_ORIGIN = f'http://{MOCK_HOST}'
 
@@ -21,6 +22,7 @@ SV_WGS_SAMPLE_DATA = [{
     'individual_guid': 'I000018_na21234', 'family_guid': 'F000014_14', 'project_guid': 'R0004_non_analyst_project',
     'affected': 'A', 'sample_id': 'NA21234', 'sample_type': 'WGS',
 }]
+SV_WES_SAMPLE_DATA = FAMILY_2_VARIANT_SAMPLE_DATA['SNV_INDEL']
 
 EXPECTED_MITO_SAMPLE_DATA = deepcopy(FAMILY_2_MITO_SAMPLE_DATA)
 EXPECTED_MITO_SAMPLE_DATA['MITO'][0].update({'individual_guid': 'I000004_hg00731', 'sample_id': 'HG00731', 'affected': 'A'})
@@ -170,11 +172,12 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
 
         self.search_model.search = {'inheritance': {'mode': 'de_novo'}, 'annotations': {'structural_consequence': ['LOF']}}
         query_variants(self.results_model, user=self.user)
-        sv_sample_data = {
-            'SV_WES': FAMILY_2_VARIANT_SAMPLE_DATA['SNV_INDEL'],
+        self._test_expected_search_call(search_fields=['annotations'], dataset_type='SV', call_offset=-2, sample_data={
+            'SV_WES': SV_WES_SAMPLE_DATA,
+        })
+        self._test_expected_search_call(search_fields=['annotations'], dataset_type='SV', call_offset=-1, sample_data={
             'SV_WGS': SV_WGS_SAMPLE_DATA,
-        }
-        self._test_expected_search_call(search_fields=['annotations'], dataset_type='SV', sample_data=sv_sample_data)
+        })
 
         del self.search_model.search['annotations']
         self.search_model.search['locus'] = {'rawVariantItems': raw_variant_locus}
@@ -186,22 +189,34 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
         self._test_expected_search_call(intervals=[['M', 10, 100]], sample_data=EXPECTED_MITO_SAMPLE_DATA)
 
         self.search_model.search['locus']['rawItems'] += raw_locus
-        query_variants(self.results_model, user=self.user)
-        self._test_expected_search_call(
-            gene_ids=LOCATION_SEARCH['gene_ids'],
-            intervals=[['M', 10, 100]] + LOCATION_SEARCH['intervals'],
-            sample_data={**MULTI_PROJECT_SAMPLE_DATA, **sv_sample_data, **EXPECTED_MITO_SAMPLE_DATA},
-        )
+        variants, total = query_variants(self.results_model, user=self.user)
+        self.assertListEqual(variants, [
+            HAIL_BACKEND_VARIANTS[0], HAIL_BACKEND_VARIANTS[0], HAIL_BACKEND_VARIANTS[1], HAIL_BACKEND_VARIANTS[1],
+        ])
+        self.assertEqual(total, 10)
+        expected_search = {
+            'gene_ids': LOCATION_SEARCH['gene_ids'],
+            'intervals': [['M', 10, 100]] + LOCATION_SEARCH['intervals'],
+        }
+        self._test_expected_search_call(**expected_search, call_offset=-2, sample_data={
+            **MULTI_PROJECT_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA, **EXPECTED_MITO_SAMPLE_DATA,
+        })
+        self._test_expected_search_call(**expected_search, call_offset=-1, sample_data={
+            'SV_WGS': SV_WGS_SAMPLE_DATA,
+        })
 
         self.search_model.search['locus']['rawItems'] = raw_locus
         query_variants(self.results_model, user=self.user)
-        self._test_expected_search_call(**LOCATION_SEARCH, sample_data={**MULTI_PROJECT_SAMPLE_DATA, **sv_sample_data})
+        self._test_expected_search_call(**LOCATION_SEARCH, call_offset=-2, sample_data={
+            **MULTI_PROJECT_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA,
+        })
+        self._test_expected_search_call(**LOCATION_SEARCH, call_offset=-1, sample_data={'SV_WGS': SV_WGS_SAMPLE_DATA})
 
         self.results_model.families.set(Family.objects.filter(project_id=1))
         query_variants(self.results_model, user=self.user)
         self._test_expected_search_call(**LOCATION_SEARCH, sample_data={
             'SNV_INDEL': FAMILY_1_SAMPLE_DATA['SNV_INDEL'] + EXPECTED_SAMPLE_DATA['SNV_INDEL'],
-            'SV_WES': sv_sample_data['SV_WES'],
+            'SV_WES': SV_WES_SAMPLE_DATA,
         })
 
         del self.search_model.search['locus']

--- a/seqr/utils/search/hail_search_utils_tests.py
+++ b/seqr/utils/search/hail_search_utils_tests.py
@@ -12,7 +12,7 @@ from seqr.utils.search.search_utils_tests import SearchTestHelper
 from hail_search.test_utils import get_hail_search_body, EXPECTED_SAMPLE_DATA, FAMILY_1_SAMPLE_DATA, \
     ALL_AFFECTED_SAMPLE_DATA, CUSTOM_AFFECTED_SAMPLE_DATA, HAIL_BACKEND_VARIANTS, \
     LOCATION_SEARCH, EXCLUDE_LOCATION_SEARCH, VARIANT_ID_SEARCH, RSID_SEARCH, GENE_COUNTS, FAMILY_2_VARIANT_SAMPLE_DATA, \
-    FAMILY_2_MITO_SAMPLE_DATA, EXPECTED_SAMPLE_DATA_WITH_SEX, VARIANT_LOOKUP_VARIANT, MULTI_PROJECT_SAMPLE_DATA, \
+    FAMILY_2_MITO_SAMPLE_DATA, EXPECTED_SAMPLE_DATA_WITH_SEX, VARIANT_LOOKUP_VARIANT, FAMILY_11_SAMPLE_WGS, \
     GCNV_VARIANT4, SV_VARIANT2
 
 MOCK_HOST = 'test-hail-host'
@@ -182,7 +182,9 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
         del self.search_model.search['annotations']
         self.search_model.search['locus'] = {'rawVariantItems': raw_variant_locus}
         query_variants(self.results_model, user=self.user)
-        self._test_expected_search_call(**VARIANT_ID_SEARCH, num_results=2,  dataset_type='SNV_INDEL', sample_data=MULTI_PROJECT_SAMPLE_DATA)
+        self._test_expected_search_call(**VARIANT_ID_SEARCH, num_results=2,  dataset_type='SNV_INDEL', sample_data={
+            'SNV_INDEL': FAMILY_2_VARIANT_SAMPLE_DATA['SNV_INDEL'] + [FAMILY_11_SAMPLE_WGS],
+        })
 
         self.search_model.search['locus'] = {'rawItems': 'M:10-100 '}
         query_variants(self.results_model, user=self.user)
@@ -199,18 +201,20 @@ class HailSearchUtilsTests(SearchTestHelper, TestCase):
             'intervals': [['M', 10, 100]] + LOCATION_SEARCH['intervals'],
         }
         self._test_expected_search_call(**expected_search, call_offset=-2, sample_data={
-            **MULTI_PROJECT_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA, **EXPECTED_MITO_SAMPLE_DATA,
+            **FAMILY_2_VARIANT_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA, **EXPECTED_MITO_SAMPLE_DATA,
         })
         self._test_expected_search_call(**expected_search, call_offset=-1, sample_data={
-            'SV_WGS': SV_WGS_SAMPLE_DATA,
+            'SNV_INDEL': [FAMILY_11_SAMPLE_WGS], 'SV_WGS': SV_WGS_SAMPLE_DATA,
         })
 
         self.search_model.search['locus']['rawItems'] = raw_locus
         query_variants(self.results_model, user=self.user)
         self._test_expected_search_call(**LOCATION_SEARCH, call_offset=-2, sample_data={
-            **MULTI_PROJECT_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA,
+            **FAMILY_2_VARIANT_SAMPLE_DATA, 'SV_WES': SV_WES_SAMPLE_DATA,
         })
-        self._test_expected_search_call(**LOCATION_SEARCH, call_offset=-1, sample_data={'SV_WGS': SV_WGS_SAMPLE_DATA})
+        self._test_expected_search_call(**LOCATION_SEARCH, call_offset=-1, sample_data={
+            'SNV_INDEL': [FAMILY_11_SAMPLE_WGS], 'SV_WGS': SV_WGS_SAMPLE_DATA,
+        })
 
         self.results_model.families.set(Family.objects.filter(project_id=1))
         query_variants(self.results_model, user=self.user)

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -669,7 +669,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
         mock_compute_indiv_guid.side_effect = ['I0000021_na19675_1', 'I0000022_na19678', 'I0000023_hg00735']
         url = reverse(add_workspace_data, args=[PROJECT2_GUID])
         self._test_mv_file_and_triggering_dag_exception(
-            url, {'guid': PROJECT2_GUID}, PROJECT2_SAMPLE_DATA, 'GRCh37', REQUEST_BODY_ADD_DATA2)
+            url, {'guid': PROJECT2_GUID}, PROJECT2_SAMPLE_DATA, 'GRCh37', REQUEST_BODY_ADD_DATA2, sample_type='WGS')
 
     def _test_errors(self, url, fields, workspace_name, has_existing_data=False):
         # Test missing required fields in the request body
@@ -822,7 +822,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
             'father__individual_id': None, 'sex': 'F', 'affected': 'N', 'notes': 'a individual note', 'features': [],
         }, individual_model_data)
 
-    def _test_mv_file_and_triggering_dag_exception(self, url, workspace, sample_data, genome_version, request_body, num_samples=None):
+    def _test_mv_file_and_triggering_dag_exception(self, url, workspace, sample_data, genome_version, request_body, num_samples=None, sample_type='WES'):
         # Test saving ID file exception
         responses.calls.reset()
         self.mock_authorized_session.reset_mock()
@@ -855,7 +855,7 @@ class LoadAnvilDataAPITest(AirflowTestCase, AirtableTest):
                 'dataset_type': 'SNV_INDEL',
                 'reference_genome': genome_version,
                 'callset_path': 'gs://test_bucket/test_path.vcf',
-                'sample_type': 'WES',
+                'sample_type': sample_type,
                 'sample_source': 'AnVIL',
             }, indent=4),
         )

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -1508,7 +1508,8 @@ class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
         'familiesCount': {'non_demo': 12, 'demo': 2},
         'individualsCount': {'non_demo': 16, 'demo': 4},
         'sampleCountsByType': {
-            'WES__SNV_INDEL': {'demo': 1, 'non_demo': 7},
+            'WES__SNV_INDEL': {'non_demo': 7},
+            'WGS__SNV_INDEL': {'demo': 1},
             'WES__MITO': {'non_demo': 1},
             'WES__SV': {'non_demo': 3},
             'WGS__SV': {'non_demo': 1},
@@ -1534,7 +1535,8 @@ class AnvilReportAPITest(AnvilAuthenticationTestCase, ReportAPITest):
         'familiesCount': {'internal': 11, 'external': 1, 'no_anvil': 0, 'demo': 2},
         'individualsCount': {'internal': 14, 'external': 2, 'no_anvil': 0, 'demo': 4},
         'sampleCountsByType': {
-            'WES__SNV_INDEL': {'internal': 7, 'demo': 1},
+            'WES__SNV_INDEL': {'internal': 7},
+            'WGS__SNV_INDEL': {'demo': 1},
             'WES__MITO': {'internal': 1},
             'WES__SV': {'internal': 3},
             'WGS__SV': {'external': 1},


### PR DESCRIPTION
We are having trouble running all project comp het searches with combined SVs and SNV_INDEL data. This change splits those queries under the hood into 2 searches instead of 1, running all of the WGS sample in one search and all of the WES samples in another. Since we will not have a project with both WES and WGS for SVs in the same project on the hail backend this will only impact multi project searches with SVs, and since those searches are currently timing out any inefficiency introduced by waiting on 2 searches is better than being unable to run the search at all.

The reason this is a logical way to speed up the searches is that the SV data is stored separately for WES and WGS so the queries are running sequentially, and then the joins with SNV_INDEL data for the comp hets are relatively sparse as the only roughly half of the project are even possible to have a comp het hit in. Only querying SNV_INDEL for those projects which are possible to pair with a given sample type speeds up both the SNV_INDEL query and the join and comp het computation