### PR TITLE
Multi data type comp het search optimization

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -476,9 +476,11 @@ class BaseHailTableQuery(object):
         return ht, comp_het_ht
 
     @staticmethod
-    def _apply_entry_filters(ht):
+    def _apply_entry_filters(ht, select_globals=True):
         if ht is not None:
-            ht = ht.filter(ht.family_entries.any(hl.is_defined)).select_globals('family_guids')
+            ht = ht.filter(ht.family_entries.any(hl.is_defined))
+            if select_globals:
+                ht = ht.select_globals('family_guids')
         return ht
 
     def _filter_single_entries_table(self, ht, project_families, inheritance_filter=None, quality_filter=None, is_merged_ht=False, **kwargs):

--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -316,7 +316,7 @@ class BaseHailTableQuery(object):
         families = set()
         project_samples = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         for s in sample_data:
-            if overlapped_families and s['family_guid'] not in overlapped_families:
+            if overlapped_families is not None and s['family_guid'] not in overlapped_families:
                 continue
             families.add(s['family_guid'])
             project_samples[s['project_guid']][s['sample_type']][s['family_guid']].append(s)
@@ -1191,10 +1191,10 @@ class BaseHailTableQuery(object):
     def search(self):
         ht = self.format_search_ht()
 
-        (total_results, collected) = ht.aggregate((hl.agg.count(), hl.agg.take(ht.row, self._num_results, ordering=ht._sort)))
+        (total_results, collected) = (0, None) if ht is None else ht.aggregate((hl.agg.count(), hl.agg.take(ht.row, self._num_results, ordering=ht._sort)))
         logger.info(f'Total hits: {total_results}. Fetched: {self._num_results}')
 
-        return self._format_collected_rows(collected), total_results
+        return [] if collected is None else self._format_collected_rows(collected), total_results
 
     def _format_collected_rows(self, collected):
         if self._has_comp_het_search:

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -28,8 +28,8 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
 
     def _load_filtered_table(self, sample_data, *args, **kwargs):
         has_merged_comp_het = self._has_comp_het_search and SNV_INDEL_DATA_TYPE in sample_data and self._sv_data_type
-        overlapped_families = {s['family_guid'] for s in sample_data[SNV_INDEL_DATA_TYPE]['samples']}.intersection(
-            {s['family_guid'] for s in sample_data[self._sv_data_type]['samples']}
+        overlapped_families = {s['family_guid'] for s in sample_data[SNV_INDEL_DATA_TYPE]}.intersection(
+            {s['family_guid'] for s in sample_data[self._sv_data_type]}
         ) if has_merged_comp_het else None
 
         data_type_families = {}

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -96,10 +96,13 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
         variants = self._filter_comp_het_families(variants, set_secondary_annotations=False)
         return hl.Table.parallelize(variants)
 
-    @staticmethod
-    def _family_filtered_ch_ht(ht, overlapped_families, families):
+    @classmethod
+    def _family_filtered_ch_ht(cls, ht, overlapped_families, families):
+        if overlapped_families == families:
+            return ht
         family_indices = hl.array([families.index(family_guid) for family_guid in overlapped_families])
-        return ht.annotate(family_entries=family_indices.map(lambda i: ht.family_entries[i]))
+        ht = ht.annotate(family_entries=family_indices.map(lambda i: ht.family_entries[i]))
+        return cls._apply_entry_filters(ht, select_globals=False)
 
     def _is_valid_comp_het_family(self, v1, v2, family_index):
         is_valid = super()._is_valid_comp_het_family(v1, v2, family_index)

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -39,7 +39,8 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
                 continue
             self._data_type_queries[data_type] = QUERY_CLASS_MAP[(data_type, GENOME_VERSION_GRCh38)](
                 sample_data[data_type], *args, override_comp_het_alt=data_type == SNV_INDEL_DATA_TYPE,
-                overlapped_families=overlapped_families, **kwargs
+                overlapped_families=overlapped_families, sort=self._sort, sort_metadata=self._sort_metadata,
+                inheritance_mode=self._inheritance_mode, num_results=self._num_results, **kwargs
             )
             if overlapped_families is not None and data_type in {self._sv_data_type, SNV_INDEL_DATA_TYPE}:
                 ht = self._data_type_queries[data_type].unfiltered_comp_het_ht

--- a/hail_search/queries/multi_data_types.py
+++ b/hail_search/queries/multi_data_types.py
@@ -42,10 +42,14 @@ class MultiDataTypeHailTableQuery(BaseHailTableQuery):
                 overlapped_families=overlapped_families, sort=self._sort, sort_metadata=self._sort_metadata,
                 inheritance_mode=self._inheritance_mode, num_results=self._num_results, **kwargs
             )
-            if overlapped_families is not None and data_type in {self._sv_data_type, SNV_INDEL_DATA_TYPE}:
+            if has_merged_comp_het and data_type in {self._sv_data_type, SNV_INDEL_DATA_TYPE}:
                 ht = self._data_type_queries[data_type].unfiltered_comp_het_ht
-                data_type_families[data_type] = hl.eval(ht.family_guids)
-                overlapped_families = overlapped_families.intersection(data_type_families[data_type])
+                if ht is None:
+                    has_merged_comp_het = False
+                    overlapped_families = set()
+                else:
+                    data_type_families[data_type] = hl.eval(ht.family_guids)
+                    overlapped_families = overlapped_families.intersection(data_type_families[data_type])
 
         if not (has_merged_comp_het and overlapped_families):
             return


### PR DESCRIPTION
When searching for comp het pairs across data types we currently read in loads of projects that we don't end up using. In the linked ticket's WES search we load SNV_INDEL data for 93 projects even though only 70 of the projects even have SV data and of those only 10 projects have possible matched variants. This changes the loading logic so that for comp-het only searches only those 10 projects would be read in for SNV_INDEL, and for recessive searches all the families will be read in initially but the comp het table will be filtered to that subset before computing pairs

This also takes advantage of the changes in https://github.com/broadinstitute/seqr/pull/4725 that split searches by sample type so there will never be multiple SV data types in the same hail backend search so this PR simplifies the logic to assume a single sv type