### PR TITLE
Update ClickHouse default data directory.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
         ports:
           - 9000:9000   # Native client interface
         volumes:
-          - /var/tmp:/bitnami/clickhouse
+          - /var/tmp:/var/seqr/clickhouse-data
           - /tmp:/in-memory-dir
         options: >-
           --health-cmd "clickhouse-client --query 'SELECT 1'" 

--- a/clickhouse_search/migrations/0001_initial.py
+++ b/clickhouse_search/migrations/0001_initial.py
@@ -132,7 +132,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'db_table': 'GRCh38/SNV_INDEL/transcripts',
-                'engine': clickhouse_search.backend.engines.EmbeddedRocksDB(primary_key='key', flatten_nested=0),
+                'engine': clickhouse_search.backend.engines.EmbeddedRocksDB(0, f'{CLICKHOUSE_DATA_DIR}/GRCh38/SNV_INDEL/transcripts', primary_key='key', flatten_nested=0),
             },
             managers=[
                 ('objects', django.db.models.manager.Manager()),

--- a/clickhouse_search/models.py
+++ b/clickhouse_search/models.py
@@ -612,7 +612,7 @@ class TranscriptsSnvIndel(models.ClickhouseModel):
 
     class Meta:
         db_table = 'GRCh38/SNV_INDEL/transcripts'
-        engine = EmbeddedRocksDB(primary_key='key', flatten_nested=0)
+        engine = EmbeddedRocksDB(0, f'{CLICKHOUSE_IN_MEMORY_DIR}/GRCh38/SNV_INDEL/transcripts', primary_key='key', flatten_nested=0)
 
 
 class Clinvar(models.ClickhouseModel):

--- a/settings.py
+++ b/settings.py
@@ -243,7 +243,7 @@ DATABASES = {
 DATABASE_ROUTERS = ['reference_data.models.ReferenceDataRouter', 'clickhouse_search.models.ClickHouseRouter']
 
 CLICKHOUSE_IN_MEMORY_DIR = os.environ.get('CLICKHOUSE_IN_MEMORY_DIR', '/in-memory-dir')
-CLICKHOUSE_DATA_DIR = os.getenv('CLICKHOUSE_DATA_DIR', '/bitnami/clickhouse')
+CLICKHOUSE_DATA_DIR = os.getenv('CLICKHOUSE_DATA_DIR', '/var/seqr/clickhouse-data')
 CLICKHOUSE_SERVICE_HOSTNAME =  os.environ.get('CLICKHOUSE_SERVICE_HOSTNAME')
 if CLICKHOUSE_SERVICE_HOSTNAME:
     DATABASES['clickhouse'] = {


### PR DESCRIPTION
The new helm chart major version provided an option to set the data directory (which was previously not provided).  This hopefully lets us follow the pattern we set previously with the `/var/seqr/...` directories.  