### PR TITLE
chore: a few small clinvar bug fixes.

### DIFF
--- a/seqr/management/commands/reload_clinvar_all_variants.py
+++ b/seqr/management/commands/reload_clinvar_all_variants.py
@@ -183,7 +183,7 @@ def parse_submitters_and_conditions(classified_record_node: xml) -> [list[str], 
     })
     conditions = sorted({
         c.attrib['Name']
-        for c in classified_record_node.findall('ClinicalAssertionList/TraitMappingList/TraitMapping/MedGen')
+        for c in classified_record_node.findall('TraitMappingList/TraitMapping/MedGen')
         if c.attrib['Name'] != 'not provided'
     })
     return submitters, conditions

--- a/seqr/management/commands/reload_clinvar_all_variants.py
+++ b/seqr/management/commands/reload_clinvar_all_variants.py
@@ -95,6 +95,7 @@ def parse_positions(classified_record_node: xml.etree.ElementTree.Element) -> di
                 and seq_loc.get('alternateAlleleVCF')
                 and seq_loc.get('positionVCF')
                 and seq_loc.get('positionVCF').isdigit()
+                and seq_loc.get('referenceAlleleVCF') != seq_loc.get('alternateAlleleVCF')
             ):
                 positions[seq_loc.attrib['Assembly']] = {
                     'chrom': seq_loc.attrib['Chr'],

--- a/seqr/management/tests/reload_clinvar_all_variants_tests.py
+++ b/seqr/management/tests/reload_clinvar_all_variants_tests.py
@@ -239,13 +239,16 @@ class ReloadClinvarAllVariantsTest(TestCase):
             with self.assertRaisesMessage(CommandError, error_message):
                 call_command('reload_clinvar_all_variants')
 
-        # Variants with missing alleles and positions are skipped
+        # Variants with missing/equivalent alleles and positions are skipped
         for simple_allele_attrs, sequence_location_attrs in [
             # Case 1: Missing AlleleId in <SimpleAllele>
             ("", 'Assembly="GRCh38" Chr="1" positionVCF="1" referenceAlleleVCF="G" alternateAlleleVCF="A"'),
 
             # Case 2: Missing alternateAlleleVCF in <SequenceLocation>
             ('AlleleID="5603"', 'Assembly="GRCh38" Chr="1" positionVCF="1" referenceAlleleVCF="G"'),
+
+            # Case 3: ref/alt are equal
+            ('AlleleID="5603"', 'Assembly="GRCh38" Chr="1" positionVCF="1" referenceAlleleVCF="G" alternateAlleleVCF="G"'),
         ]:
             data = f'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
             <ClinVarVariationRelease xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/seqr/management/tests/reload_clinvar_all_variants_tests.py
+++ b/seqr/management/tests/reload_clinvar_all_variants_tests.py
@@ -42,24 +42,24 @@ WEEKLY_XML_RELEASE_DATA = WEEKLY_XML_RELEASE_HEADER + '''
                 <ClinicalAssertion>
                     <ClinVarAccession SubmitterName="Revvity Omics, Revvity" OrgID="167595" OrganizationCategory="laboratory"/>
                 </ClinicalAssertion>
-                <TraitMappingList>
-                    <TraitMapping>
-                        <MedGen CUI="C3661900" Name="not provided"/>
-                    </TraitMapping>
-                    <TraitMapping>
-                        <MedGen CUI="C0678222" Name="Breast carcinoma"/>
-                    </TraitMapping>
-                    <TraitMapping>
-                        <MedGen CUI="None" Name="CHEK2-related disorder"/>
-                    </TraitMapping>
-                    <TraitMapping>
-                        <MedGen CUI="C5882668" Name="CHEK2-related cancer predisposition"/>
-                    </TraitMapping>
-                    <TraitMapping>
-                        <MedGen CUI="C0027672" Name="Hereditary cancer-predisposing syndrome"/>
-                    </TraitMapping>
-                </TraitMappingList>
             </ClinicalAssertionList>
+            <TraitMappingList>
+                <TraitMapping>
+                    <MedGen CUI="C3661900" Name="not provided"/>
+                </TraitMapping>
+                <TraitMapping>
+                    <MedGen CUI="C0678222" Name="Breast carcinoma"/>
+                </TraitMapping>
+                <TraitMapping>
+                    <MedGen CUI="None" Name="CHEK2-related disorder"/>
+                </TraitMapping>
+                <TraitMapping>
+                    <MedGen CUI="C5882668" Name="CHEK2-related cancer predisposition"/>
+                </TraitMapping>
+                <TraitMapping>
+                    <MedGen CUI="C0027672" Name="Hereditary cancer-predisposing syndrome"/>
+                </TraitMapping>
+            </TraitMappingList>
         </ClassifiedRecord>
     </VariationArchive>
     <VariationArchive VariationID="5603" RecordType="classified" NumberOfSubmissions="38" NumberOfSubmitters="36" DateLastUpdated="2025-06-29" DateCreated="2016-03-20" MostRecentSubmission="2025-06-29">


### PR DESCRIPTION
A few small bug fixes:
- Filter variants where ref and alt alleles are equal.  These are present in the VCF with alt allele of "." and we're filtering them on import.
- The XML tree for conditions got spliced incorrectly when making the unit tests and is incorrectly nested.  