### PR TITLE
prevent duplicate gene modals for comp hets

### DIFF
--- a/ui/shared/components/panel/variants/Variants.jsx
+++ b/ui/shared/components/panel/variants/Variants.jsx
@@ -82,6 +82,7 @@ const VariantLayout = (
   },
 ) => {
   const coreVariant = Array.isArray(variant) ? variant[0] : variant
+  const geneModalId = Array.isArray(variant) ? variant.map(({ variantId }) => variantId).join('_') : variant.variantId
   return (
     <StyledVariantRow {...rowProps}>
       <Grid.Column width={16}>
@@ -101,9 +102,14 @@ const VariantLayout = (
       {!isCompoundHet && (
         <Grid.Column width={4}>
           {!mainGeneId && coreVariant.svName && <Header size="medium" content={coreVariant.svName} />}
-          {mainGeneId ?
-            <VariantGene geneId={mainGeneId} variant={coreVariant} compoundHetToggle={compoundHetToggle} /> :
-            <VariantGenes variant={variant} />}
+          {mainGeneId ? (
+            <VariantGene
+              geneId={mainGeneId}
+              geneModalId={geneModalId}
+              variant={coreVariant}
+              compoundHetToggle={compoundHetToggle}
+            />
+          ) : <VariantGenes variant={variant} />}
         </Grid.Column>
       )}
       <Grid.Column width={isCompoundHet ? 16 : 12}>


### PR DESCRIPTION
There is a bug with compound hets js where when you click the main gene to open the modal it opens 2 modals on top of each other, and GTEX was being rendered in the back modal but not the front modal. Correctly setting the modal ID fixes this issues and ensures only 1 modal is opened per gene link and thus GTEX displays correctly