### PR TITLE
Fix variant lookup across genome builds

### DIFF
--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -546,13 +546,13 @@ def _add_liftover_genotypes(variant, data_type, variant_id):
     lifted_entry_cls = ENTRY_CLASS_MAP.get(variant.get('liftedOverGenomeVersion'), {}).get(data_type)
     if not lifted_entry_cls:
         return
-    lifted_id = (variant['liftedOverChrom'], str(variant['liftedOverPos']), *variant_id[2:])
+    lifted_id = (variant['liftedOverChrom'], variant['liftedOverPos'], *variant_id[2:])
     keys = KEY_LOOKUP_CLASS_MAP[variant['liftedOverGenomeVersion']][data_type].objects.filter(
-        variant_id='-'.join(lifted_id),
+        variant_id='-'.join([str(o) for o in lifted_id]),
     ).values_list('key', flat=True)
     if not keys:
         return
-    lifted_entries = lifted_entry_cls.objects.filter_locus(variant_ids=[variant_id]).filter(key=keys[0])
+    lifted_entries = lifted_entry_cls.objects.filter_locus(variant_ids=[lifted_id]).filter(key=keys[0])
     lifted_entry_data = lifted_entries.values('key').annotate(
         familyGenotypes=GroupArrayArray(lifted_entry_cls.objects.genotype_expression())
     )

--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -541,8 +541,11 @@ def clickhouse_variant_lookup(user, variant_id, data_type, genome_version=None, 
     else:
         lifted_genome_version = next(gv for gv in ENTRY_CLASS_MAP.keys() if gv != genome_version)
         if ENTRY_CLASS_MAP[lifted_genome_version].get(data_type):
-            lifted_id = _liftover_variant_id(variant_id, lifted_genome_version)
-            variant = _clickhouse_variant_lookup(lifted_id, lifted_genome_version, data_type, samples)
+            from seqr.utils.search.utils import run_liftover
+            liftover_results = run_liftover(lifted_genome_version, variant_id[0], variant_id[1])
+            if liftover_results:
+                lifted_id = (liftover_results[0], liftover_results[1], *variant_id[2:])
+                variant = _clickhouse_variant_lookup(lifted_id, lifted_genome_version, data_type, samples)
 
     if not variant:
         raise ObjectDoesNotExist('Variant not present in seqr')

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -2,11 +2,13 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import timedelta
 from django.db.models import Count
+from pyliftover.liftover import LiftOver
 
 from clickhouse_search.search import clickhouse_backend_enabled, get_clickhouse_variants, format_clickhouse_results, \
     get_clickhouse_cache_results, clickhouse_variant_lookup, get_clickhouse_variant_by_id
 from reference_data.models import GENOME_VERSION_GRCh38, GENOME_VERSION_GRCh37
 from seqr.models import Sample, Individual, Project
+from seqr.utils.logging_utils import SeqrLogger
 from seqr.utils.redis_utils import safe_redis_get_json, safe_redis_get_wildcard_json, safe_redis_set_json
 from seqr.utils.search.constants import XPOS_SORT_KEY, PRIORITIZED_GENE_SORT, RECESSIVE, COMPOUND_HET, \
     MAX_NO_LOCATION_COMP_HET_FAMILIES, SV_ANNOTATION_TYPES, ALL_DATA_TYPES, MAX_EXPORT_VARIANTS, X_LINKED_RECESSIVE, \
@@ -19,6 +21,7 @@ from seqr.utils.search.hail_search_utils import get_hail_variants, get_hail_vari
 from seqr.utils.gene_utils import parse_locus_list_items
 from seqr.utils.xpos_utils import get_xpos, format_chrom, MIN_POS, MAX_POS
 
+logger = SeqrLogger(__name__)
 
 class InvalidSearchException(Exception):
     pass
@@ -657,3 +660,32 @@ def _format_interval(chrom=None, start=None, end=None, offset=None, **kwargs):
         end = min(end + offset_pos, MAX_POS)
     return [chrom, start, end]
 
+
+LIFTOVERS = {
+    GENOME_VERSION_GRCh38: None,
+    GENOME_VERSION_GRCh37: None,
+}
+PYLIFTOVER_BUILD_LOOKUP = {
+    GENOME_VERSION_GRCh38: ('hg19', 'hg38'),
+    GENOME_VERSION_GRCh37: ('hg38', 'hg19'),
+}
+def _get_liftover(genome_version):
+    global LIFTOVERS
+    if not LIFTOVERS[genome_version]:
+        try:
+            LIFTOVERS[genome_version] = LiftOver(*PYLIFTOVER_BUILD_LOOKUP[genome_version])
+        except Exception as e:
+            logger.error('ERROR: Unable to set up liftover. {}'.format(e), user=None)
+    return LIFTOVERS[genome_version]
+
+
+def run_liftover(genome_version, chrom, pos):
+    liftover = _get_liftover(genome_version)
+    if not liftover:
+        return None
+    lifted_coord = liftover.convert_coordinate(
+        'chr{}'.format(chrom.lstrip('chr')), int(pos)
+    )
+    if lifted_coord and lifted_coord[0]:
+        return (lifted_coord[0][0].lstrip('chr'), lifted_coord[0][1])
+    return None

--- a/seqr/utils/search/utils.py
+++ b/seqr/utils/search/utils.py
@@ -670,7 +670,6 @@ PYLIFTOVER_BUILD_LOOKUP = {
     GENOME_VERSION_GRCh37: ('hg38', 'hg19'),
 }
 def _get_liftover(genome_version):
-    global LIFTOVERS
     if not LIFTOVERS[genome_version]:
         try:
             LIFTOVERS[genome_version] = LiftOver(*PYLIFTOVER_BUILD_LOOKUP[genome_version])


### PR DESCRIPTION
VLM will return counts across genome builds, but currently variant lookup is buggy when trying to return results from both builds. This fixes a bug in the case where the variant is present on both builds, and also adds explicit liftover in the case where it is absent from the requested build so we can check the other build. For this new liftover I abstracted the existing litover code we had set up to run on elasticsearch - pyliftover is already configured in our repo and is a much more lightweight solution than setting up all of hail just to run liftover