### PR TITLE
Ad clinvar to clickhouse response

### DIFF
--- a/clickhouse_search/backend/fields.py
+++ b/clickhouse_search/backend/fields.py
@@ -39,6 +39,12 @@ class UInt64FieldDeltaCodecField(models.UInt64Field):
 
 class NamedTupleField(models.TupleField):
 
+    def __init__(self, *args, null_if_empty=False, **kwargs):
+        self.null_if_empty = null_if_empty
+        super().__init__(*args, **kwargs)
+
     def _convert_type(self, value):
         value = super()._convert_type(value)
-        return value._asdict() if value is not None else value
+        if self.null_if_empty and not any(value):
+            return None
+        return value._asdict()

--- a/clickhouse_search/backend/functions.py
+++ b/clickhouse_search/backend/functions.py
@@ -7,3 +7,7 @@ class Array(Func):
 class ArrayMap(Func):
     function = 'arrayMap'
     template = "%(function)s(x -> %(mapped_expression)s, %(expressions)s)"
+
+
+class Tuple(Func):
+    function = 'tuple'

--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -55,7 +55,7 @@ def get_clickhouse_variants(samples, search, user, previous_search_results, geno
             mapped_expression=f"tuple({_get_sample_map_expression(sample_data)}[x.sampleId], {', '.join(GENOTYPE_FIELDS.keys())})",
             output_field=NestedField([('individualGuid', models.StringField()), *GENOTYPE_FIELDS.values()], group_by_key='individualGuid')
         ),
-        clinvar=Tuple(*CLINVAR_FIELDS.keys(), output_field=NamedTupleField(list(CLINVAR_FIELDS.values()))),
+        clinvar=Tuple(*CLINVAR_FIELDS.keys(), output_field=NamedTupleField(list(CLINVAR_FIELDS.values()), null_if_empty=True)),
         genomeVersion=Value(genome_version),
         liftedOverGenomeVersion=Value(_liftover_genome_version(genome_version)),
         **ANNOTATION_VALUES,

--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -22,8 +22,8 @@ ANNOTATION_VALUES = {
 }
 
 CLINVAR_FIELDS = OrderedDict({
-    f'key__clinvar__{field.name}': (field.db_column or field.name, field.formfield())
-    for field in Clinvar._meta.local_fields
+    f'key__clinvar__{field.name}': (field.db_column or field.name, field.clone())
+    for field in Clinvar._meta.local_fields if field.name not in CORE_ENTRIES_FIELDS
 })
 
 GENOTYPE_FIELDS = OrderedDict({


### PR DESCRIPTION
The generated SQL is now as follows (ran in 1.2 seconds)

```
SELECT "GRCh38/SNV_INDEL/entries"."key",
       "GRCh38/SNV_INDEL/entries"."xpos",
       array("GRCh38/SNV_INDEL/entries"."family_guid") AS "familyGuids",
       arrayMap(x -> tuple(map('BON_B24_34_1_D2', 'I0155759_bon_b24_34_1_d2', 'BON_B24_34_3_D2', 'I0155761_bon_b24_34_3_d2', 'BON_B24_34_2_D2', 'I0155760_bon_b24_34_2_d2')[x.sampleId], project_guid, family_guid, sample_type, filters, x.gt::Nullable(Int8), x.sampleId, x.gq, x.ab, x.dp), "GRCh38/SNV_INDEL/entries"."calls") AS "genotypes",
       tuple("GRCh38/SNV_INDEL/clinvar"."alleleId", "GRCh38/SNV_INDEL/clinvar"."conflictingPathogenicities", "GRCh38/SNV_INDEL/clinvar"."goldStars", "GRCh38/SNV_INDEL/clinvar"."submitters", "GRCh38/SNV_INDEL/clinvar"."conditions", "GRCh38/SNV_INDEL/clinvar"."assertions", "GRCh38/SNV_INDEL/clinvar"."pathogenicity") AS "clinvar",
       '38' AS "genomeVersion",
       '37' AS "liftedOverGenomeVersion",
       "GRCh38/SNV_INDEL/annotations_memory"."chrom" AS "chrom",
       "GRCh38/SNV_INDEL/annotations_memory"."pos" AS "pos",
       "GRCh38/SNV_INDEL/annotations_memory"."ref" AS "ref",
       "GRCh38/SNV_INDEL/annotations_memory"."alt" AS "alt",
       "GRCh38/SNV_INDEL/annotations_memory"."variantId" AS "variantId",
       "GRCh38/SNV_INDEL/annotations_memory"."rsid" AS "rsid",
       "GRCh38/SNV_INDEL/annotations_memory"."CAID" AS "CAID",
       "GRCh38/SNV_INDEL/annotations_memory"."liftedOverChrom" AS "liftedOverChrom",
       "GRCh38/SNV_INDEL/annotations_memory"."liftedOverPos" AS "liftedOverPos",
       "GRCh38/SNV_INDEL/annotations_memory"."hgmd" AS "hgmd",
       "GRCh38/SNV_INDEL/annotations_memory"."screenRegionType" AS "screenRegionType",
       "GRCh38/SNV_INDEL/annotations_memory"."predictions" AS "predictions",
       "GRCh38/SNV_INDEL/annotations_memory"."populations" AS "populations",
       "GRCh38/SNV_INDEL/annotations_memory"."sortedTranscriptConsequences" AS "sortedTranscriptConsequences",
       "GRCh38/SNV_INDEL/annotations_memory"."sortedMotifFeatureConsequences" AS "sortedMotifFeatureConsequences",
       "GRCh38/SNV_INDEL/annotations_memory"."sortedRegulatoryFeatureConsequences" AS "sortedRegulatoryFeatureConsequences"
  FROM "GRCh38/SNV_INDEL/entries"
 INNER JOIN "GRCh38/SNV_INDEL/annotations_memory"
    ON ("GRCh38/SNV_INDEL/entries"."key" = "GRCh38/SNV_INDEL/annotations_memory"."key")
  LEFT OUTER JOIN "GRCh38/SNV_INDEL/clinvar"
    ON ("GRCh38/SNV_INDEL/annotations_memory"."key" = "GRCh38/SNV_INDEL/clinvar"."key")
 WHERE ("GRCh38/SNV_INDEL/entries"."family_guid" = 'F077540_bon_b24_34' AND "GRCh38/SNV_INDEL/entries"."project_guid" = 'R0565_mgrc_bonnemann_wgs')
 LIMIT 10001
```