### PR TITLE
update logic for determining pednding loading project

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -52,7 +52,7 @@
     "fields": {
         "guid": "R0003_test",
         "created_date": "2017-03-12T19:27:08.156Z",
-        "created_by": 10,
+        "created_by": 11,
         "last_modified_date": "2017-03-13T09:07:49.582Z",
         "name": "Test Reprocessed Project",
         "description": "",

--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -11,7 +11,7 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect
 
 from reference_data.models import GENOME_VERSION_LOOKUP
-from seqr.models import Project, CAN_EDIT, Sample, IgvSample
+from seqr.models import Project, Family, CAN_EDIT, Sample, IgvSample
 from seqr.views.react_app import render_app_html
 from seqr.views.utils.airtable_utils import AirtableSession, ANVIL_REQUEST_TRACKING_TABLE
 from seqr.views.utils.airflow_utils import trigger_airflow_data_loading
@@ -142,7 +142,8 @@ def validate_anvil_vcf(request, namespace, name, workspace_meta):
     # Validate no pending loading projects
     pending_project = Project.objects.filter(
         created_by=request.user, genome_version=body['genomeVersion'],
-    ).exclude(family__individual__sample__is_active=True).first()
+        family__analysis_status=Family.ANALYSIS_STATUS_WAITING_FOR_DATA
+    ).first()
     if pending_project:
         raise ErrorsWarningsException([
             f'Project "{pending_project.name}" is awaiting loading. Please wait for loading to complete before requesting additional data loading'

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -287,7 +287,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         response = self.client.post(url, content_type='application/json', data=json.dumps({**VALIDATE_VCF_BODY, 'genomeVersion': '37'}))
         self.assertEqual(response.status_code, 400)
         self.assertListEqual(response.json()['errors'], [
-            'Project "Empty Project" is awaiting loading. Please wait for loading to complete before requesting additional data loading'
+            'Project "Test Reprocessed Project" is awaiting loading. Please wait for loading to complete before requesting additional data loading'
         ])
 
         # Test bad data path

--- a/seqr/views/apis/dashboard_api_tests.py
+++ b/seqr/views/apis/dashboard_api_tests.py
@@ -65,7 +65,7 @@ class DashboardPageTest(object):
         self.assertTrue(response_json['projectsByGuid']['R0002_empty']['userIsCreator'])
         self.assertTrue(response_json['projectsByGuid']['R0004_non_analyst_project']['userIsCreator'])
         self.assertFalse(response_json['projectsByGuid']['R0001_1kg']['userIsCreator'])
-        self.assertFalse(response_json['projectsByGuid']['R0003_test']['userIsCreator'])
+        self.assertTrue(response_json['projectsByGuid']['R0003_test']['userIsCreator'])
         self.assertTrue(response_json['projectsByGuid']['R0002_empty']['userCanDelete'])
         self.assertFalse(response_json['projectsByGuid']['R0004_non_analyst_project']['userCanDelete'])
 
@@ -76,7 +76,7 @@ class DashboardPageTest(object):
         self.assertEqual(len(response_json['projectsByGuid']), 3)
         self.assertFalse(response_json['projectsByGuid']['R0002_empty']['userIsCreator'])
         self.assertTrue(response_json['projectsByGuid']['R0001_1kg']['userIsCreator'])
-        self.assertTrue(response_json['projectsByGuid']['R0003_test']['userIsCreator'])
+        self.assertFalse(response_json['projectsByGuid']['R0003_test']['userIsCreator'])
         mock_get_redis.assert_called_with('projects__test_user')
         mock_set_redis.assert_called_with('projects__test_user', list(response_json['projectsByGuid'].keys()), expire=300)
 


### PR DESCRIPTION
when checking if a user had any pending loading projects, we excluded any projects that have any loaded data. which means if a user had successfully loaded data to a project and then requested more data at a later date we would not consider that project to be pending even before the additional samples completed. This changes the logic explicitly check whether there are any families in the "waiting for data"state