### PR TITLE
Family id error message

### DIFF
--- a/clickhouse_search/management/tests/set_saved_variant_key_tests.py
+++ b/clickhouse_search/management/tests/set_saved_variant_key_tests.py
@@ -115,7 +115,7 @@ class SetSavedVariantKeyFailedMappingTest(SetSavedVariantKeyTest):
             ('Finding keys for 2 SNV_INDEL (GRCh38) variant ids', None),
             ('Found 0 keys', None),
             ('3 variants have no key, 1 of which have no search data, 1 of which are absent from the hail backend.', None),
-            ('1 remaining variants: M-14783-T-C - 14', None),
+            ('1 remaining variants: M-14783-T-C - fam14', None),
             ('Finding keys for 2 SV_WGS (GRCh38) variant ids', None),
             ('Found 0 keys', None),
             ('Finding keys for 2 SV_WES (GRCh38) variant ids', None),

--- a/matchmaker/views/external_api_tests.py
+++ b/matchmaker/views/external_api_tests.py
@@ -253,7 +253,7 @@ Our website can be found at https://seqr.broadinstitute.org/matchmaker/matchbox 
 be found found at https://seqr.broadinstitute.org/matchmaker/disclaimer."""
         match1 = 'seqr ID NA19675_1 from project 1kg project n\u00e5me with uni\u00e7\u00f8de in family 1 inserted into matchbox on May 23, 2018, with seqr link /project/R0001_1kg/family_page/F000001_1/matchmaker_exchange'
         match2 = 'seqr ID NA20888 from project Test Reprocessed Project in family 12 inserted into matchbox on Feb 05, 2019, with seqr link /project/R0003_test/family_page/F000012_12/matchmaker_exchange'
