### PR TITLE
gracefully handle reference data update version check errors

### DIFF
--- a/reference_data/management/commands/update_all_reference_data.py
+++ b/reference_data/management/commands/update_all_reference_data.py
@@ -36,14 +36,21 @@ class Command(BaseCommand):
         parser.add_argument('--gene-symbol-change-dir', help='Directory to upload tracked gene symbol changes')
 
     def handle(self, *args, **options):
+        latest_versions = {}
+        update_failed = []
+        for model in REFERENCE_DATA_MODELS:
+            try:
+                latest_versions[model] = model.get_current_version(**options)
+            except Exception as e:
+                logger.error("unable to get current version for {}: {}".format(model.__name__, e))
+                update_failed.append(model.__name__)
+
         current_versions ={dv.data_model_name: dv for dv in DataVersions.objects.all()}
-        latest_versions = {model: model.get_current_version(**options) for model in REFERENCE_DATA_MODELS}
         to_update = OrderedDict([
             (model, version) for model, version in latest_versions.items()
             if not current_versions.get(model.__name__) or current_versions[model.__name__].version != version
         ])
         updated = []
-        update_failed = []
 
         if GeneInfo in to_update:
             latest_version = to_update.pop(GeneInfo)

--- a/reference_data/management/tests/test_utils.py
+++ b/reference_data/management/tests/test_utils.py
@@ -32,7 +32,8 @@ class ReferenceDataCommandTestCase(AuthenticationTestCase):
         self.mock_get_file_last_modified.return_value = 'Thu, 20 Mar 2025 20:52:24 GMT'
         self.addCleanup(self.mock_get_file_last_modified_patcher.stop)
         self.mock_clingen_version_patcher = mock.patch('reference_data.models.ClinGen.get_current_version')
-        self.mock_clingen_version_patcher.start().return_value = '2025-02-05'
+        self.mock_clingen_version = self.mock_clingen_version_patcher.start()
+        self.mock_clingen_version.return_value = '2025-02-05'
         self.addCleanup(self.mock_clingen_version_patcher.stop)
         self.mock_hpo_version_patcher = mock.patch('reference_data.models.HumanPhenotypeOntology.get_current_version')
         self.mock_hpo_version_patcher.start().return_value = '2025-03-03'

--- a/reference_data/management/tests/update_all_reference_data_tests.py
+++ b/reference_data/management/tests/update_all_reference_data_tests.py
@@ -122,8 +122,12 @@ class UpdateAllReferenceDataTest(BaseUpdateAllReferenceDataTest):
         dbnsfp_version = DataVersions.objects.get(data_model_name='dbNSFPGene')
         dbnsfp_version.version = 'dbNSFP3.2_gene'
         dbnsfp_version.save()
+        self.mock_clingen_version.side_effect = Exception('version check failed')
 
-        call_command('update_all_reference_data')
+        with self.assertRaises(CommandError) as e:
+            call_command('update_all_reference_data')
+
+        self.assertEqual(str(e.exception),'Failed to Update: ClinGen')
 
         self.mock_update_gencode.assert_not_called()
         kwargs = {'gene_ids_to_gene': mock.ANY, 'gene_symbols_to_gene': mock.ANY}
@@ -137,6 +141,10 @@ class UpdateAllReferenceDataTest(BaseUpdateAllReferenceDataTest):
         self.assertEqual(len(self.mock_update_calls[0][1]['gene_symbols_to_gene']), 50)
 
         self.assert_json_logs(user=None, expected=[
+            ('unable to get current version for ClinGen: version check failed', {
+                'severity': 'ERROR',
+                '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
+            }),
             ('Done', None),
             ('Updated: Omim, dbNSFPGene, GenCC', None),
         ])


### PR DESCRIPTION
The update all reference data command is supposed to catch any errors that happen when updating a particular dataset  without disrupting the other dataset's loading, and just report an error about the ones that fail. This generally works, but it turns out if an error occurs when we are trying to get the latest dataset version then the whole command will fail without updating anything. This adds error handling for that case