### PR TITLE
fix behavior for callset ac validation

### DIFF
--- a/clickhouse_search/managers.py
+++ b/clickhouse_search/managers.py
@@ -1546,7 +1546,7 @@ class EntriesManager(BaseEntriesManager):
 
     def _filter_frequency(self, entries, frequencies, pathogenicity=None, sample_data=None, **kwargs):
         callset_filter = frequencies.get(self.callset_filter_field) or {}
-        if (not callset_filter.get('ac') or callset_filter['ac'] >= self.MIN_MULTI_FAMILY_SEQR_AC) and (
+        if (not callset_filter.get('ac') or callset_filter['ac'] > self.MIN_MULTI_FAMILY_SEQR_AC) and (
             len(sample_data['sample_type_families']) > 1 or len(next(iter(sample_data['sample_type_families'].values()))) > 1
         ):
             raise InvalidSearchException(


### PR DESCRIPTION
When I moved the validation for minimum seqr AC filter during code cleanup I accidentally changed a `>` to a `>=`:
https://github.com/broadinstitute/seqr/pull/5367/changes#diff-20e96f31f5b1390b1b519bb5fc6cefb42e859489cbc0d4d2f084b80a2ee63342L290

This is causing the tag prioritized variants jobs to fail because they include some searches with a AC filter of the exact threshold