### PR TITLE
do not allow moving families still associated with analysis groups

### DIFF
--- a/seqr/management/tests/transfer_families_to_different_project_tests.py
+++ b/seqr/management/tests/transfer_families_to_different_project_tests.py
@@ -15,7 +15,7 @@ class TransferFamiliesTest(object):
 
         self.assert_json_logs(user=None, expected=[
             logs[0],
-            ('Skipping 1 families with analysis groups in the project: 5', None),
+            ('Skipping 1 families with analysis groups in the project: 5 (Test Group 1)', None),
             *logs[1:],
             ('Updating "Excluded" tags', None),
             ('Updating families', None),


### PR DESCRIPTION
This error occurred because a family was moved out of a project without properly removing it from ana analysis group: https://github.com/broadinstitute/seqr/issues/4933
This PR will prevent that from happening in the future by forcing a manual clean up of analysis groups before allowing the transfer