### PR TITLE
fix vlm requirements install

### DIFF
--- a/vlm/deploy/Dockerfile
+++ b/vlm/deploy/Dockerfile
@@ -2,12 +2,12 @@ FROM python:3.11-slim-bullseye
 
 LABEL maintainer="Broad TGG"
 
-RUN pip install --no-cache-dir -r vlm/requirements.txt
-
 WORKDIR /vlm
 
 # Application Code
 COPY vlm/ .
+
+RUN pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /
 EXPOSE 7000


### PR DESCRIPTION
Changes to the VLM docker image in the last release caused the build to fail: https://github.com/broadinstitute/seqr/actions/runs/26654831208/job/78562197026