### PR TITLE
Show error when file iter fails

### DIFF
--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -338,6 +338,7 @@ OPENED_RUN_JSON_FILES = [{
 
 def mock_opened_file(index):
     m = mock.MagicMock()
+    m.wait.return_value = 0
     m.stdout = [json.dumps(OPENED_RUN_JSON_FILES[index]).encode()]
     return m
 

--- a/seqr/management/tests/update_individuals_sample_qc_tests.py
+++ b/seqr/management/tests/update_individuals_sample_qc_tests.py
@@ -99,6 +99,7 @@ class UpdateIndividualsSampleQC(TestCase):
         # Test 'sample_qc' not in metadata
         self.mock_ls_process.communicate.return_value = b'gs://seqr-hail-search-data/v3.1/GRCh38/SNV_INDEL/runs/manual__2025-02-24/metadata.json\n', b''
         self.mock_metadata_file.stdout = [json.dumps({}).encode()]
+        self.mock_metadata_file.wait.return_value = 0
         self.mock_subprocess.side_effect = [self.mock_ls_process, self.mock_metadata_file]
 
         with self.assertRaises(CommandError):

--- a/seqr/utils/file_utils.py
+++ b/seqr/utils/file_utils.py
@@ -82,7 +82,7 @@ def file_iter(file_path, byte_range=None, raw_content=False, user=None, **kwargs
 def _google_bucket_file_iter(gs_path, byte_range=None, raw_content=False, user=None, **kwargs):
     """Iterate over lines in the given file"""
     range_arg = ' -r {}-{}'.format(byte_range[0], byte_range[1]) if byte_range else ''
-    process = _run_gsutil_command(
+    process = run_gsutil_with_wait(
         'cat{}'.format(range_arg), gs_path, gunzip=gs_path.endswith("gz") and not raw_content, user=user, **kwargs)
     for line in process.stdout:
         if not raw_content:
@@ -109,8 +109,8 @@ def _get_gs_file_list(gs_path, user, check_subfolders, allow_missing):
     return [line for line in all_lines if is_google_bucket_file_path(line)]
 
 
-def run_gsutil_with_wait(command, gs_path, user=None):
-    process = _run_gsutil_command(command, gs_path, user=user)
+def run_gsutil_with_wait(command, gs_path, user=None, **kwargs):
+    process = _run_gsutil_command(command, gs_path, user=user, **kwargs)
     if process.wait() != 0:
         errors = [line.decode('utf-8').strip() for line in process.stdout]
         raise Exception('Run command failed: ' + ' '.join(errors))

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -427,6 +427,7 @@ class AnvilWorkspaceAPITest(AnvilAuthenticationTestCase):
         mock_subprocess.side_effect = [mock_file_exist_or_list_subproc, mock_get_header_subproc]
         mock_file_exist_or_list_subproc.communicate.return_value = b'gs://test_bucket/test_path-001.vcf.gz\ngs://test_bucket/test_path-102.vcf.gz\n', None
         mock_get_header_subproc.stdout = BASIC_META + INFO_META + FORMAT_META + HEADER_LINE + DATA_LINES
+        mock_get_header_subproc.wait.return_value = 0
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY_SHARDED_DATA_PATH))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json(), {'fullDataPath': 'gs://test_bucket/test_path-*.vcf.gz', 'vcfSamples': ['HG00735', 'NA19675_1', 'NA19679']})

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -823,6 +823,7 @@ class DataManagerAPITest(AirtableTest):
         mock_does_file_exist.wait.return_value = 0
         mock_file_iter = mock.MagicMock()
         def _set_file_iter_stdout(rows):
+            mock_file_iter.wait.return_value = 0
             mock_file_iter.stdout = [('\t'.join([str(col) for col in row]) + '\n').encode() for row in rows]
             mock_subprocess.side_effect = [mock_does_file_exist, mock_file_iter, mock_does_file_exist]
 
@@ -1757,6 +1758,7 @@ class AnvilDataManagerAPITest(AnvilAuthenticationTestCase, DataManagerAPITest):
         self.mock_does_file_exist = mock.MagicMock()
         self.mock_file_iter = mock.MagicMock()
         self.mock_file_iter.stdout = []
+        self.mock_file_iter.wait.return_value = 0
         self.mock_subprocess.side_effect = [self.mock_does_file_exist, self.mock_file_iter]
         self.addCleanup(patcher.stop)
         patcher = mock.patch('seqr.utils.search.add_data_utils.safe_post_to_slack')

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -1018,7 +1018,7 @@ class IndividualAPITest(object):
             'OR4G11P', '', '', '', 'Heterozygous', '', 'unknown', 'Broad_NA20889_1_248367227', '', 'Candidate',
             'IRIDA syndrome', 'MONDO:0008788', 'Autosomal dominant', 'Full', '', '', 'SR-ES', '', '', '', '', '', '', '',
         ])
