### PR TITLE
fix variant lookup links in vlm

### DIFF
--- a/vlm/match.py
+++ b/vlm/match.py
@@ -63,7 +63,7 @@ def _get_contact_url(chrom: str, pos: int, ref: str, alt: str, genome_build: str
         pos = lifted.position
         genome_build = liftover_genome_build
     genome_build = genome_build.replace('GRCh', '')
-    return f'{SEQR_BASE_URL}summary_data/variant_lookup?genomeVersion={genome_build}&variantId={chrom}-{pos}-{ref}-{alt}'
+    return f'{SEQR_BASE_URL}variant_lookup?genomeVersion={genome_build}&variantId={chrom}-{pos}-{ref}-{alt}'
 
 
 def _parse_match_query(query: dict) -> tuple[str, int, str, str, str]:

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -52,7 +52,7 @@ class VlmTestCase(AioHTTPTestCase):
                         'id': 'TestVLM',
                         'label': 'TestVLM browser',
                     },
-                    'url': 'https://test-seqr.org/summary_data/variant_lookup?genomeVersion=38&variantId=chr1-38724419-T-G',
+                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=chr1-38724419-T-G',
                     'email': None,
                 }
             ],
@@ -124,7 +124,7 @@ class VlmTestCase(AioHTTPTestCase):
                         'id': 'TestVLM',
                         'label': 'TestVLM browser',
                     },
-                    'url': 'https://test-seqr.org/summary_data/variant_lookup?genomeVersion=37&variantId=7-143270172-A-G',
+                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=37&variantId=7-143270172-A-G',
                     'email': None,
                 }
             ],
@@ -195,7 +195,7 @@ class VlmTestCase(AioHTTPTestCase):
                         'id': 'TestVLM',
                         'label': 'TestVLM browser',
                     },
-                    'url': 'https://test-seqr.org/summary_data/variant_lookup?genomeVersion=38&variantId=chr7-143270172-A-G',
+                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=chr7-143270172-A-G',
                     'email': None,
                 }
             ],


### PR DESCRIPTION
when we changed the variant lookup url in https://github.com/broadinstitute/seqr/pull/5350 we did not update the VLM accordingly