### PR TITLE
fix json encoding for SVs with null genes

### DIFF
--- a/clickhouse_search/backend/fields.py
+++ b/clickhouse_search/backend/fields.py
@@ -50,7 +50,8 @@ class NestedField(models.TupleField):
         if self.group_by_key:
             group_value = defaultdict(list)
             for item in value:
-                group_value[item[self.group_by_key]].append(item)
+                group_key = item[self.group_by_key]
+                group_value['null' if group_key is None else group_key].append(item)
             if self.flatten_groups:
                 value = {k: v[0] if len(v) == 1 else v for k, v in group_value.items()}
             else:

--- a/clickhouse_search/test_utils.py
+++ b/clickhouse_search/test_utils.py
@@ -504,7 +504,7 @@ SV_GENE_COUNTS = {
     'ENSG00000171621': {'total': 2, 'families': {'F000014_14': 2}},
     'ENSG00000083544': {'total': 1, 'families': {'F000014_14': 1}},
     'ENSG00000184986': {'total': 1, 'families': {'F000014_14': 1}},
-    None: {'total': 1, 'families': {'F000014_14': 1}},
+    'null': {'total': 1, 'families': {'F000014_14': 1}},
 }
 
 GCNV_GENE_COUNTS = {


### PR DESCRIPTION
In the hail backend this is handled automatically with how aiohttp encodes the json for the http response, but in django this is throwing an error