### PR TITLE
error handling when unmapped sample id in no access lookup project

### DIFF
--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -1341,12 +1341,16 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
         no_access_missing_gt_variant = {
             **GRCH37_VARIANT,
             'familyGuids': ['F0_7-143270172-A-G'],
-            'genotypes': {'I1_F0_7-143270172-A-G': GRCH37_VARIANT['genotypes']['I000004_hg00731']},
+            'genotypes': {'I1_F0_7-143270172-A-G': {
+                k: v for k, v in GRCH37_VARIANT['genotypes']['I000004_hg00731'].items()
+                if k not in {'familyGuid', 'individualGuid', 'sampleId'}
+            }}
         }
-        self.maxDiff = None
         self._assert_expected_lookup(
             '7-143270172-A-G', no_access_missing_gt_variant, cache_key, cached_variants=[GRCH37_VARIANT],
-            genome_version='37', expected_individuals=expected_individuals, locusListsByGuid={},
+            genome_version='37', expected_individuals=expected_individuals, locusListsByGuid={}, skip_fields={
+                'variantFunctionalDataByGuid', 'variantNotesByGuid', 'variantTagsByGuid',
+            },
         )
         self.assert_json_logs(self.manager_user, [
             ('Looking up variant 7-143270172-A-G with data type SNV_INDEL', None),

--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -1327,11 +1327,26 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
         ])
 
         self.login_base_user()
+        expected_individuals = {'I1_F0_7-143270172-A-G': {
+            'affected': 'A',
+            'familyGuid': 'F0_7-143270172-A-G',
+            'features': [
+                {'category': 'HP:0000707', 'id': 'HP:0002011', 'label': 'Morphological abnormality of the central nervous system'},
+                {'category': 'HP:0001626', 'id': 'HP:0011675',  'label': 'Arrhythmia'},
+            ],
+            'individualGuid': 'I1_F0_7-143270172-A-G',
+            'sex': 'X0',
+            'vlmContactEmail': 'test@broadinstitute.org,vlm@broadinstitute.org',
+        }}
+        no_access_missing_gt_variant = {
+            **GRCH37_VARIANT,
+            'familyGuids': ['F0_7-143270172-A-G'],
+            'genotypes': {'I1_F0_7-143270172-A-G': GRCH37_VARIANT['genotypes']['I000004_hg00731']},
+        }
         self.maxDiff = None
         self._assert_expected_lookup(
-            '7-143270172-A-G', missing_gt_variant, cache_key, cached_variants=[GRCH37_VARIANT], genome_version='37',
-            project_guids=['R0001_1kg'], family_guids=['F000002_2'],
-            individual_guids=['I000006_hg00733', 'I000005_hg00732', 'I000004_hg00731']
+            '7-143270172-A-G', no_access_missing_gt_variant, cache_key, cached_variants=[GRCH37_VARIANT],
+            genome_version='37', expected_individuals=expected_individuals, locusListsByGuid={},
         )
         self.assert_json_logs(self.manager_user, [
             ('Looking up variant 7-143270172-A-G with data type SNV_INDEL', None),

--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -1326,6 +1326,19 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
             }),
         ])
 
+        self._assert_expected_lookup(
+            '7-143260172-A-G', missing_gt_variant, 'variant_lookup_results__7-143260172-A-G__38',
+            cached_variants=[GRCH37_VARIANT], project_guids=['R0001_1kg'], family_guids=['F000002_2'],
+            individual_guids=['I000006_hg00733', 'I000005_hg00732', 'I000004_hg00731']
+        )
+        self.assert_json_logs(self.manager_user, [
+            ('Looking up variant 7-143260172-A-G with data type SNV_INDEL', None),
+            ('Unable to map sample HG00733 in family F000002_2 to an individual for variant 7-143260172-A-G', {
+                'severity': 'ERROR',
+                '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
+            }),
+        ])
+
     def _assert_expected_lookup(self, variant_id, variant, cache_key, genome_version='38', hom_only=False, affected_only=False, project_guids=None, family_guids=None, individual_guids=None, expected_individuals=None, skip_fields=None, cached_variants=None, additional_variant=None, sample_type=None, **kwargs):
         url = f'{reverse(variant_lookup_handler)}?variantId={variant_id}&genomeVersion={genome_version}'
         if hom_only:

--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -1328,6 +1328,7 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
         self.assert_json_logs(self.manager_user, unmapped_sample_logs)
 
         self.login_base_user()
+        self.reset_logs()
         expected_individuals = {'I1_F0_7-143270172-A-G': {
             'affected': 'A',
             'familyGuid': 'F0_7-143270172-A-G',
@@ -1353,7 +1354,7 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
                 'variantFunctionalDataByGuid', 'variantNotesByGuid', 'variantTagsByGuid',
             },
         )
