### PR TITLE
actually apply x chrom filter for x linked search

### DIFF
--- a/clickhouse_search/managers.py
+++ b/clickhouse_search/managers.py
@@ -811,6 +811,9 @@ class EntriesManager(SearchQuerySet):
 
        entries = entries.filter(family_q)
 
+       if inheritance_mode == X_LINKED_RECESSIVE:
+           entries = entries.filter(self._interval_query('X', start=MIN_POS, end=MAX_POS))
+
        inheritance_q = None
        quality_q = None
        gt_filter = None


### PR DESCRIPTION
This was a piece of functionality that was missed from the hail backend migration - hail code for this logic can be viewed here: https://github.com/broadinstitute/seqr/blob/820ccf67609a99658f173bab326689227e116c88/hail_search/queries/base.py#L796-L800