### PR TITLE
add allele validation before querying VLM

### DIFF
--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -1082,6 +1082,10 @@ class VariantSearchAPITest(object):
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'error': 'VLM lookup is not supported for SVs'})
 
+        response = self.client.get(f'{base_url}?variantId=8-10439--ATGS')
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(response.json(), {'error': 'Unable to search VLM for invalid allele(s): "", "ATGS"'})
+
         self.reset_logs()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Since the variant lookup page allows users to put in a free text variant ID, we need better validation that the ID we are proxying to the VLM is valid. Looking through the logs I found a case where MyGene2 was returning an error because we had passed along a totally invalid variant. Adding this validation will prevent undo alert fatigue from the VLM (any time a request does not return a 200 we get alerted)