### PR TITLE
fix encoding for saving tagged prioritized variants

### DIFF
--- a/clickhouse_search/search.py
+++ b/clickhouse_search/search.py
@@ -35,7 +35,7 @@ SELECTED_GENE_FIELD = 'selectedGeneId'
 SELECTED_TRANSCRIPT_FIELD = 'selectedTranscript'
 
 
-def get_clickhouse_variants(families, search, user, genome_version, sort=None, sample_data_by_dataset_type=None, encode_genotypes_json=False):
+def get_clickhouse_variants(families, search, user, genome_version, sort=None, sample_data_by_dataset_type=None):
     inheritance_mode = search.get('inheritance_mode')
     has_comp_het = inheritance_mode in {RECESSIVE, COMPOUND_HET}
     has_x_chrom_comp_het = has_comp_het and _is_x_chrom_only(genome_version, **search)
@@ -94,7 +94,7 @@ def get_clickhouse_variants(families, search, user, genome_version, sort=None, s
                 dataset_results += _evaluate_results(result_q, is_comp_het=True)
 
         if 'samples' not in sample_data:
-            _add_individual_guids(dataset_results, encode_genotypes_json=encode_genotypes_json)
+            _add_individual_guids(dataset_results)
         results += dataset_results
         searched_dataset_types.add(dataset_type)
 
@@ -372,7 +372,7 @@ def _result_as_tuple(results, field_prefix):
     return Tuple(*fields.keys(), output_field=NamedTupleField(list(fields.values())))
 
 
-def _add_individual_guids(results, encode_genotypes_json=False):
+def _add_individual_guids(results):
     families = set()
     for result in results:
         for r in (result if isinstance(result, list) else [result]):
@@ -385,12 +385,12 @@ def _add_individual_guids(results, encode_genotypes_json=False):
     for result in results:
         if isinstance(result, list):
             for variant in result:
-                _set_individual_guids(variant, sample_map, encode_genotypes_json)
+                _set_individual_guids(variant, sample_map)
         else:
-            _set_individual_guids(result, sample_map, encode_genotypes_json)
+            _set_individual_guids(result, sample_map)
 
 
-def _set_individual_guids(result, sample_map, encode_genotypes_json):
+def _set_individual_guids(result, sample_map):
     if 'familyGenotypes' not in result:
         return
     result['familyGuids'] = sorted(result['familyGenotypes'].keys())
@@ -399,10 +399,7 @@ def _set_individual_guids(result, sample_map, encode_genotypes_json):
         for genotype in genotypes:
             individual_guid = sample_map[(family_guid, genotype['sampleId'])]
             individual_genotypes[individual_guid].append({**genotype, 'individualGuid': individual_guid})
-    genotypes = {k: v[0] if len(v) == 1 else v for k, v in individual_genotypes.items()}
-    if encode_genotypes_json:
-        genotypes = _clickhouse_genotypes_json(genotypes)
-    result['genotypes'] = genotypes
+    result['genotypes'] = {k: v[0] if len(v) == 1 else v for k, v in individual_genotypes.items()}
 
 
 def get_sorted_search_results(results, sort, families):

--- a/seqr/management/commands/tag_seqr_prioritized_variants.py
+++ b/seqr/management/commands/tag_seqr_prioritized_variants.py
@@ -4,6 +4,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 from django.db.models.functions import JSONObject
+import json
 
 from clickhouse_search.search import get_clickhouse_variants, ENTRY_CLASS_MAP
 from panelapp.models import PaLocusListGene
@@ -12,6 +13,7 @@ from seqr.models import Project, Family, Individual, Sample, LocusList
 from seqr.utils.communication_utils import send_project_notification
 from seqr.utils.gene_utils import get_genes
 from clickhouse_search.constants import ANY_AFFECTED, HOMOZYGOUS_RECESSIVE, X_LINKED_RECESSIVE_MALE_AFFECTED, DE_NOVO, COMPOUND_HET
+from seqr.views.utils.json_utils import DjangoJSONEncoderWithSets
 from seqr.views.utils.orm_to_json_utils import SEQR_TAG_TYPE
 from seqr.views.utils.variant_utils import bulk_create_tagged_variants, get_saved_variant_annotations
 from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL
@@ -587,7 +589,7 @@ class Command(BaseCommand):
                 dataset_type=dataset_type, genome_version=GENOME_VERSION_GRCh38, primary_id_field='key',
             )
             return {
-                k: {**v, 'dataset_type': dataset_type, **(variants_by_id.get(k[1], {}))}
+                k: {**v, 'dataset_type': dataset_type, **json.loads(json.dumps(variants_by_id.get(k[1], {}), cls=DjangoJSONEncoderWithSets))}
                 for k, v in family_variant_data.items() if k in new_variant_keys
             }
         return wrapped
@@ -629,7 +631,7 @@ class Command(BaseCommand):
     def _execute_search(sample_data_by_dataset_type, search_name, family_variant_data, family_guid_map, **kwargs):
         results = get_clickhouse_variants(
             families=None, search=kwargs, user=None, genome_version=GENOME_VERSION_GRCh38,
-            encode_genotypes_json=True, sample_data_by_dataset_type={
+            sample_data_by_dataset_type={
                 **{dt: None for dt in ENTRY_CLASS_MAP[GENOME_VERSION_GRCh38]}, **sample_data_by_dataset_type,
             },
         )
@@ -639,12 +641,14 @@ class Command(BaseCommand):
                     for variant, support_id in [(result[0], result[1]['key']), (result[1], result[0]['key'])]:
                         variant_data = family_variant_data[(family_guid_map[family_guid], variant['key'])]
                         variant_data.update(variant)
+                        variant_data['genotypes'] = json.loads(json.dumps(variant_data['genotypes'], cls=DjangoJSONEncoderWithSets))
                         variant_data['support_vars'].add(support_id)
                         variant_data['matched_comp_het_searches'].add(search_name)
             else:
                 for family_guid in result.pop('familyGuids'):
                     variant_data = family_variant_data[(family_guid_map[family_guid], result['key'])]
                     variant_data.update(result)
+                    variant_data['genotypes'] = json.loads(json.dumps(variant_data['genotypes'], cls=DjangoJSONEncoderWithSets))
                     variant_data['matched_searches'].add(search_name)
 
         return len(results)


### PR DESCRIPTION
Some changes I made to how encoding new saved before saving them worked in the prioritized tag logic broke things. This overall impacted ~30 variants which were unable to be properly tagged/saved in production