### PR TITLE
do not allow clinvar override for secondary annotations

### DIFF
--- a/hail_search/queries/base.py
+++ b/hail_search/queries/base.py
@@ -912,7 +912,7 @@ class BaseHailTableQuery(object):
             secondary_annotation_overrides = None
             if self.SECONDARY_ANNOTATION_OVERRIDE_FIELDS:
                 secondary_annotation_overrides = self._get_annotation_override_fields(
-                    annotations_secondary, override_fields=self.SECONDARY_ANNOTATION_OVERRIDE_FIELDS, **kwargs)
+                    annotations_secondary, override_fields=self.SECONDARY_ANNOTATION_OVERRIDE_FIELDS)
                 has_data_type_secondary_annotations |= bool(secondary_annotation_overrides)
                 has_different_secondary |= secondary_annotation_overrides != annotation_overrides
 


### PR DESCRIPTION
We [added support ](https://github.com/broadinstitute/seqr/pull/4744)to have regulatory and motif consequences allowed for secondary annotations, but this introduced a bug where pathogenicity overrides, which are only supposed to apply to primary annotations, are also applied to secondary. This PR fixes that bug by no longer passing through pathogenicity to the secondary filter