-        self.assert_json_logs(self.manager_user, unmapped_sample_logs)
+        self.assert_json_logs(self.no_access_user, unmapped_sample_logs)
 
     def _assert_expected_lookup(self, variant_id, variant, cache_key, genome_version='38', hom_only=False, affected_only=False, project_guids=None, family_guids=None, individual_guids=None, expected_individuals=None, skip_fields=None, cached_variants=None, additional_variant=None, sample_type=None, **kwargs):
         url = f'{reverse(variant_lookup_handler)}?variantId={variant_id}&genomeVersion={genome_version}'

--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -1318,13 +1318,14 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
             project_guids=['R0001_1kg'], family_guids=['F000002_2'],
             individual_guids=['I000006_hg00733', 'I000005_hg00732', 'I000004_hg00731']
         )
-        self.assert_json_logs(self.manager_user, [
+        unmapped_sample_logs = [
             ('Looking up variant 7-143270172-A-G with data type SNV_INDEL', None),
             ('Unable to map sample HG00733 in family F000002_2 to an individual for variant 7-143270172-A-G', {
                 'severity': 'ERROR',
                 '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
             }),
-        ])
+        ]
+        self.assert_json_logs(self.manager_user, unmapped_sample_logs)
 
         self.login_base_user()
         expected_individuals = {'I1_F0_7-143270172-A-G': {
@@ -1352,13 +1353,7 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
                 'variantFunctionalDataByGuid', 'variantNotesByGuid', 'variantTagsByGuid',
             },
         )
-        self.assert_json_logs(self.manager_user, [
-            ('Looking up variant 7-143270172-A-G with data type SNV_INDEL', None),
-            ('Unable to map sample HG00733 in family F000002_2 to an individual for variant 7-143270172-A-G', {
-                'severity': 'ERROR',
-                '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
-            }),
-        ])
+        self.assert_json_logs(self.manager_user, unmapped_sample_logs)
 
     def _assert_expected_lookup(self, variant_id, variant, cache_key, genome_version='38', hom_only=False, affected_only=False, project_guids=None, family_guids=None, individual_guids=None, expected_individuals=None, skip_fields=None, cached_variants=None, additional_variant=None, sample_type=None, **kwargs):
         url = f'{reverse(variant_lookup_handler)}?variantId={variant_id}&genomeVersion={genome_version}'

--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -1326,14 +1326,16 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
             }),
         ])
 
+        self.login_base_user()
+        self.maxDiff = None
         self._assert_expected_lookup(
-            '7-143260172-A-G', missing_gt_variant, 'variant_lookup_results__7-143260172-A-G__38',
-            cached_variants=[GRCH37_VARIANT], project_guids=['R0001_1kg'], family_guids=['F000002_2'],
+            '7-143270172-A-G', missing_gt_variant, cache_key, cached_variants=[GRCH37_VARIANT], genome_version='37',
+            project_guids=['R0001_1kg'], family_guids=['F000002_2'],
             individual_guids=['I000006_hg00733', 'I000005_hg00732', 'I000004_hg00731']
         )
         self.assert_json_logs(self.manager_user, [
-            ('Looking up variant 7-143260172-A-G with data type SNV_INDEL', None),
-            ('Unable to map sample HG00733 in family F000002_2 to an individual for variant 7-143260172-A-G', {
+            ('Looking up variant 7-143270172-A-G with data type SNV_INDEL', None),
+            ('Unable to map sample HG00733 in family F000002_2 to an individual for variant 7-143270172-A-G', {
                 'severity': 'ERROR',
                 '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
             }),

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -669,7 +669,7 @@ def _update_lookup_variant(variant, response, individual_guid_map, user):
             individual_key = (genotype.pop('familyGuid'), genotype.pop('sampleId'))
             if individual_key not in individual_summary_map:
                 logger.error(
-                    f'Unable to map sample {genotype["sampleId"]} in family {family_guid} to an individual for variant {variant["variantId"]}',
+                    f'Unable to map sample {individual_key[1]} in family {individual_key[0]} to an individual for variant {variant["variantId"]}',
                     user,
                 )
                 continue

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -666,7 +666,14 @@ def _update_lookup_variant(variant, response, individual_guid_map, user):
             variant['liftedFamilyGuids'][variant['liftedFamilyGuids'].index(unmapped_family_guid)] = family_guid
         individual_guid_map = {}
         for j, genotype in enumerate(genotypes):
-            unmapped_individual_guid, individual = individual_summary_map[(genotype.pop('familyGuid'), genotype.pop('sampleId'))]
+            individual_key = (genotype.pop('familyGuid'), genotype.pop('sampleId'))
+            if individual_key not in individual_summary_map:
+                logger.error(
+                    f'Unable to map sample {genotype["sampleId"]} in family {family_guid} to an individual for variant {variant["variantId"]}',
+                    user,
+                )
+                continue
+            unmapped_individual_guid, individual = individual_summary_map[individual_key]
             if unmapped_individual_guid in individual_guid_map:
                 individual_guid = individual_guid_map[unmapped_individual_guid]
                 variant['genotypes'][individual_guid] = [variant['genotypes'][individual_guid], genotype]


### PR DESCRIPTION
We added explicit error handling for when a sample ID returned from variant lookup does not correspond to a seqr individual ID, but we only added error handling in the case where the user has access to the family and not the case where they do not