### PR TITLE
Clickhouse use cached unsorted

### DIFF
--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -88,14 +88,19 @@ def get_clickhouse_variants(samples, search, user, previous_search_results, geno
     )
     results = results[:MAX_VARIANTS+1]
 
-    sort_metadata = _get_sort_gene_metadata(sort, results, sample_data[0]['family_guid'])
+    cache_results = get_clickhouse_cache_results(results, sort, sample_data[0]['family_guid'])
+    previous_search_results.update(cache_results)
+
+    logger.info(f'Total results: {cache_results["total_results"]}', user)
+
+    return format_clickhouse_results(cache_results['all_results'][(page-1)*num_results:page*num_results])
+
+
+def get_clickhouse_cache_results(results, sort, family_guid):
+    sort_metadata = _get_sort_gene_metadata(sort, results, family_guid)
     sorted_results = sorted(results, key=_get_sort_key(sort, sort_metadata))
     total_results = len(sorted_results)
-    previous_search_results.update({'all_results': sorted_results, 'total_results': total_results})
-
-    logger.info(f'Total results: {total_results}', user)
-
-    return format_clickhouse_results(sorted_results[(page-1)*num_results:page*num_results])
+    return {'all_results': sorted_results, 'total_results': total_results}
 
 
 def format_clickhouse_results(results, **kwargs):

--- a/seqr/utils/redis_utils.py
+++ b/seqr/utils/redis_utils.py
@@ -34,7 +34,7 @@ def _redis_get_wildcard(redis_client, cache_key):
 
 
 def safe_redis_get_wildcard_json(cache_key):
-    safe_redis_get_json(cache_key, redis_get=_redis_get_wildcard)
+    return safe_redis_get_json(cache_key, redis_get=_redis_get_wildcard)
 
 
 def safe_redis_set_json(cache_key, value, expire=None):

--- a/seqr/utils/redis_utils.py
+++ b/seqr/utils/redis_utils.py
@@ -8,10 +8,14 @@ from settings import REDIS_SERVICE_HOSTNAME, REDIS_SERVICE_PORT
 logger = logging.getLogger(__name__)
 
 
-def safe_redis_get_json(cache_key):
+def _redis_get(redis_client, cache_key):
+    return redis_client.get(cache_key)
+
+
+def safe_redis_get_json(cache_key, redis_get=_redis_get):
     try:
         redis_client = redis.StrictRedis(host=REDIS_SERVICE_HOSTNAME, port=REDIS_SERVICE_PORT, socket_connect_timeout=3)
-        value = redis_client.get(cache_key)
+        value = redis_get(redis_client, cache_key)
         if value:
             logger.info('Loaded {} from redis'.format(cache_key))
             return json.loads(value)
@@ -20,6 +24,17 @@ def safe_redis_get_json(cache_key):
     except Exception as e:
         logger.error('Unable to connect to redis host {}: {}'.format(REDIS_SERVICE_HOSTNAME, str(e)))
     return None
+
+
+def _redis_get_wildcard(redis_client, cache_key):
+    keys = redis_client.keys(pattern=cache_key)
+    if keys:
+        return redis_client.get(keys[0])  # Return the first matching key's value
+    return None
+
+
+def safe_redis_get_wildcard_json(cache_key):
+    safe_redis_get_json(cache_key, redis_get=_redis_get_wildcard)
 
 
 def safe_redis_set_json(cache_key, value, expire=None):

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -693,7 +693,9 @@ class ClickhouseSearchUtilsTests(TestCase, SearchUtilsTests):
             mock.call(f'{cache_key_prefix}__xpos'),
         ])
         self.mock_redis.keys.assert_called_with(pattern=f'{cache_key_prefix}__*')
-        self.assert_cached_results({'all_results': variants, 'total_results': 4})
+        self.assert_cached_results(
+            {'all_results': [CACHED_VARIANTS_BY_KEY[key] for key in [4, 2, 1, 3]], 'total_results': 4}
+        )
 
 
     @mock.patch('seqr.utils.search.utils.get_clickhouse_variants')

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -684,6 +684,7 @@ class ClickhouseSearchUtilsTests(TestCase, SearchUtilsTests):
         self.mock_redis.keys.return_value = [f'{cache_key_prefix}__xpos', f'{cache_key_prefix}__gnomad']
 
         variants, total = query_variants(self.results_model, user=self.user, sort='cadd')
+        self.assertEqual(total, 4)
         self.assertListEqual(
             json.loads(json.dumps(variants, cls=DjangoJSONEncoderWithSets)),
             [VARIANT4, VARIANT2, VARIANT1, VARIANT3]

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -680,7 +680,7 @@ class ClickhouseSearchUtilsTests(TestCase, SearchUtilsTests):
         super().test_cached_query_variants()
 
         cache_key_prefix = f'search_results__{self.results_model.guid}'
-        self.mock_redis.get.side_effect = [None, {'total_results': 4, 'all_results': self.CACHED_VARIANTS}]
+        self.mock_redis.get.side_effect = [None, json.dumps({'total_results': 4, 'all_results': self.CACHED_VARIANTS})]
         self.mock_redis.keys.return_value = [f'{cache_key_prefix}__xpos', f'{cache_key_prefix}__gnomad']
 
         variants, total = query_variants(self.results_model, user=self.user, sort='cadd')

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -695,7 +695,8 @@ class ClickhouseSearchUtilsTests(TestCase, SearchUtilsTests):
         ])
         self.mock_redis.keys.assert_called_with(pattern=f'{cache_key_prefix}__*')
         self.assert_cached_results(
-            {'all_results': [CACHED_VARIANTS_BY_KEY[key] for key in [4, 2, 1, 3]], 'total_results': 4}
+            {'all_results': [CACHED_VARIANTS_BY_KEY[key] for key in [4, 2, 1, 3]], 'total_results': 4},
+            sort='cadd',
         )
 
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -200,7 +200,7 @@ def _get_search_cache_key(search_model, sort=None):
 
 
 def _process_clickhouse_unsorted_cached_results(cache_key, sort, family_guid):
-    unsorted_results = safe_redis_get_wildcard_json(cache_key.replace(sort, '*'))
+    unsorted_results = safe_redis_get_wildcard_json(cache_key.replace(sort or 'xpos', '*'))
     if not unsorted_results:
         return None
     results = get_clickhouse_cache_results(unsorted_results['all_results'], sort, family_guid)

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -203,7 +203,7 @@ def _process_clickhouse_unsorted_cached_results(cache_key, sort, family_guid):
     unsorted_results = safe_redis_get_wildcard_json(cache_key.replace(sort, '*'))
     if not unsorted_results:
         return None
-    results = get_clickhouse_cache_results(unsorted_results, sort, family_guid)
+    results = get_clickhouse_cache_results(unsorted_results['all_results'], sort, family_guid)
     safe_redis_set_json(cache_key, results, expire=timedelta(weeks=2))
     return results
 


### PR DESCRIPTION
Search results are cached in redis, and since clickhouse sorting is done in python and not at the database level we can add an optimization that if the results are already cached with a different sort we can sort the existing cached results without querying the database