### PR TITLE
Cache intermediate search results

### DIFF
--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -68,8 +68,7 @@ def get_clickhouse_variants(samples, search, user, previous_search_results, geno
         results += dataset_results
 
         if dataset_type == Sample.DATASET_TYPE_VARIANT_CALLS and len(sample_data_by_dataset_type) > 1 and skip_individual_guid:
-            previous_search_results['variant_only_results'] = dataset_results
-            safe_redis_set_json(cache_key, previous_search_results, expire=60*60*24)
+            safe_redis_set_json(cache_key, {'variant_only_results': dataset_results}, expire=60*60*24)
 
     if has_comp_het and Sample.DATASET_TYPE_VARIANT_CALLS in sample_data_by_dataset_type and any(
         dataset_type.startswith(Sample.DATASET_TYPE_SV_CALLS) for dataset_type in sample_data_by_dataset_type

--- a/clickhouse_search/search_tests.py
+++ b/clickhouse_search/search_tests.py
@@ -207,6 +207,7 @@ class ClickhouseSearchTests(DifferentDbTransactionSupportMixin, SearchTestHelper
             [PROJECT_2_VARIANT, MULTI_PROJECT_VARIANT1, MULTI_PROJECT_VARIANT2, VARIANT3, VARIANT4,
              GCNV_VARIANT1, GCNV_VARIANT2, GCNV_VARIANT3, GCNV_VARIANT4, MITO_VARIANT1, MITO_VARIANT2, MITO_VARIANT3],
             gene_counts=gene_counts, locus={'rawItems': 'chr1:1-100000000, chr13:1-100000000, chr14:1-100000000, chr16:1-100000000, chr17:1-100000000, M:1-100000000'},
+            initial_cache_offset=4,
         )
 
         self.results_model.families.set(Family.objects.filter(guid__in=['F000002_2', 'F000011_11', 'F000014_14']))

--- a/seqr/utils/search/elasticsearch/es_utils.py
+++ b/seqr/utils/search/elasticsearch/es_utils.py
@@ -271,7 +271,7 @@ def get_es_variants_for_variant_ids(samples, genome_version, variants_by_id, use
 
 
 def get_es_variants(samples, search, user, previous_search_results, genome_version, sort=None, page=None, num_results=None,
-                    gene_agg=False, skip_genotype_filter=False):
+                    gene_agg=False, skip_genotype_filter=False, **kwargs):
     es_search_cls = EsGeneAggSearch if gene_agg else EsSearch
 
     es_search = es_search_cls(

--- a/seqr/utils/search/search_utils_tests.py
+++ b/seqr/utils/search/search_utils_tests.py
@@ -340,7 +340,8 @@ class SearchUtilsTests(SearchTestHelper):
         if annotations_secondary is not None:
             expected_search['annotations_secondary'] = annotations_secondary
 
-        mock_get_variants.assert_called_with(mock.ANY, expected_search, self.user, results_cache, '37', **kwargs)
+        cache_key = f'search_results__{self.results_model.guid}__{kwargs.get("sort") or "xpos"}'
+        mock_get_variants.assert_called_with(mock.ANY, expected_search, self.user, results_cache, '37', cache_key=cache_key, **kwargs)
         self._assert_expected_search_samples(mock_get_variants, omitted_sample_guids, has_gene_search and not exclude_locations)
 
         gene_ids = intervals = None

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -369,12 +369,13 @@ def _query_variants(search_model, user, previous_search_results, genome_version,
 
     _validate_search(parsed_search, samples, previous_search_results)
 
+    cache_key = _get_search_cache_key(search_model, sort=sort)
+
     variant_results = _execute_search(
         samples, parsed_search, user, previous_search_results, genome_version,
-        sort=sort, num_results=num_results, **kwargs,
+        sort=sort, num_results=num_results, cache_key=cache_key, **kwargs,
     )
 
-    cache_key = _get_search_cache_key(search_model, sort=sort)
     safe_redis_set_json(cache_key, previous_search_results, expire=timedelta(weeks=2))
 
     return variant_results, previous_search_results.get('total_results')


### PR DESCRIPTION
There are still some searches where for users with access to more than just our internal data (currently one user) we are getting time outs on all project search. While we have longer term plans to support searches on this many families, for now as a workaround this PR adds intermediate caching of the SNV_INDEL search results (the bottleneck for these searches) so that if the cumulative time for all the search components times out the bulk of the query result will be cached so on page refresh the search will succeed. While this is not ideal behavior, it is a better than being fully unable to run searches until the refactor is completed