### PR TITLE
fix vlm response parsing

### DIFF
--- a/clickhouse_search/migrations/0009_materializedviews_and_dictionaries.py
+++ b/clickhouse_search/migrations/0009_materializedviews_and_dictionaries.py
@@ -53,7 +53,7 @@ LAYOUT(FLAT(MAX_ARRAY_SIZE $size))
     # double substitution these shared values
     clickhouse_user=CLICKHOUSE_USER,
     clickhouse_password=CLICKHOUSE_PASSWORD,
-    clickhouse_database=DATABASES['clickhouse']['NAME'],
+    clickhouse_database=DATABASES.get('clickhouse', {}).get('NAME'),
 ))
 
 class Migration(migrations.Migration):

--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -160,12 +160,16 @@ VLM_CLIENTS_RESPONSE = [
 ]
 VLM_MATCH_URL = 'https://node1.com/variant_lookup/1-10439-AC-A'
 VLM_MATCH_RESPONSE = {
-    'beaconHandovers': {'handovers': [
+    'beaconHandovers': [
         {
             'handoverType': {'id': 'Test Node', 'label': 'Test Node browser'},
             'url': VLM_MATCH_URL,
+        },
+        {
+            'handoverType': {'id': 'Test SecondaryDB', 'label': 'Test secondary database'},
+            'url': f'{VLM_MATCH_URL}/secondarydb',
         }
-    ]},
+    ],
     'meta': {
         'apiVersion': 'v1.0',
         'beaconId': 'com.gnx.beacon.v2',
@@ -194,6 +198,60 @@ VLM_MATCH_RESPONSE = {
                 'id': 'Test Node Heterozygous',
                 'results': [],
                 'resultsCount': 23,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'Test SecondaryDB Homozygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': True,
+                'id': 'Test SecondaryDB Heterozygous',
+                'results': [],
+                'resultsCount': 2,
+                'setType': 'genomicVariant'
+            },
+        ],
+    }
+}
+VLM_MATCH_RESPONSE_2 = {
+    'beaconHandovers': [
+        {
+            'handoverType': {'id': 'Node2', 'label': ''},
+            'url': VLM_MATCH_URL,
+        }
+    ],
+    'meta': {
+        'apiVersion': 'v1.0',
+        'beaconId': 'com.gnx.beacon.v2',
+        'returnedSchemas': [
+            {
+                'entityType': 'genomicVariant',
+                'schema': 'ga4gh-beacon-variant-v2.0.0',
+            }
+        ]
+    },
+    'responseSummary': {
+        'exists': True,
+        'total': 30,
+    },
+    'response': {
+        'resultSets': [
+            {
+                'exists': True,
+                'id': 'Homozygous',
+                'results': [],
+                'resultsCount': 1,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'Heterozygous',
+                'results': [],
+                'resultsCount': 0,
                 'setType': 'genomicVariant'
             },
         ],
@@ -1029,7 +1087,10 @@ class VariantSearchAPITest(object):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         expected_body = {'vlmMatches': {
-            'Node 1': {'Test Node': {'url': VLM_MATCH_URL, 'counts': {'Heterozygous': 23, 'Homozygous': 7}}}
+            'Node 1': {
+                'Test Node': {'url': VLM_MATCH_URL, 'counts': {'Heterozygous': 23, 'Homozygous': 7}},
+                'Test SecondaryDB': {'url': f'{VLM_MATCH_URL}/secondarydb', 'counts': {'Heterozygous': 2, 'Homozygous': 0}},
+            }
         }}
         self.assertDictEqual(response.json(), expected_body)
 
@@ -1058,18 +1119,21 @@ class VariantSearchAPITest(object):
         # test with cached token and clients
         self.reset_logs()
         responses.calls.reset()
+        responses.add(responses.GET, node_2_url, json=VLM_MATCH_RESPONSE_2)
+        expected_body['vlmMatches']['Node 2'] = {
+            'Node2': {'url': VLM_MATCH_URL, 'counts': {'Heterozygous': 0, 'Homozygous': 1}}
+        }
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), expected_body)
         self.assertEqual(len(responses.calls), 2)
         self.assertListEqual([call.request.url for call in responses.calls], [node_1_url, node_2_url])
         self.assertSetEqual({call.request.headers['Authorization'] for call in responses.calls}, {'Bearer mock_token'})
-        self.maxDiff = None
         self.assert_json_logs(None, [
             ('Loaded VLM_TOKEN from redis', None),
             ('Loaded VLM_CLIENTS from redis', None),
         ])
-        self.assert_json_logs(self.no_access_user, expected_logs, offset=2)
+        self.assert_json_logs(self.no_access_user, expected_logs[:2], offset=2)
 
 
     def test_saved_search(self):

--- a/seqr/views/utils/vlm_utils.py
+++ b/seqr/views/utils/vlm_utils.py
@@ -42,10 +42,12 @@ def vlm_lookup(user, chrom, pos, ref, alt, genome_version=None, **kwargs):
             response_json = response.json()
             results[client_name] = {
                 meta['handoverType']['id']: {'url': meta['url'], 'counts': {}}
-                for meta in response_json['beaconHandovers']['handovers']
+                for meta in response_json['beaconHandovers']
             }
             for result in response_json['response']['resultSets']:
-                result_id, count_type = result['id'].rsplit(' ', 1)
+                parsed_id = result['id'].rsplit(' ', 1)
+                count_type = parsed_id[-1]
+                result_id =  parsed_id[0] if len(parsed_id) == 2 else next(iter(results[client_name].keys()))
                 results[client_name][result_id]['counts'][count_type] = result['resultsCount']
         except Exception as e:
             logger.error(f'VLM match error for {client_name}: {e}', user, detail=params)


### PR DESCRIPTION
VariantMatcher has now implemented a compliant VLM spec and we are turning on that connection. In testing it, I found  2 issues with how we are currently parsing the VLM responses:
1) The dev MyGene2 connection had added an incorrect extra level of nesting in their handover response so when I built the parsing I built it to work with that incorrect schema. I have now confirmed that none of the nodes have this error in production anymore (including seqr)
2) VariantMatcher formats the result set IDs slightly differently that MyGene2, in part because VariantMatcher only has 1 possible db in its result set while MyGene2 actually has 2. Both formats are technically valid in our API spec (😭 ) so I have updated our parsing to be tolerant of both