-        match3 = 'seqr ID NA21234 from project Non-Analyst Project in family 14 inserted into matchbox on Feb 05, 2019, with seqr link /project/R0004_non_analyst_project/family_page/F000014_14/matchmaker_exchange'
+        match3 = 'seqr ID NA21234 from project Non-Analyst Project in family fam14 inserted into matchbox on Feb 05, 2019, with seqr link /project/R0004_non_analyst_project/family_page/F000014_14/matchmaker_exchange'
 
         mock_post_to_slack.assert_called_with('matchmaker_matches', message_template.format(
             matches='\n'.join([match1, match2, match3]),

--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -375,7 +375,7 @@
         "created_by": null,
         "last_modified_date": "2017-03-12T22:37:17.555Z",
         "project": 4,
-        "family_id": "14",
+        "family_id": "fam14",
         "analysis_status": "Rncc",
         "success_story": "Differential treatement",
         "success_story_types": ["A", "D"]

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -679,7 +679,7 @@ The following 2 families failed missing samples:
                 """Encountered the following errors loading Non-Analyst Project:
 
 The following 1 families failed sex check:
-- 14: Sample NA21987 has pedigree sex M but imputed sex F""",
+- fam14: Sample NA21987 has pedigree sex M but imputed sex F""",
             ),
             mock.call(
                 'seqr-data-loading',

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1495,8 +1495,8 @@ class DataManagerAPITest(AirtableTest):
         self.assertEqual(len(file), 3)
         self.assertListEqual(file, [
             pedigree_header,
-            ['R0004_non_analyst_project', 'F000014_14', '14', 'NA21234', '', '', 'F'] + (['ABC123'] if has_remap else []),
-            ['R0004_non_analyst_project', 'F000014_14', '14', 'NA21987', '', '', 'M'] + ([''] if has_remap else []),
+            ['R0004_non_analyst_project', 'F000014_14', 'fam14', 'NA21234', '', '', 'F'] + (['ABC123'] if has_remap else []),
+            ['R0004_non_analyst_project', 'F000014_14', 'fam14', 'NA21987', '', '', 'M'] + ([''] if has_remap else []),
         ])
 
     def _test_load_single_project(self, mock_open, mock_mkdir, response, *args, **kwargs):
@@ -1919,7 +1919,7 @@ class AnvilDataManagerAPITest(AirflowTestCase, DataManagerAPITest):
             'warnings': None,
             'errors': [
                 'The following samples are included in airtable but are missing from the VCF: NA21987',
-                'The following families have previously loaded samples absent from airtable\nFamily 14: NA21234, NA21654',
+                'The following families have previously loaded samples absent from airtable\nFamily fam14: NA21234, NA21654',
             ],
         })
         self.assertEqual(len(responses.calls), 2)

--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -459,7 +459,7 @@ class FamilyAPITest(object):
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertEqual(response_json['F000014_14']['description'], 'Updated description')
-        expected_id = 'new_id' if self._anvil_enabled() else '14'
+        expected_id = 'new_id' if self._anvil_enabled() else 'fam14'
         self.assertEqual(response_json['F000014_14'][FAMILY_ID_FIELD], expected_id)
         self.assertEqual(response_json['F000014_14']['displayName'], expected_id)
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -121,6 +121,7 @@ def anvil_export(request, project_guid):
     project = get_project_and_check_permissions(project_guid, request.user)
 
     parsed_rows = defaultdict(list)
+    family_id_map = {}
     family_diseases = {}
 
     def _add_row(row, family_id, row_type):
@@ -130,7 +131,7 @@ def anvil_export(request, project_guid):
                 if not (discovery_row.get(GENE_COLUMN) or discovery_row.get('sv_type'))]
             if missing_gene_rows:
                 raise ErrorsWarningsException(
-                    [f'Discovery variant(s) {", ".join(sorted(missing_gene_rows))} in family {family_id} have no associated gene'])
+                    [f'Discovery variant(s) {", ".join(sorted(missing_gene_rows))} in family {family_id_map[family_id]} have no associated gene'])
             parsed_rows[row_type] += [{
                 'entity:discovery_id': f'{discovery_row["chrom"]}_{discovery_row["pos"]}_{discovery_row["participant_id"]}',
                 **{k: str(discovery_row.get(k.lower()) or '') for k in ['Zygosity', 'Chrom', 'Pos', 'Ref', 'Alt', 'Transcript']},
@@ -164,6 +165,7 @@ def anvil_export(request, project_guid):
                     'disease_id': row.get('condition_id', '').replace('|', ';'),
                     'disease_description': row.get('known_condition_name', '').replace('|', ';'),
                 }
+                family_id_map[family_id] = row[id_field]
             parsed_rows[row_type].append(row)
 
     max_loaded_date = request.GET.get('loadedBefore') or (datetime.now() - timedelta(days=365)).strftime('%Y-%m-%d')

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -784,7 +784,7 @@ class ReportAPITest(AirtableTest):
         response = self.client.get(no_analyst_project_url)
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['errors'],
-                         ['Discovery variant(s) 1-248367227-TC-T, MT-14783-T-C in family 14 have no associated gene'])
+                         ['Discovery variant(s) 1-248367227-TC-T, MT-14783-T-C in family fam14 have no associated gene'])
 
     @mock.patch('seqr.views.apis.report_api.GREGOR_DATA_MODEL_URL', MOCK_DATA_MODEL_URL)
     @mock.patch('seqr.views.apis.report_api.datetime')

--- a/seqr/views/apis/summary_data_api_tests.py
+++ b/seqr/views/apis/summary_data_api_tests.py
@@ -129,8 +129,8 @@ EXPECTED_SAMPLE_METADATA_ROW.update(EXPECTED_NO_AIRTABLE_SAMPLE_METADATA_ROW)
 EXPECTED_NO_GENE_SAMPLE_METADATA_ROW = {
     'participant_id': 'NA21234',
     'familyGuid': 'F000014_14',
-    'family_id': '14',
-    'displayName': '14',
+    'family_id': 'fam14',
+    'displayName': 'fam14',
     'projectGuid': 'R0004_non_analyst_project',
     'internal_project_id': 'Non-Analyst Project',
     'affected_status': 'Affected',


### PR DESCRIPTION
The human readable family id and integer db id were identical in our test data which made this bug hard to detect, so in addition to fixing the bug I also updated the fixture data