### PR TITLE
chore: Add 'LCL Pellet' to Airtable Mapping.

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -62,6 +62,7 @@ AIRTABLE_TISSUE_TYPE_MAP = {
     'muscle':  'Muscle',
     'airway_cultured_epithelium': 'Nasal Epithelium',
     'brain': 'Brain',
+    'lymphocytes': 'LCL Pellet'
 }
 TISSUE_TYPE_MAP = {
     AIRTABLE_TISSUE_TYPE_MAP[name]: type


### PR DESCRIPTION
This value is missing in the translation layer:


<img width="708" height="252" alt="Screenshot 2026-01-30 at 2 01 25 PM" src="https://github.com/user-attachments/assets/13f81719-469d-4b97-abc2-d14846b14fa9" />

Slack convo for context: 
<img width="982" height="119" alt="Screenshot 2026-01-30 at 2 01 38 PM" src="https://github.com/user-attachments/assets/610320c7-8190-4775-9851-94300d58c162" />
