### PR TITLE
update python version for runtime image

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -50,7 +50,7 @@ COPY ./ui/ .
 
 RUN npm run build
 
-FROM python:3.9-slim-bullseye as runtime
+FROM python:3.11-slim-bullseye as runtime
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
I updated the python version for the build image but not the runtime image. unsurprisingly, this does not result in a valid docker image