### PR TITLE
start view before refreshing

### DIFF
--- a/clickhouse_search/backend/table_models.py
+++ b/clickhouse_search/backend/table_models.py
@@ -17,6 +17,7 @@ class RefreshableMaterializedView(IncrementalMaterializedView):
     @classmethod
     def refresh(cls):
         with connections['clickhouse_write'].cursor() as cursor:
+            cursor.execute(f'SYSTEM START VIEW "{cls._meta.db_table}"')
             cursor.execute(f'SYSTEM REFRESH VIEW "{cls._meta.db_table}"')
             cursor.execute(f'SYSTEM WAIT VIEW "{cls._meta.db_table}"')
 


### PR DESCRIPTION
This is a less urgent fix than the pipeline as refreshing is currently only done in seqr:
- After reloading clinvar
- After deleting a project