### PR TITLE
better error grouping for vlm errors

### DIFF
--- a/seqr/views/apis/variant_search_api_tests.py
+++ b/seqr/views/apis/variant_search_api_tests.py
@@ -310,7 +310,7 @@ class VariantSearchAPITest(AuthenticationTestCase):
         expected_logs = [
             ('VLM match request to Node 1', {'detail': expected_params}),
             ('VLM match request to Node 2', {'detail': expected_params}),
-            (f'VLM match error for Node 2: 400 Client Error: Bad Request for url: {node_2_url}', {
+            (f'VLM Node 2 match error: 400 Client Error: Bad Request for url: {node_2_url}', {
                 'severity': 'ERROR',
                 '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
                 'detail': expected_params,

--- a/seqr/views/utils/vlm_utils.py
+++ b/seqr/views/utils/vlm_utils.py
@@ -50,7 +50,7 @@ def vlm_lookup(user, chrom, pos, ref, alt, genome_version=None, **kwargs):
                 result_id =  parsed_id[0] if len(parsed_id) == 2 else next(iter(results[client_name].keys()))
                 results[client_name][result_id]['counts'][count_type] = result['resultsCount']
         except Exception as e:
-            logger.error(f'VLM match error for {client_name}: {e}', user, detail=params)
+            logger.error(f'VLM {client_name} match error: {e}', user, detail=params)
 
     return results
 


### PR DESCRIPTION
Google error grouping uses the first 3 words to group errors together so all vlm errors for all nodes were grouped together. We had muted this error due to a known issue with MyGene2 which then meant we missed a new error in VariantMatcher. Roordering the message will prevent this in the future