### PR TITLE
Use computed gt stats fixtures in unit tests

### DIFF
--- a/clickhouse_search/migrations/0009_materializedviews_and_dictionaries.py
+++ b/clickhouse_search/migrations/0009_materializedviews_and_dictionaries.py
@@ -45,7 +45,7 @@ CREATE DICTIONARY `$reference_genome/$dataset_type/gt_stats_dict`
     $columns
 )
 PRIMARY KEY key
-SOURCE(CLICKHOUSE(USER $clickhouse_user PASSWORD $clickhouse_password DB $clickhouse_database TABLE `$reference_genome/$dataset_type/gt_stats`))
+SOURCE(CLICKHOUSE(USER $clickhouse_user PASSWORD $clickhouse_password TABLE `$reference_genome/$dataset_type/gt_stats`))
 LIFETIME(MIN 0 MAX 0)
 LAYOUT(FLAT(MAX_ARRAY_SIZE $size))
 """).safe_substitute(
@@ -53,7 +53,6 @@ LAYOUT(FLAT(MAX_ARRAY_SIZE $size))
     # double substitution these shared values
     clickhouse_user=CLICKHOUSE_USER,
     clickhouse_password=CLICKHOUSE_PASSWORD,
-    clickhouse_database=DATABASES.get('clickhouse', {}).get('NAME'),
 ))
 
 class Migration(migrations.Migration):

--- a/clickhouse_search/search_tests.py
+++ b/clickhouse_search/search_tests.py
@@ -24,66 +24,11 @@ class ClickhouseSearchTests(SearchTestHelper, TestCase):
     databases = '__all__'
     fixtures = ['users', '1kg_project', 'reference_data', 'clickhouse_search', 'clickhouse_transcripts']
 
-    @classmethod
-    def setUpTestData(cls):
-        with connections['clickhouse'].cursor() as cursor:
-            cursor.execute("""
-            CREATE OR REPLACE DICTIONARY "GRCh38/SNV_INDEL/gt_stats_dict"
-            (
-                key UInt32,
-                ac_wes UInt32,
-                ac_wgs UInt32,
-                hom_wes UInt32,
-                hom_wgs UInt32,
-            )
-            PRIMARY KEY key
-            SOURCE(CLICKHOUSE(
-                USER %s
-                PASSWORD %s
-                QUERY "SELECT * FROM VALUES ((1, 4, 5, 2, 0), (2, 12, 16, 3, 1), (3, 4, 0, 1, 0), (4, 0, 2, 0, 0))"
-            ))
-            LIFETIME(0)
-            LAYOUT(FLAT(MAX_ARRAY_SIZE 500000000))
-            """, [os.environ.get('CLICKHOUSE_USER', 'clickhouse'), os.environ.get('CLICKHOUSE_PASSWORD', 'clickhouse_test')])
-            cursor.execute("""
-            CREATE OR REPLACE DICTIONARY "GRCh37/SNV_INDEL/gt_stats_dict"
-            (
-                key UInt32,
-                ac_wes UInt32,
-                ac_wgs UInt32,
-                hom_wes UInt32,
-                hom_wgs UInt32,
-            )
-            PRIMARY KEY key
-            SOURCE(CLICKHOUSE(
-                USER %s
-                PASSWORD %s
-                QUERY "SELECT * FROM VALUES ((11, 4711, 0, 1508, 0))"
-            ))
-            LIFETIME(0)
-            LAYOUT(FLAT(MAX_ARRAY_SIZE 500000000))
-            """, [os.environ.get('CLICKHOUSE_USER', 'clickhouse'), os.environ.get('CLICKHOUSE_PASSWORD', 'clickhouse_test')])
-            cursor.execute("""
-            CREATE OR REPLACE DICTIONARY "GRCh38/MITO/gt_stats_dict"
-            (
-                key UInt32,
-                ac_het_wes UInt32,
-                ac_het_wgs UInt32,
-                ac_hom_wes UInt32,
-                ac_hom_wgs UInt32,
-            )
-            PRIMARY KEY key
-            SOURCE(CLICKHOUSE(
-                USER %s
-                PASSWORD %s
-                QUERY "SELECT * FROM VALUES ((6, 0, 1, 0, 0), (7, 1, 0, 0, 0), (8, 0, 1, 2, 1))"
-            ))
-            LIFETIME(0)
-            LAYOUT(FLAT(MAX_ARRAY_SIZE 500000000))
-            """, [os.environ.get('CLICKHOUSE_USER', 'clickhouse'), os.environ.get('CLICKHOUSE_PASSWORD', 'clickhouse_test')])
-
     def setUp(self):
         super().set_up()
+        with connections['clickhouse'].cursor() as cursor:
+            for table_base in ['GRCh38/SNV_INDEL', 'GRCh38/MITO', 'GRCh38/SV', 'GRCh37/SNV_INDEL']:
+                cursor.execute(f'SYSTEM REFRESH VIEW "{table_base}/project_gt_stats_to_gt_stats_mv"')
         Project.objects.update(genome_version='38')
         Sample.objects.filter(dataset_type=Sample.DATASET_TYPE_SV_CALLS).update(is_active=False)
 

--- a/clickhouse_search/search_tests.py
+++ b/clickhouse_search/search_tests.py
@@ -624,13 +624,9 @@ class ClickhouseSearchTests(SearchTestHelper, TestCase):
         )
 
         self._assert_expected_search(
-            [VARIANT4, MITO_VARIANT1, MITO_VARIANT2],
+            [MULTI_FAMILY_VARIANT, VARIANT4, MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3],
             # [MULTI_FAMILY_VARIANT, VARIANT4, GCNV_VARIANT2, GCNV_VARIANT3, GCNV_VARIANT4],
-            freqs={'callset': {'ac': 2}, **sv_callset_filter},
-        )
-
-        self._assert_expected_search(
-            [MULTI_FAMILY_VARIANT, VARIANT4, MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3], freqs={'callset': {'ac': 4}},
+            freqs={'callset': {'ac': 6}, **sv_callset_filter},
         )
 
         self._assert_expected_search(
@@ -638,7 +634,7 @@ class ClickhouseSearchTests(SearchTestHelper, TestCase):
         )
 
         self._assert_expected_search(
-            [VARIANT4, MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3], freqs={'callset': {'ac': 4, 'hh': 0}},
+            [MULTI_FAMILY_VARIANT, MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3], freqs={'callset': {'ac': 6, 'hh': 0}},
         )
 
 #         self._assert_expected_search(
@@ -660,7 +656,7 @@ class ClickhouseSearchTests(SearchTestHelper, TestCase):
 
         self._assert_expected_search(
             [VARIANT4, MITO_VARIANT1, MITO_VARIANT2],
-            freqs={'callset': {'ac': 10}, 'gnomad_genomes': {'ac': 50}, 'gnomad_mito': {'ac': 10}},
+            freqs={'callset': {'ac': 6}, 'gnomad_genomes': {'ac': 50}, 'gnomad_mito': {'ac': 10}},
         )
 
         self._assert_expected_search(
@@ -1113,7 +1109,7 @@ class ClickhouseSearchTests(SearchTestHelper, TestCase):
         # )
 
         self._assert_expected_search(
-            [MITO_VARIANT1, MITO_VARIANT2, VARIANT4, MITO_VARIANT3, MULTI_FAMILY_VARIANT, VARIANT1, VARIANT2],
+            [MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3, VARIANT4, MULTI_FAMILY_VARIANT, VARIANT2, VARIANT1],
             sort='callset_af',
         )
 
@@ -1212,9 +1208,9 @@ class ClickhouseSearchTests(SearchTestHelper, TestCase):
         )
 
         self._assert_expected_search(
-            [[VARIANT4, VARIANT3], MITO_VARIANT3, VARIANT2],
+            [MITO_VARIANT3, [VARIANT4, VARIANT3], VARIANT2],
             sort='callset_af', inheritance_mode='recessive', **COMP_HET_ALL_PASS_FILTERS, cached_variant_fields=[
-                [{'selectedGeneId': 'ENSG00000097046'}, {'selectedGeneId': 'ENSG00000097046'}], {}, {},
+                {}, [{'selectedGeneId': 'ENSG00000097046'}, {'selectedGeneId': 'ENSG00000097046'}], {},
             ],
         )
 

--- a/clickhouse_search/test_utils.py
+++ b/clickhouse_search/test_utils.py
@@ -12,14 +12,14 @@ from hail_search.test_utils import (
     MITO_VARIANT3 as HAIL_MITO_VARIANT3,
 )
 
-VARIANT1 = {**deepcopy(HAIL_VARIANT1), 'key': 1}
-VARIANT2 = {**deepcopy(HAIL_VARIANT2), 'key': 2}
-VARIANT3 = {**deepcopy(HAIL_VARIANT3), 'key': 3}
-VARIANT4 = {**deepcopy(HAIL_VARIANT4), 'key': 4}
-PROJECT_2_VARIANT = {**deepcopy(HAIL_PROJECT_2_VARIANT), 'key': 5}
-MITO_VARIANT1 = {**deepcopy(HAIL_MITO_VARIANT1), 'key': 6}
-MITO_VARIANT2 = {**deepcopy(HAIL_MITO_VARIANT2), 'key': 7}
-MITO_VARIANT3 = {**deepcopy(HAIL_MITO_VARIANT3), 'key': 8}
+VARIANT1 = {**deepcopy(HAIL_VARIANT1), 'key': 1, 'populations': {**HAIL_VARIANT1['populations'], 'seqr': {'ac': 8, 'hom': 3}}}
+VARIANT2 = {**deepcopy(HAIL_VARIANT2), 'key': 2, 'populations': {**HAIL_VARIANT2['populations'], 'seqr': {'ac': 7, 'hom': 2}}}
+VARIANT3 = {**deepcopy(HAIL_VARIANT3), 'key': 3, 'populations': {**HAIL_VARIANT3['populations'], 'seqr': {'ac': 6, 'hom': 0}}}
+VARIANT4 = {**deepcopy(HAIL_VARIANT4), 'key': 4, 'populations': {**HAIL_VARIANT4['populations'], 'seqr': {'ac': 4, 'hom': 1}}}
+PROJECT_2_VARIANT = {**deepcopy(HAIL_PROJECT_2_VARIANT), 'key': 5, 'populations': {**HAIL_PROJECT_2_VARIANT['populations'], 'seqr': {'ac': 2, 'hom': 0}}}
+MITO_VARIANT1 = {**deepcopy(HAIL_MITO_VARIANT1), 'key': 6, 'populations': {**HAIL_MITO_VARIANT1['populations'], 'seqr': {'ac': 0}, 'seqr_heteroplasmy': {'ac': 1}}}
+MITO_VARIANT2 = {**deepcopy(HAIL_MITO_VARIANT2), 'key': 7, 'populations': {**HAIL_MITO_VARIANT2['populations'], 'seqr': {'ac': 0}, 'seqr_heteroplasmy': {'ac': 1}}}
+MITO_VARIANT3 = {**deepcopy(HAIL_MITO_VARIANT3), 'key': 8, 'populations': {**HAIL_MITO_VARIANT3['populations'], 'seqr': {'ac': 1}, 'seqr_heteroplasmy': {'ac': 0}}}
 for variant in [MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3]:
     variant['genotypes'] = {
         'I000004_hg00731': {
@@ -39,6 +39,7 @@ GRCH37_VARIANT = {
     'liftedOverGenomeVersion': '38',
     'liftedOverChrom': '7',
     'liftedOverPos': 143271368,
+    'populations': {**HAIL_GRCH37_VARIANT['populations'], 'seqr': {'ac': 3, 'hom': 1}},
 }
 for genotype in GRCH37_VARIANT['genotypes'].values():
     genotype['sampleType'] = 'WES'


### PR DESCRIPTION
Instead of hardcoding gt stats dictionaries in tests, use the actual materialized views and dictionaries. While this does change the values in the test results it does not reduce functionality coverage, and it is more accurate and maintainable to use the dictionaries as they are created by the migrations