### PR TITLE
bugfix: quote passwords

### DIFF
--- a/clickhouse_search/migrations/0015_remove_gnomadgenomessnvindel_key_and_more.py
+++ b/clickhouse_search/migrations/0015_remove_gnomadgenomessnvindel_key_and_more.py
@@ -54,7 +54,7 @@ CREATE DICTIONARY `$reference_genome/$dataset_type/gt_stats_dict`
     $columns
 )
 PRIMARY KEY key
-SOURCE(CLICKHOUSE(USER $clickhouse_writer_user PASSWORD $clickhouse_writer_password TABLE `$reference_genome/$dataset_type/gt_stats`))
+SOURCE(CLICKHOUSE(USER '$clickhouse_writer_user' PASSWORD '$clickhouse_writer_password' TABLE `$reference_genome/$dataset_type/gt_stats`))
 LIFETIME(MIN 0 MAX 0)
 LAYOUT(FLAT(MAX_ARRAY_SIZE $size))
 """).safe_substitute(

--- a/clickhouse_search/migrations/0016_add_affected_status.py
+++ b/clickhouse_search/migrations/0016_add_affected_status.py
@@ -19,7 +19,7 @@ CREATE DICTIONARY `$reference_genome/$dataset_type/gt_stats_dict`
     $columns
 )
 PRIMARY KEY key
-SOURCE(CLICKHOUSE(USER $clickhouse_writer_user PASSWORD $clickhouse_writer_password TABLE `$reference_genome/$dataset_type/gt_stats`))
+SOURCE(CLICKHOUSE(USER '$clickhouse_writer_user' PASSWORD '$clickhouse_writer_password' TABLE `$reference_genome/$dataset_type/gt_stats`))
 LIFETIME(MIN 0 MAX 0)
 LAYOUT(FLAT(MAX_ARRAY_SIZE $size))
 """).safe_substitute(


### PR DESCRIPTION
Resolves an issue with passwords with special characters.

We _could_ do this with a new migration with REPLACE, but the migrations actually crash as is.  