### PR TITLE
fix logic for grouping comp hets

### DIFF
--- a/ui/shared/components/panel/variants/selectors.js
+++ b/ui/shared/components/panel/variants/selectors.js
@@ -154,7 +154,8 @@ export const getPairedSelectedSavedVariants = createSelector(
         variantGuids.forEach((variantGuid) => {
           delete acc[variantGuid]
         })
-        acc[key] = variantGuids.map(variantGuid => selectedVariantsByGuid[variantGuid]).sort(sortCompHet)
+        const pairVariants = variantGuids.map(variantGuid => selectedVariantsByGuid[variantGuid])
+        acc[key] = pairVariants.length === 1 ? pairVariants[0] : pairVariants.sort(sortCompHet)
       }
       return acc
     }, {})

--- a/ui/shared/components/panel/variants/selectors.test.js
+++ b/ui/shared/components/panel/variants/selectors.test.js
@@ -37,19 +37,16 @@ test('getPairedSelectedSavedVariants', () => {
   const savedFamilyVariants = getPairedSelectedSavedVariants(
     STATE_WITH_2_FAMILIES, { match: { params:  { familyGuid: 'F011652_1' } } }
   )
-  expect(savedFamilyVariants.length).toEqual(3)
+  expect(savedFamilyVariants.length).toEqual(2)
   expect(savedFamilyVariants[0].variantGuid).toEqual('SV0000004_116042722_r0390_1000')
   expect(savedFamilyVariants[1].variantGuid).toEqual('SV0000002_1248367227_r0390_100')
-  expect(savedFamilyVariants[2].variantGuid).toEqual('SV0000002_SV48367227_r0390_100')
 
   const savedAnalysisGroupVariants = getPairedSelectedSavedVariants(
     STATE_WITH_2_FAMILIES, { match: { params:  { analysisGroupGuid: 'AG0000183_test_group' } } }
   )
-  expect(savedAnalysisGroupVariants.length).toEqual(3)
+  expect(savedAnalysisGroupVariants.length).toEqual(2)
   expect(savedAnalysisGroupVariants[0].variantGuid).toEqual('SV0000004_116042722_r0390_1000')
   expect(savedAnalysisGroupVariants[1].variantGuid).toEqual('SV0000002_1248367227_r0390_100')
-  expect(savedFamilyVariants[2].variantGuid).toEqual('SV0000002_SV48367227_r0390_100')
-
 
   const savedVariants = getPairedSelectedSavedVariants(
     STATE_WITH_2_FAMILIES, { match: { params:  { variantGuid: 'SV0000004_116042722_r0390_1000' } } }


### PR DESCRIPTION
Fixes a bug Lynn identified while looking into the prioritized variants. The current logic for getting paired variants is to go variant by variant, check all the note and tag guids and find the correct sets within them. Rather than try to debug that logic I simplified it and changed it to go through the notes and tags and identify all the unique pairs