### PR TITLE
use clickhouse as default backend for non-local unit tests

### DIFF
--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -877,6 +877,8 @@ class AirtableCheckNewSamplesTest(AnvilAuthenticationTestCase, CheckNewSamplesTe
     airtable_loading_tracking_url = "http://testairtable/appUelDNM3BnWaR7M/AnVIL%20Seqr%20Loading%20Requests%20Tracking"
     AIRTABLE_LOADING_QUERY_TEMPLATE = "?fields[]=Status&pageSize=2&filterByFormula=AND({{AnVIL Project URL}}='https://seqr.broadinstitute.org/project/{}/project_page',OR(Status='Loading',Status='Loading Requested'))"
 
+    CLICKHOUSE_HOSTNAME = ''
+
     MOCK_DATA_DIR = 'gs://seqr-hail-search-data/v3.1'
     PROJECT_EMAIL_TEXT = ANVIL_TEXT_EMAIL
     PROJECT_EMAIL_HTML = ANVIL_HTML_EMAIL

--- a/seqr/management/tests/lift_project_to_hg38_tests.py
+++ b/seqr/management/tests/lift_project_to_hg38_tests.py
@@ -166,7 +166,7 @@ class LiftProjectToHg38Test(TestCase):
             with self.assertRaises(Exception) as ce:
                 call_command('lift_project_to_hg38', '--project={}'.format(PROJECT_NAME),
                              '--es-index={}'.format(ELASTICSEARCH_INDEX))
-        self.assertEqual(str(ce.exception), 'Adding samples is disabled for the hail backend')
+        self.assertEqual(str(ce.exception), 'Adding samples is disabled without the elasticsearch backend')
 
         # Test discontinue on a failed lift
         mock_liftover_to_38 = mock_liftover.return_value

--- a/seqr/utils/search/add_data_utils.py
+++ b/seqr/utils/search/add_data_utils.py
@@ -19,8 +19,8 @@ from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL, BASE_URL, ANVI
 logger = SeqrLogger(__name__)
 
 
-def _hail_backend_error(*args, **kwargs):
-    raise ValueError('Adding samples is disabled for the hail backend')
+def _no_es_backend_error(*args, **kwargs):
+    raise ValueError('Adding samples is disabled without the elasticsearch backend')
 
 
 def add_new_es_search_samples(request_json, project, user, notify=False, expected_families=None):
@@ -30,7 +30,8 @@ def add_new_es_search_samples(request_json, project, user, notify=False, expecte
 
     sample_ids, sample_type, sample_data = backend_specific_call(
         validate_es_index_metadata_and_get_samples,
-        _hail_backend_error,
+        _no_es_backend_error,
+        _no_es_backend_error,
     )(request_json, project)
     if not sample_ids:
         raise ValueError('No samples found. Make sure the specified caller type is correct')

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -127,6 +127,7 @@ def delete_search_backend_data(data_id):
 
     return backend_specific_call(
         delete_es_index, _raise_search_error('Deleting indices is disabled without the elasticsearch backend'),
+        _raise_search_error('Deleting indices is disabled without the elasticsearch backend'),
     )(data_id)
 
 

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -76,7 +76,7 @@ def ping_search_backend_admin():
 
 
 def get_search_backend_status():
-    return backend_specific_call(get_elasticsearch_status, _raise_search_error('Elasticsearch is disabled'))()
+    return backend_specific_call(get_elasticsearch_status, _raise_search_error('Elasticsearch is disabled'), _raise_search_error('Elasticsearch is disabled'))()
 
 
 def _get_filtered_search_samples(search_filter, active_only=True):
@@ -126,7 +126,7 @@ def delete_search_backend_data(data_id):
         raise InvalidSearchException(f'"{data_id}" is still used by: {", ".join(projects)}')
 
     return backend_specific_call(
-        delete_es_index, _raise_search_error('Deleting indices is disabled for the hail backend'),
+        delete_es_index, _raise_search_error('Deleting indices is disabled without the elasticsearch backend'),
     )(data_id)
 
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1777,7 +1777,7 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
 
     def _assert_expected_delete_index_response(self, response):
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['error'], 'Deleting indices is disabled for the hail backend')
+        self.assertEqual(response.json()['error'], 'Deleting indices is disabled without the elasticsearch backend')
 
     def _assert_expected_get_projects_requests(self):
         pdo_filter = "OR(SEARCH('Methods (Loading)',ARRAYJOIN(PDOStatus,';')),SEARCH('On hold for phenotips, but ready to load',ARRAYJOIN(PDOStatus,';')))"

--- a/seqr/views/apis/dataset_api_tests.py
+++ b/seqr/views/apis/dataset_api_tests.py
@@ -464,7 +464,7 @@ class AnvilDatasetAPITest(AnvilAuthenticationTestCase, DatasetAPITest):
     def _assert_expected_add_dataset_errors(self, url):
         response = self.client.post(url, content_type='application/json', data=ADD_DATASET_PAYLOAD)
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json()['errors'][0], 'Adding samples is disabled for the hail backend')
+        self.assertEqual(response.json()['errors'][0], 'Adding samples is disabled without the elasticsearch backend')
 
     def test_add_variants_dataset(self, *args):
         # Adding dataset is always disabled when ES is disabled, which is tested in test_add_variants_dataset_errors

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -598,7 +598,7 @@ def _update_lookup_variant(variant, response):
     add_individual_hpo_details(individual_summary_map.values())
 
     variant['genotypes'] = {}
-    variant['lookupFamilyGuids'] = variant.pop('familyGuids')
+    variant['lookupFamilyGuids'] = sorted(variant.pop('familyGuids'))
     variant['familyGuids'] = []
     for family_guid in variant['lookupFamilyGuids']:
         variant['genotypes'].update({

--- a/seqr/views/utils/test_utils.py
+++ b/seqr/views/utils/test_utils.py
@@ -519,6 +519,7 @@ def get_group_members_side_effect(user, group, use_sa_credentials=False):
 class AnvilAuthenticationTestCase(AuthenticationTestCase):
 
     ES_HOSTNAME = ''
+    CLICKHOUSE_HOSTNAME = 'testhost'
     MOCK_AIRTABLE_KEY = 'airflow_access'
 
     # mock the terra apis


### PR DESCRIPTION
Updates our unit test fixtures to use clickhouse instead of hail search as the default backend for testing Non-local functionality. This does not actually decrease coverage for hail search functionality, and allows us to test the clickhouse-specific functionality for saved variants when it is added