-        self._set_metadata_file_iter(mock_subprocess, genetic_findings_table)
+        mock_subprocess.return_value.stdout.__iter__.return_value = [b'Bucket is a requester pays bucket but no user project provided']
 
         url = reverse(import_gregor_metadata, args=[PM_REQUIRED_PROJECT_GUID])
         self.check_pm_login(url)
@@ -1027,6 +1027,13 @@ class IndividualAPITest(object):
             'workspaceNamespace': 'my-seqr-billing', 'workspaceName': 'anvil-1kg project nåme with uniçøde',
             'sampleType': 'exome',
         }
+        response = self.client.post(url, content_type='application/json', data=json.dumps(body))
+        self.assertEqual(response.status_code, 500)
+        self.assertDictEqual(response.json(), {'error': 'Run command failed: Bucket is a requester pays bucket but no user project provided'})
+
+        mock_subprocess.reset_mock()
+        self._set_metadata_file_iter(mock_subprocess, genetic_findings_table)
+        mock_subprocess.return_value.wait.return_value = 0
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
@@ -1224,14 +1231,19 @@ class IndividualAPITest(object):
 
         mock_subprocess.assert_has_calls([
             mock.call('gsutil cat gs://test_bucket/data_tables/experiment_dna_short_read.tsv', stdout=-1, stderr=-2, shell=True),  # nosec
+            mock.call().wait(),
             mock.call().stdout.__iter__(),
             mock.call('gsutil cat gs://test_bucket/data_tables/experiment.tsv', stdout=-1, stderr=-2, shell=True),  # nosec
+            mock.call().wait(),
             mock.call().stdout.__iter__(),
             mock.call('gsutil cat gs://test_bucket/data_tables/participant.tsv', stdout=-1, stderr=-2, shell=True), # nosec
+            mock.call().wait(),
             mock.call().stdout.__iter__(),
             mock.call('gsutil cat gs://test_bucket/data_tables/phenotype.tsv', stdout=-1, stderr=-2, shell=True),  # nosec
+            mock.call().wait(),
             mock.call().stdout.__iter__(),
             mock.call('gsutil cat gs://test_bucket/data_tables/genetic_findings.tsv', stdout=-1, stderr=-2, shell=True),  # nosec
+            mock.call().wait(),
             mock.call().stdout.__iter__(),
         ])
 

--- a/seqr/views/utils/file_utils_tests.py
+++ b/seqr/views/utils/file_utils_tests.py
@@ -154,6 +154,7 @@ class AnvilFileUtilsTest(AnvilAuthenticationTestCase, FileUtilsTest):
             mock.call(f'gsutil mv {self._temp_file_path()} {gs_file}', stdout=-1, stderr=-2, shell=True),  # nosec
             mock.call().wait(),
             mock.call(f'gsutil cat {gs_file} | gunzip -c -q - ', stdout=-1, stderr=-2, shell=True),  # nosec
+            mock.call().wait(),
             mock.call().stdout.__iter__(),
         ])
 


### PR DESCRIPTION
The issue in https://github.com/broadinstitute/seqr-private/issues/1714 would have been much more evident and not required engineering time to investigate if we actually checked if file iteration succeeded instead of just iterating an "empty" file