### PR TITLE
sync tag updates to postgres dicts

### DIFF
--- a/reference_data/management/commands/update_all_reference_data.py
+++ b/reference_data/management/commands/update_all_reference_data.py
@@ -2,6 +2,7 @@ import logging
 from collections import OrderedDict
 from django.core.management.base import BaseCommand, CommandError
 
+from clickhouse_search.models.postgres_dicts import GeneIdDict
 from panelapp.models import PanelAppAU, PanelAppUK
 from reference_data.utils.gene_utils import get_genes_by_id_and_symbol
 from reference_data.models import GeneInfo, TranscriptInfo, HumanPhenotypeOntology, RefseqTranscript, GeneConstraint, \
@@ -57,6 +58,8 @@ class Command(BaseCommand):
             data_model_name = GeneInfo.__name__
             self._update_gencode(current_versions.get(data_model_name), options['gene_symbol_change_dir'])
             self._track_success_updates(data_model_name, latest_version, current_versions, updated)
+            GeneIdDict.reload()
+
 
         gene_ids_to_gene, gene_symbols_to_gene = get_genes_by_id_and_symbol() if to_update else (None, None)
         for data_cls, latest_version in to_update.items():

--- a/reference_data/management/tests/update_all_reference_data_tests.py
+++ b/reference_data/management/tests/update_all_reference_data_tests.py
@@ -42,6 +42,7 @@ class BaseUpdateAllReferenceDataTest(ReferenceDataCommandTestCase):
 
 
 class NewDbUpdateAllReferenceDataTest(BaseUpdateAllReferenceDataTest):
+    databases = '__all__'
     fixtures = ['users']
 
     def test_empty_db_update_all_reference_data_command(self):
@@ -78,6 +79,7 @@ class NewDbUpdateAllReferenceDataTest(BaseUpdateAllReferenceDataTest):
 
         self.mock_slack.assert_not_called()
         self.assert_json_logs(user=None, expected=[
+            ('Reloading dictionary seqrdb_gene_ids', None),
             ('unable to update PrimateAI: Primate_AI failed', {
                 'severity': 'ERROR',
                 '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',

--- a/reference_data/management/tests/update_gencode_tests.py
+++ b/reference_data/management/tests/update_gencode_tests.py
@@ -54,6 +54,8 @@ REFSEQ_DATA = [
 
 class UpdateGencodeTest(ReferenceDataCommandTestCase):
 
+    databases = '__all__'
+
     def setUp(self):
         super().setUp()
 
@@ -202,6 +204,7 @@ class UpdateGencodeTest(ReferenceDataCommandTestCase):
             ('Loaded 3 RefseqTranscript records', None),
             ('Skipped 1 records with unrecognized or duplicated transcripts', None),
             ('Updated GeneInfo reference data from version "31" to version "39"', None),
+            ('Reloading dictionary seqrdb_gene_ids', None),
             ('Done', None),
             ('Updated: GeneInfo', None),
         ])

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -5,7 +5,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Count, Max, Q, F
 from django.db.models.fields.files import ImageFieldFile
 
-from clickhouse_search.models.postgres_dicts import IndividualMetadataDict
+from clickhouse_search.models.postgres_dicts import AffectedDict, SexDict, IndividualMetadataDict
 from matchmaker.models import MatchmakerSubmission
 from reference_data.models import Omim
 from seqr.utils.gene_utils import get_genes_for_variant_display
@@ -211,6 +211,8 @@ def delete_families_handler(request, project_guid):
     # delete families
     Family.bulk_delete(request.user, project=project, guid__in=family_guids_to_delete)
 
+    AffectedDict.reload(request.user)
+    SexDict.reload(request.user)
     IndividualMetadataDict.reload(request.user)
 
     # send response

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -211,7 +211,7 @@ def delete_families_handler(request, project_guid):
     # delete families
     Family.bulk_delete(request.user, project=project, guid__in=family_guids_to_delete)
 
-    IndividualMetadataDict.reload()
+    IndividualMetadataDict.reload(request.user)
 
     # send response
     return create_json_response({
@@ -238,7 +238,7 @@ def update_family_fields_handler(request, family_guid):
         'display_name',
     ] + immutable_keys, updated_fields=updated_fields)
     if updated_fields.intersection({'post_discovery_omim_numbers', 'post_discovery_mondo_id', 'analysis_status'}):
-        IndividualMetadataDict.reload()
+        IndividualMetadataDict.reload(request.user)
 
     return create_json_response({
         family.guid: _get_json_for_model(family, user=request.user, process_result=_set_display_name)

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -5,6 +5,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Count, Max, Q, F
 from django.db.models.fields.files import ImageFieldFile
 
+from clickhouse_search.models.postgres_dicts import IndividualMetadataDict
 from matchmaker.models import MatchmakerSubmission
 from reference_data.models import Omim
 from seqr.utils.gene_utils import get_genes_for_variant_display
@@ -210,6 +211,8 @@ def delete_families_handler(request, project_guid):
     # delete families
     Family.bulk_delete(request.user, project=project, guid__in=family_guids_to_delete)
 
+    IndividualMetadataDict.reload()
+
     # send response
     return create_json_response({
         'individualsByGuid': {
@@ -230,9 +233,12 @@ def update_family_fields_handler(request, family_guid):
 
     request_json = json.loads(request.body)
     immutable_keys = [] if external_anvil_project_can_edit(family.project, request.user) else ['family_id']
+    updated_fields = set()
     update_family_from_json(family, request_json, user=request.user, allow_unknown_keys=True, immutable_keys=[
         'display_name',
-    ] + immutable_keys)
+    ] + immutable_keys, updated_fields=updated_fields)
+    if updated_fields.intersection({'post_discovery_omim_numbers', 'post_discovery_mondo_id', 'analysis_status'}):
+        IndividualMetadataDict.reload()
 
     return create_json_response({
         family.guid: _get_json_for_model(family, user=request.user, process_result=_set_display_name)

--- a/seqr/views/apis/family_api_tests.py
+++ b/seqr/views/apis/family_api_tests.py
@@ -456,12 +456,19 @@ class FamilyAPITest(object):
                                     data=json.dumps({'successStoryTypes': ['O', 'D']}))
         self.assertEqual(response.status_code, 403)
 
+        self.reset_logs()
         self.login_analyst_user()
         response = self.client.post(url, content_type='application/json',
                                     data=json.dumps({'successStoryTypes': ['O', 'D']}))
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
         self.assertListEqual(response_json[FAMILY_GUID]['successStoryTypes'], ['O', 'D'])
+        self.assert_json_logs(self.analyst_user, [
+            ('update Family F000001_1', {'dbUpdate': {
+                'dbEntity': 'Family', 'entityId': 'F000001_1', 'updateType': 'update', 'updateFields': ['success_story_types'],
+            }}),
+            (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),
+        ])
 
         self.check_no_analyst_no_access(url, get_response=lambda: self.client.post(
             url, content_type='application/json', data=json.dumps({'successStoryTypes': []})))
@@ -471,6 +478,7 @@ class FamilyAPITest(object):
         url = reverse(update_family_fields_handler, args=[FAMILY_GUID])
         self.check_collaborator_login(url)
 
+        self.reset_logs()
         body = {FAMILY_ID_FIELD: 'new_id', 'description': 'Updated description', 'analysis_status': 'C'}
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 200)
@@ -481,6 +489,14 @@ class FamilyAPITest(object):
         self.assertEqual(response_json[FAMILY_GUID]['analysisStatus'], 'C')
         self.assertEqual(response_json[FAMILY_GUID]['analysisStatusLastModifiedBy'], 'Test Collaborator User')
         self.assertEqual(response_json[FAMILY_GUID]['analysisStatusLastModifiedDate'], '2020-01-01T00:00:00')
+        self.assert_json_logs(self.collaborator_user, [
+            ('update Family F000001_1', {'dbUpdate': {
+                'dbEntity': 'Family', 'entityId': 'F000001_1', 'updateType': 'update',
+                'updateFields': ['analysis_status', 'analysis_status_last_modified_by', 'analysis_status_last_modified_date', 'description'],
+            }}),
+            ('Reloading dictionary seqrdb_individual_metadata_dict', None),
+            (None, {'httpRequest': mock.ANY, 'requestBody': body}),
+        ])
 
         # Do not update audit fields if value does not change
         self.login_manager()

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from django.contrib.auth.models import User
 from django.db.models import prefetch_related_objects
 
+from clickhouse_search.models.postgres_dicts import IndividualMetadataDict, SexDict, AffectedDict
 from reference_data.models import HumanPhenotypeOntology
 from seqr.models import Individual, Family, CAN_VIEW
 from seqr.utils.file_utils import file_iter
@@ -93,6 +94,7 @@ def update_individual_hpo_terms(request, individual_guid):
         for key in feature_fields
     }
     update_individual_from_json(individual, update_json, user=request.user, allow_features_update=True)
+    IndividualMetadataDict.reload()
 
     individual_json = {k: getattr(individual, _to_snake_case(k)) for k in feature_fields}
     add_individual_hpo_details([individual_json])
@@ -218,6 +220,9 @@ def delete_individuals_handler(request, project_guid):
 
     # delete the individuals
     families_with_deleted_individuals = delete_individuals(project, individual_guids_to_delete, request.user)
+    AffectedDict.reload()
+    SexDict.reload()
+    IndividualMetadataDict.reload()
 
     deleted_individuals_by_guid = {
         individual_guid: None for individual_guid in individual_guids_to_delete
@@ -664,6 +669,9 @@ def save_individuals_metadata_table_handler(request, project_guid, upload_file_i
             individual, {k: record[k] for k in INDIVIDUAL_METADATA_FIELDS.keys() if k in record}, user=request.user, allow_features_update=True)
         if record.get(ASSIGNED_ANALYST_COL):
             family_assigned_analysts[record[ASSIGNED_ANALYST_COL]].append(individual.family.id)
+
+    if any(FEATURES_COL in record for record in json_records):
+        IndividualMetadataDict.reload()
 
     response = {
         'individualsByGuid': {

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -94,7 +94,7 @@ def update_individual_hpo_terms(request, individual_guid):
         for key in feature_fields
     }
     update_individual_from_json(individual, update_json, user=request.user, allow_features_update=True)
-    IndividualMetadataDict.reload()
+    IndividualMetadataDict.reload(request.user)
 
     individual_json = {k: getattr(individual, _to_snake_case(k)) for k in feature_fields}
     add_individual_hpo_details([individual_json])
@@ -220,9 +220,9 @@ def delete_individuals_handler(request, project_guid):
 
     # delete the individuals
     families_with_deleted_individuals = delete_individuals(project, individual_guids_to_delete, request.user)
-    AffectedDict.reload()
-    SexDict.reload()
-    IndividualMetadataDict.reload()
+    AffectedDict.reload(request.user)
+    SexDict.reload(request.user)
+    IndividualMetadataDict.reload(request.user)
 
     deleted_individuals_by_guid = {
         individual_guid: None for individual_guid in individual_guids_to_delete
@@ -671,7 +671,7 @@ def save_individuals_metadata_table_handler(request, project_guid, upload_file_i
             family_assigned_analysts[record[ASSIGNED_ANALYST_COL]].append(individual.family.id)
 
     if any(FEATURES_COL in record for record in json_records):
-        IndividualMetadataDict.reload()
+        IndividualMetadataDict.reload(request.user)
 
     response = {
         'individualsByGuid': {

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -627,6 +627,8 @@ class IndividualAPITest(object):
         self.assertEqual(response_json['individualsByGuid']['I000008_na20872']['individualId'], 'NA20872_update')
 
         self._assert_expected_reload_calls(PROJECT_GUID)
+        read_tmp_table_logs = self._read_tmp_table_logs('ffa788c23360f0908f3de16dca799fe1')
+        self.assert_json_logs(None, read_tmp_table_logs)
         self.assert_json_logs(self.manager_user, [
             (mock.ANY, {'dbUpdate': {
                 'dbEntity': 'Family', 'entityId': mock.ANY, 'updateFields': ['family_id', 'project'], 'updateType': 'create',
@@ -653,7 +655,7 @@ class IndividualAPITest(object):
             ('Triggered Rebuild Gt Stats', {'detail': {'project_guids': ['R0001_1kg']}}),
             ('Reloading dictionary seqrdb_sex_dict', None),
             ('Reloading dictionary seqrdb_individual_metadata_dict', None),
-        ])
+        ], offset=len(read_tmp_table_logs))
 
         # Test PM permission
         receive_url = reverse(receive_individuals_table_handler, args=[PM_REQUIRED_PROJECT_GUID])
@@ -675,6 +677,10 @@ class IndividualAPITest(object):
     def _assert_expected_reload_calls(self, project_guid):
         self.assertEqual(len(responses.calls), 1)
         self.assertDictEqual(json.loads(responses.calls[0].request.body), {'project_guids': [project_guid]})
+
+    @staticmethod
+    def _read_tmp_table_logs(file_name):
+        return []
 
     @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP', 'project-managers')
     @mock.patch('seqr.views.utils.pedigree_info_utils.NO_VALIDATE_MANIFEST_PROJECT_CATEGORIES')
@@ -1096,12 +1102,15 @@ class IndividualAPITest(object):
         f = SimpleUploadedFile('updates.csv', "{}\n{}".format(header, '\n'.join(rows)).encode('utf-8'))
         response = self.client.post(url, data={'f': f})
         self._is_expected_individuals_metadata_upload(response, expected_families=True, has_non_hpo_update=True)
+
+        read_tmp_table_logs = self._read_tmp_table_logs('6aea3d1f1bfc295340aa504370102fd5')
+        offset = 2 if read_tmp_table_logs else 1
+        self.assert_json_logs(None, read_tmp_table_logs, offset=offset)
         self.assert_json_logs(self.collaborator_user, [
-            (None, {'httpRequest': mock.ANY}),
             ('update Individual I000002_na19678', {'dbUpdate': mock.ANY}),
             ('update Individual I000001_na19675', {'dbUpdate': mock.ANY}),
             ('Reloading dictionary seqrdb_individual_metadata_dict', None),
-        ])
+        ], offset=offset+len(read_tmp_table_logs))
 
     def test_individuals_metadata_hpo_term_number_table_handler(self):
         url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])
@@ -1518,3 +1527,10 @@ class AnvilIndividualAPITest(AnvilAuthenticationTestCase, IndividualAPITest):
         else:
             self.mock_subprocess.stdout.__iter__.return_value = self.gs_files[file_name]
         return self.mock_subprocess
+
+    @staticmethod
+    def _read_tmp_table_logs(file_name):
+        return [
+            (f'==> gsutil ls gs://seqr-scratch-temp/temp_upload_{file_name}.json.gz', None),
+            (f'==> gsutil cat gs://seqr-scratch-temp/temp_upload_{file_name}.json.gz | gunzip -c -q - ', None),
+        ]

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -150,6 +150,7 @@ class IndividualAPITest(object):
         edit_individuals_url = reverse(update_individual_hpo_terms, args=[INDIVIDUAL_UPDATE_GUID])
         self.check_manager_login(edit_individuals_url)
 
+        self.reset_logs()
         response = self.client.post(edit_individuals_url, content_type='application/json',
                                     data=json.dumps(INDIVIDUAL_UPDATE_DATA))
 
@@ -174,6 +175,11 @@ class IndividualAPITest(object):
         self.assertListEqual(Individual.objects.get(guid=INDIVIDUAL_UPDATE_GUID).features, [
             {'id': 'HP:0002011', 'qualifiers': [{'type': 'onset', 'label': 'congenital'}]},
             {'id': 'HP:0011675', 'notes': 'A new term'},
+        ])
+
+        self.assert_json_logs(self.manager_user, [
+            ('update Individual I000007_na20870', {'dbUpdate': mock.ANY}),
+            ('Reloading dictionary seqrdb_individual_metadata_dict', None),
         ])
 
     @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP')
@@ -378,6 +384,7 @@ class IndividualAPITest(object):
             dataset.active_individuals.set(set())
 
         # send valid requests
+        self.reset_logs()
         response = self.client.post(individuals_url, content_type='application/json', data=json.dumps({
             'individuals': [INDIVIDUAL_IDS_UPDATE_DATA]
         }))
@@ -392,6 +399,14 @@ class IndividualAPITest(object):
         self.assertFalse('I000002_na19678' in response_json['familiesByGuid']['F000001_1']['individualGuids'])
         self.assertIsNone(response_json['familiesByGuid']['F000001_1']['pedigreeImage'])
         self.assertFalse(Dataset.objects.filter(guid='S000130_na19678').exists())
+        self.assert_json_logs(self.manager_user, [
+            ('delete Dataset S000130_na19678', {'dbUpdate': mock.ANY}),
+            ('delete 1 Individuals', {'dbUpdate': mock.ANY}),
+            ('update 1 Familys', {'dbUpdate': mock.ANY}),
+            ('Reloading dictionary seqrdb_affected_status_dict', None),
+            ('Reloading dictionary seqrdb_sex_dict', None),
+            ('Reloading dictionary seqrdb_individual_metadata_dict', None),
+        ])
 
         # Test PM permission
         pm_required_delete_individuals_url = reverse(delete_individuals_handler, args=[PM_REQUIRED_PROJECT_GUID])
@@ -577,6 +592,7 @@ class IndividualAPITest(object):
 
         url = reverse(save_individuals_table_handler, args=[PROJECT_GUID, response_json['uploadedFileId']])
 
+        self.reset_logs()
         response = self.client.post(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
@@ -611,6 +627,33 @@ class IndividualAPITest(object):
         self.assertEqual(response_json['individualsByGuid']['I000008_na20872']['individualId'], 'NA20872_update')
 
         self._assert_expected_reload_calls(PROJECT_GUID)
+        self.assert_json_logs(self.manager_user, [
+            (mock.ANY, {'dbUpdate': {
+                'dbEntity': 'Family', 'entityId': mock.ANY, 'updateFields': ['family_id', 'project'], 'updateType': 'create',
+            }}),
+            ('update Individual I000001_na19675', {'dbUpdate': mock.ANY}),
+            ('update Individual I000002_na19678', {'dbUpdate': mock.ANY}),
+            ('update Individual I000008_na20872', {'dbUpdate': mock.ANY}),
+            (mock.ANY, {'dbUpdate': {
+                'dbEntity': 'Individual', 'entityId': mock.ANY, 'updateType': 'create', 'updateFields': [
+                    'affected', 'case_review_status', 'family', 'individual_id',
+                ],
+            }}),
+            (mock.ANY, {'dbUpdate': {
+                'dbEntity': 'FamilyNote', 'entityId': mock.ANY, 'updateType': 'create', 'updateFields': [
+                    'family', 'note', 'note_type',
+                ],
+            }}),
+            (mock.ANY, {'dbUpdate': {
+                'dbEntity': 'Individual', 'entityId': mock.ANY, 'updateType': 'update', 'updateFields': ['sex'],
+            }}),
+            ('update 3 Familys', {'dbUpdate': mock.ANY}),
+            ('Reloading dictionary seqrdb_affected_status_dict', None),
+            ('Triggering rebuild_gt_stats for R0001_1kg', None),
+            ('Triggered Rebuild Gt Stats', {'detail': {'project_guids': ['R0001_1kg']}}),
+            ('Reloading dictionary seqrdb_sex_dict', None),
+            ('Reloading dictionary seqrdb_individual_metadata_dict', None),
+        ])
 
         # Test PM permission
         receive_url = reverse(receive_individuals_table_handler, args=[PM_REQUIRED_PROJECT_GUID])
@@ -1044,6 +1087,7 @@ class IndividualAPITest(object):
             ]})
 
         # send valid request
+        self.reset_logs()
         header = f'family_id,{header}'
         rows[0] = '1,NA19678,,,,,false,,,,,'
         rows[1] = f'1,{rows[1]}'
@@ -1052,6 +1096,12 @@ class IndividualAPITest(object):
         f = SimpleUploadedFile('updates.csv', "{}\n{}".format(header, '\n'.join(rows)).encode('utf-8'))
         response = self.client.post(url, data={'f': f})
         self._is_expected_individuals_metadata_upload(response, expected_families=True, has_non_hpo_update=True)
+        self.assert_json_logs(self.collaborator_user, [
+            (None, {'httpRequest': mock.ANY}),
+            ('update Individual I000002_na19678', {'dbUpdate': mock.ANY}),
+            ('update Individual I000001_na19675', {'dbUpdate': mock.ANY}),
+            ('Reloading dictionary seqrdb_individual_metadata_dict', None),
+        ])
 
     def test_individuals_metadata_hpo_term_number_table_handler(self):
         url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -82,7 +82,7 @@ def update_project_handler(request, project_guid):
     check_project_permissions(project, request.user, can_edit=True)
 
     request_json = json.loads(request.body)
-    updated_fields = None
+    updated_fields = set()
     consent_code = request_json.get('consentCode')
     if consent_code and consent_code != project.consent_code:
         if not user_is_pm(request.user):

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -7,7 +7,7 @@ from django.db.models.functions import JSONObject, TruncDate
 from django.utils import timezone
 from notifications.models import Notification
 
-from clickhouse_search.models.postgres_dicts import IndividualMetadataDict
+from clickhouse_search.models.postgres_dicts import AffectedDict, SexDict, IndividualMetadataDict
 from matchmaker.models import MatchmakerSubmission
 from seqr.models import Project, Family, Individual, Dataset, RnaSample, FamilyNote, PhenotypePrioritization, CAN_EDIT
 from seqr.utils.file_utils import file_iter
@@ -60,7 +60,7 @@ def create_project_handler(request):
         project_args['is_mme_enabled'] = False
 
     project = create_model_from_json(Project, project_args, user=request.user)
-    IndividualMetadataDict.reload()
+    IndividualMetadataDict.reload(request.user)
 
     return create_json_response({
         'projectsByGuid': {
@@ -92,7 +92,7 @@ def update_project_handler(request, project_guid):
 
     update_project_from_json(project, request_json, request.user, allow_unknown_keys=True, updated_fields=updated_fields)
     if 'restrict_sharing' in updated_fields or 'vlm_contact_email' in updated_fields:
-        IndividualMetadataDict.reload()
+        IndividualMetadataDict.reload(request.user)
 
     return create_json_response({
         'projectsByGuid': {
@@ -382,7 +382,9 @@ def _delete_project(project_guid, user):
 
     project.delete_model(user, user_can_delete=True)
 
-    IndividualMetadataDict.reload()
+    AffectedDict.reload(user)
+    SexDict.reload(user)
+    IndividualMetadataDict.reload(user)
 
     if anvil_enabled() and not is_internal_anvil_project(project):
         AirtableSession(user, base=AirtableSession.ANVIL_BASE).safe_patch_records(

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -7,6 +7,7 @@ from django.db.models.functions import JSONObject, TruncDate
 from django.utils import timezone
 from notifications.models import Notification
 
+from clickhouse_search.models.postgres_dicts import IndividualMetadataDict
 from matchmaker.models import MatchmakerSubmission
 from seqr.models import Project, Family, Individual, Dataset, RnaSample, FamilyNote, PhenotypePrioritization, CAN_EDIT
 from seqr.utils.file_utils import file_iter
@@ -59,6 +60,7 @@ def create_project_handler(request):
         project_args['is_mme_enabled'] = False
 
     project = create_model_from_json(Project, project_args, user=request.user)
+    IndividualMetadataDict.reload()
 
     return create_json_response({
         'projectsByGuid': {
@@ -89,6 +91,8 @@ def update_project_handler(request, project_guid):
         updated_fields = {'consent_code'}
 
     update_project_from_json(project, request_json, request.user, allow_unknown_keys=True, updated_fields=updated_fields)
+    if 'restrict_sharing' in updated_fields or 'vlm_contact_email' in updated_fields:
+        IndividualMetadataDict.reload()
 
     return create_json_response({
         'projectsByGuid': {
@@ -377,6 +381,8 @@ def _delete_project(project_guid, user):
     Family.bulk_delete(user, project=project)
 
     project.delete_model(user, user_can_delete=True)
+
+    IndividualMetadataDict.reload()
 
     if anvil_enabled() and not is_internal_anvil_project(project):
         AirtableSession(user, base=AirtableSession.ANVIL_BASE).safe_patch_records(

--- a/seqr/views/apis/project_api_tests.py
+++ b/seqr/views/apis/project_api_tests.py
@@ -204,6 +204,7 @@ class ProjectAPITest(object):
         self.assertEqual(project.genome_version, '37')
         self.assertEqual(project.consent_code, 'H')
 
+        self.reset_logs()
         response = self.client.post(update_project_url, content_type='application/json', data=json.dumps(
             {'description': 'updated project description', 'restrictSharing': True, 'genomeVersion': '38', 'workspaceName': 'test update name'}
         ))
@@ -218,6 +219,14 @@ class ProjectAPITest(object):
         self.assertEqual(updated_project.description, 'updated project description')
         self.assertEqual(updated_project.genome_version, '37')
         self.assertEqual(updated_project.workspace_name, expected_workspace_name)
+        self.assert_json_logs(self.manager_user, [
+            ('update Project R0001_1kg', {'dbUpdate': {
+                'dbEntity': 'Project', 'entityId': 'R0001_1kg', 'updateType': 'update',
+                'updateFields': ['description', 'restrict_sharing'],
+            }}),
+            ('Reloading dictionary seqrdb_individual_metadata_dict', None),
+            (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),
+        ])
 
         # test consent code
         response = self.client.post(update_project_url, content_type='application/json', data=json.dumps(
@@ -225,12 +234,19 @@ class ProjectAPITest(object):
         ))
         self.assertEqual(response.status_code, 403)
         self.login_pm_user()
+        self.reset_logs()
         response = self.client.post(update_project_url, content_type='application/json', data=json.dumps(
             {'consentCode': 'G'}
         ))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['projectsByGuid'][PROJECT_GUID]['consentCode'], 'G')
         self.assertEqual(Project.objects.get(guid=PROJECT_GUID).consent_code, 'G')
+        self.assert_json_logs(self.pm_user, [
+            ('update Project R0001_1kg', {'dbUpdate': {
+                'dbEntity': 'Project', 'entityId': 'R0001_1kg', 'updateType': 'update', 'updateFields': ['consent_code'],
+            }}),
+            (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),
+        ])
 
     @mock.patch('seqr.views.utils.permissions_utils.PM_USER_GROUP', None)
     def test_create_project_no_pm(self):

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -3,6 +3,7 @@ import json
 
 from django.db.models import Q
 
+from clickhouse_search.models.postgres_dicts import DiscoveryVariantDict, ExcludedVariantDict
 from seqr.models import SavedVariant, VariantTagType, VariantTag, VariantNote, VariantFunctionalData,\
     Family, GeneNote, Project, Dataset
 from seqr.utils.xpos_utils import get_xpos
@@ -13,7 +14,7 @@ from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_
     get_json_for_saved_variants_child_entities, get_json_for_gene_notes_by_gene_id, STRUCTURED_METADATA_TAG_TYPES
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
     login_and_policies_required
-from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json
+from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json, DISCOVERY_CATEGORY
 
 
 logger = logging.getLogger(__name__)
@@ -274,9 +275,9 @@ def _update_variant_tag_models(request, variant_guids, tag_key, model_cls, get_t
 
     tag_type = tag_key.lower().rstrip('s')
     updated_data = request_json.get(tag_key, [])
-    deleted_guids = _delete_removed_tags(saved_variants, all_variant_guids, updated_data, request.user, tag_type, protected_tag_types)
+    deleted_guids, has_discovery_update, has_excluded_update = _delete_removed_tags(saved_variants, all_variant_guids, updated_data, request.user, tag_type, protected_tag_types)
 
-    _update_tags(saved_variants, request_json, request.user, tag_key, model_cls, get_tag_create_data)
+    _update_tags(saved_variants, request_json, request.user, tag_key, model_cls, get_tag_create_data, has_discovery_update=has_discovery_update, has_excluded_update=has_excluded_update)
 
     saved_variant_id_map = {sv.id: sv.guid for sv in saved_variants}
     tags, variant_tag_map = get_json_for_saved_variants_child_entities(model_cls, saved_variant_id_map)
@@ -311,15 +312,18 @@ def _delete_removed_tags(saved_variants, all_variant_guids, tag_updates, user, t
     remove_tags = tag_set.exclude(guid__in=existing_tag_guids)
     if protected_tag_types:
         remove_tags = remove_tags.exclude(variant_tag_type__name__in=protected_tag_types)
+    track_updates = tag_type == 'tag'
+    has_discovery_update = remove_tags.filter(variant_tag_type__category=DISCOVERY_CATEGORY).exists() if track_updates else False
+    has_excluded_update = remove_tags.filter(variant_tag_type__name='Excluded').exists() if track_updates else False
     for tag in remove_tags:
         tag_variant_guids = {sv.guid for sv in tag.saved_variants.all()}
         if tag_variant_guids == all_variant_guids:
             deleted_tag_guids.append(tag.guid)
             tag.delete_model(user, user_can_delete=True)
-    return deleted_tag_guids
+    return deleted_tag_guids, has_discovery_update, has_excluded_update
 
 
-def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=VariantTag, get_tag_create_data=_get_tag_type_create_data):
+def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=VariantTag, get_tag_create_data=_get_tag_type_create_data, has_discovery_update=False, has_excluded_update=False):
     tags = tags_json.get(tag_key, [])
     for tag in tags:
         if tag.get('tagGuid'):
@@ -327,12 +331,22 @@ def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=Vari
             update_model_from_json(model, tag, user=user, allow_unknown_keys=True)
         else:
             create_data = get_tag_create_data(tag, saved_variants=saved_variants)
+            if 'variant_tag_type' in create_data:
+                if create_data['variant_tag_type'].category == DISCOVERY_CATEGORY:
+                    has_discovery_update = True
+                elif create_data['variant_tag_type'].name == 'Excluded':
+                    has_excluded_update = True
             create_data.update({
                 'metadata': tag.get('metadata'),
                 'search_hash': tags_json.get('searchHash'),
             })
             model = create_model_from_json(model_cls, create_data, user)
             model.saved_variants.set(saved_variants)
+
+    if has_discovery_update:
+        DiscoveryVariantDict.reload()
+    if has_excluded_update:
+        ExcludedVariantDict.reload()
 
 
 @login_and_policies_required

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -344,9 +344,9 @@ def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=Vari
             model.saved_variants.set(saved_variants)
 
     if has_discovery_update:
-        DiscoveryVariantDict.reload()
+        DiscoveryVariantDict.reload(user)
     if has_excluded_update:
-        ExcludedVariantDict.reload()
+        ExcludedVariantDict.reload(user)
 
 
 @login_and_policies_required

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -313,11 +313,16 @@ def _delete_removed_tags(saved_variants, all_variant_guids, tag_updates, user, t
     if protected_tag_types:
         remove_tags = remove_tags.exclude(variant_tag_type__name__in=protected_tag_types)
     track_updates = tag_type == 'tag'
-    has_discovery_update = remove_tags.filter(variant_tag_type__category=DISCOVERY_CATEGORY).exists() if track_updates else False
-    has_excluded_update = remove_tags.filter(variant_tag_type__name='Excluded').exists() if track_updates else False
+    has_discovery_update = False
+    has_excluded_update = False
     for tag in remove_tags:
         tag_variant_guids = {sv.guid for sv in tag.saved_variants.all()}
         if tag_variant_guids == all_variant_guids:
+            if track_updates:
+                if tag.variant_tag_type.category == DISCOVERY_CATEGORY:
+                    has_discovery_update = True
+                elif tag.variant_tag_type.name == 'Excluded':
+                    has_excluded_update = True
             deleted_tag_guids.append(tag.guid)
             tag.delete_model(user, user_can_delete=True)
     return deleted_tag_guids, has_discovery_update, has_excluded_update

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -949,6 +949,7 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         update_variant_tags_url = reverse(update_variant_tags_handler, args=[VARIANT_GUID])
         self.check_collaborator_login(update_variant_tags_url, request_data={'familyGuid': 'F000001_1'})
 
+        self.reset_logs()
         review_guid = 'VT1708633_2103343353_r0390_100'
         response = self.client.post(update_variant_tags_url, content_type='application/json', data=json.dumps({
             'tags': [
@@ -971,8 +972,19 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         self.assertSetEqual(
             {"Review", "Excluded"}, {vt.variant_tag_type.name for vt in
                                      VariantTag.objects.filter(saved_variants__guid__contains=VARIANT_GUID)})
+        self.assert_json_logs(self.collaborator_user, [
+            ('delete VariantTag VT1726961_2103343353_r0390_100', {'dbUpdate': mock.ANY}),
+            ('update VariantTag VT1708633_2103343353_r0390_100', {'dbUpdate': mock.ANY}),
+            (mock.ANY, {'dbUpdate': {'dbEntity': 'VariantTag', 'entityId': mock.ANY, 'updateType': 'create', 'updateFields': [
+                'metadata', 'search_hash', 'variant_tag_type',
+            ]}}),
+            ('Reloading dictionary seqrdb_discovery_variant_dict', None),
+            ('Reloading dictionary seqrdb_excluded_variant_dict', None),
+            (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),
+        ])
 
         # test delete all - with MME submission
+        self.reset_logs()
         response = self.client.post(update_variant_tags_url, content_type='application/json', data=json.dumps({
             'tags': [],
             'familyGuid': 'F000001_1'
@@ -984,6 +996,12 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         })
         self.assertEqual(VariantTag.objects.filter(saved_variants__guid__contains=VARIANT_GUID).count(), 0)
         self.assertEqual(SavedVariant.objects.filter(guid=VARIANT_GUID).count(), 1)
+        self.assert_json_logs(self.collaborator_user, [
+            ('delete VariantTag VT1708633_2103343353_r0390_100', {'dbUpdate': mock.ANY}),
+            (mock.ANY, {'dbUpdate': {'dbEntity': 'VariantTag', 'entityId': mock.ANY, 'updateType': 'delete'}}),
+            ('Reloading dictionary seqrdb_excluded_variant_dict', None),
+            (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),
+        ])
 
         # test delete all - no MME submission
         update_no_submission_variant_tags_url = reverse(update_variant_tags_handler, args=[COMPOUND_HET_1_GUID])
@@ -1048,6 +1066,7 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
             update_variant_tags_handler, args=[','.join([COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID])])
         self.check_collaborator_login(update_variant_tags_url, request_data={'familyGuid': 'F000001_1'})
 
+        self.reset_logs()
         response = self.client.post(update_variant_tags_url, content_type='application/json', data=json.dumps({
             'tags': [{'name': 'Review'}, {'name': 'Excluded'}],
             'familyGuid': 'F000001_1'
@@ -1071,6 +1090,17 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
             {"Review", "Excluded"},
             {vt.variant_tag_type.name for vt in VariantTag.objects.filter(
                 saved_variants__guid__in=[COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID])})
+
+        self.assert_json_logs(self.collaborator_user, [
+            (mock.ANY, {'dbUpdate': {'dbEntity': 'VariantTag', 'entityId': mock.ANY, 'updateType': 'create', 'updateFields': [
+                 'metadata', 'search_hash', 'variant_tag_type',
+             ]}}),
+            (mock.ANY, {'dbUpdate': {'dbEntity': 'VariantTag', 'entityId': mock.ANY, 'updateType': 'create', 'updateFields': [
+                 'metadata', 'search_hash', 'variant_tag_type',
+             ]}}),
+            ('Reloading dictionary seqrdb_excluded_variant_dict', None),
+            (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),
+        ])
 
         invalid_url = reverse(update_variant_tags_handler, args=['not_variant,{}'.format(COMPOUND_HET_1_GUID)])
         response = self.client.post(invalid_url, content_type='application/json', data=json.dumps({

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -3,15 +3,15 @@ import mock
 
 from django.urls.base import reverse
 
-from clickhouse_search.models.reference_data_models import DbnsfpGRCh37SnvIndelMv, DbnsfpGRCh37SnvIndelDict
+from clickhouse_search.all_search_tests import ClickhouseSearchTestCase
 from seqr.models import SavedVariant, VariantNote, VariantTag, VariantFunctionalData, Project
 from seqr.views.apis.saved_variant_api import saved_variant_data, create_variant_note_handler, create_saved_variant_handler, \
     update_variant_note_handler, delete_variant_note_handler, update_variant_tags_handler, create_manual_saved_variant_handler, \
     update_variant_main_transcript, update_variant_functional_data_handler, update_variant_acmg_classification_handler
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants
-from seqr.views.utils.test_utils import AuthenticationTestCase, SAVED_VARIANT_DETAIL_FIELDS, TAG_FIELDS, GENE_VARIANT_FIELDS, \
+from seqr.views.utils.test_utils import SAVED_VARIANT_DETAIL_FIELDS, TAG_FIELDS, GENE_VARIANT_FIELDS, \
     TAG_TYPE_FIELDS, LOCUS_LIST_FIELDS, PA_LOCUS_LIST_FIELDS, FAMILY_FIELDS, INDIVIDUAL_FIELDS, IGV_SAMPLE_FIELDS, \
-    FAMILY_NOTE_FIELDS, MATCHMAKER_SUBMISSION_FIELDS, SAVED_VARIANT_FIELDS, AnvilAuthenticationTestCase
+    FAMILY_NOTE_FIELDS, MATCHMAKER_SUBMISSION_FIELDS, SAVED_VARIANT_FIELDS
 
 
 PROJECT_GUID = 'R0001_1kg'
@@ -144,10 +144,13 @@ CREATE_VARIANT_JSON = {
 }
 
 
-class SavedVariantAPITest(object):
+class SavedVariantAPITest(ClickhouseSearchTestCase):
+    fixtures = ['users', 'social_auth', '1kg_project', 'reference_data', 'clickhouse_discovery_variants', 'clickhouse_saved_variants']
 
     @mock.patch('seqr.views.utils.variant_utils.OMIM_GENOME_VERSION', '37')
     def test_saved_variant_data(self):
+        Project.objects.filter(guid__in=[PROJECT_GUID, 'R0003_test']).update(genome_version='37')
+
         url = reverse(saved_variant_data, args=[PROJECT_GUID])
         self.check_collaborator_login(url)
 
@@ -378,6 +381,17 @@ class SavedVariantAPITest(object):
             *variant_fields, *SAVED_VARIANT_DETAIL_FIELDS, 'discoveryTags', 'noAccessDiscoveryFamilies', 'screenRegionType', 'sortedRegulatoryFeatureConsequences', 'sortedMotifFeatureConsequences',
         })
 
+        self.mock_list_workspaces.assert_called_with(self.analyst_user)
+        self.mock_get_ws_access_level.assert_any_call(
+            mock.ANY, 'ext-data', 'empty')
+        self.mock_get_ws_access_level.assert_called_with(
+            mock.ANY, 'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 15)
+        self.mock_get_groups.assert_called_with(self.collaborator_user)
+        self.assertEqual(self.mock_get_groups.call_count, 1)
+        self.mock_get_ws_acl.assert_not_called()
+        self.mock_get_group_members.assert_not_called()
+
     def test_create_saved_variant(self):
         create_saved_variant_url = reverse(create_saved_variant_handler)
         self.check_collaborator_login(create_saved_variant_url, request_data={'familyGuid': 'F000001_1'})
@@ -429,6 +443,8 @@ class SavedVariantAPITest(object):
             create_variant_request_body))
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(list(response.json()['savedVariantsByGuid'].keys()), [variant_guid])
+
+        self.assert_no_list_ws_has_al(3)
 
     def _assert_created_variant(self, saved_variant, variant_json, gene_ids=None, dataset_type='SNV_INDEL', sv_type=None, main_transcript=None):
         for field in ['xpos', 'ref', 'alt', 'key']:
@@ -511,6 +527,8 @@ class SavedVariantAPITest(object):
         self.assertDictEqual(response_json['variantTagsByGuid'], {})
         self.assertDictEqual(response_json['variantFunctionalDataByGuid'], {})
 
+        self.assert_no_list_ws_has_al(2)
+
     def test_create_saved_compound_hets(self):
         create_saved_compound_hets_url = reverse(create_saved_variant_handler)
         self.check_collaborator_login(create_saved_compound_hets_url, request_data={'familyGuid': 'F000001_1'})
@@ -568,6 +586,8 @@ class SavedVariantAPITest(object):
             saved_variants__guid__contains=new_compound_het_3_guid)])
         self.assertListEqual(["Review"], [vt.variant_tag_type.name for vt in VariantTag.objects.filter(
             saved_variants__guid__contains=new_compound_het_4_guid)])
+
+        self.assert_no_list_ws_has_al(2)
 
     def test_create_manual_variant(self):
         create_saved_variant_url = reverse(create_manual_saved_variant_handler, args=['F000001_1'])
@@ -766,6 +786,8 @@ class SavedVariantAPITest(object):
         new_variant_note = VariantNote.objects.filter(guid=updated_note_response['noteGuid'])
         self.assertEqual(len(new_variant_note), 0)
 
+        self.assert_no_list_ws_has_al(8)
+
     def test_create_partially_saved_compound_het_variant_note(self):
         # compound het 5 is not saved, whereas compound het 1 is saved
         create_saved_variant_url = reverse(create_saved_variant_handler)
@@ -811,6 +833,8 @@ class SavedVariantAPITest(object):
         self.assertEqual(
             'one_saved_one_not_saved_compount_hets_note', response_json['variantNotesByGuid'][note_guids[0]]['note'],
         )
+
+        self.assert_no_list_ws_has_al(2)
 
     def test_create_update_and_delete_compound_hets_variant_note(self):
         # send valid request to create variant_note for compound hets
@@ -916,6 +940,8 @@ class SavedVariantAPITest(object):
         variants = SavedVariant.objects.filter(guid__in=[COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID])
         self.assertEqual(len(variants), 0)
 
+        self.assert_no_list_ws_has_al(7)
+
     def test_update_variant_tags(self):
         variant_tags = VariantTag.objects.filter(saved_variants__guid__contains=VARIANT_GUID)
         self.assertSetEqual({"Review", "Tier 1 - Novel gene and phenotype"}, {vt.variant_tag_type.name for vt in variant_tags})
@@ -972,6 +998,8 @@ class SavedVariantAPITest(object):
         self.assertEqual(VariantTag.objects.filter(saved_variants__guid__contains=COMPOUND_HET_1_GUID).count(), 0)
         self.assertEqual(SavedVariant.objects.filter(guid=COMPOUND_HET_1_GUID).count(), 0)
 
+        self.assert_no_list_ws_has_al(4)
+
     def test_update_variant_functional_data(self):
         variant_functional_data = VariantFunctionalData.objects.filter(saved_variants__guid__contains=VARIANT_GUID)
         self.assertSetEqual(
@@ -1009,6 +1037,8 @@ class SavedVariantAPITest(object):
             {"Biochemical Function", "Bonferroni corrected p-value"},
             {vt.functional_data_tag for vt in variant_functional_data})
         self.assertSetEqual({"An updated note", "0.05"}, {vt.metadata for vt in variant_functional_data})
+
+        self.assert_no_list_ws_has_al(2)
 
     def test_update_compound_hets_variant_tags(self):
         variant_tags = VariantTag.objects.filter(saved_variants__guid__in=[COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID])
@@ -1049,6 +1079,8 @@ class SavedVariantAPITest(object):
         }))
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'error': 'Unable to find the following variant(s): not_variant'})
+
+        self.assert_no_list_ws_has_al(3)
 
     def test_update_compound_hets_variant_functional_data(self):
         variant_functional_data = VariantFunctionalData.objects.filter(
@@ -1095,6 +1127,8 @@ class SavedVariantAPITest(object):
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'error': 'Unable to find the following variant(s): not_variant'})
 
+        self.assert_no_list_ws_has_al(3)
+
     def test_update_variant_main_transcript(self):
         transcript_id = 'ENST00000438943'
         update_main_transcript_url = reverse(update_variant_main_transcript, args=[VARIANT_GUID, transcript_id])
@@ -1110,6 +1144,8 @@ class SavedVariantAPITest(object):
         self.assertEqual(saved_variants.first().selected_main_transcript_id, transcript_id)
         self.assertDictEqual(saved_variants.first().main_transcript, transcript)
         self.assertEqual(get_json_for_saved_variants(saved_variants)[0]['selectedMainTranscriptId'], transcript_id)
+
+        self.assert_no_list_ws_has_al(2)
 
     def test_update_variant_acmg_classification(self):
         update_variant_acmg_classification_url = reverse(update_variant_acmg_classification_handler, args=[VARIANT_GUID])
@@ -1129,87 +1165,11 @@ class SavedVariantAPITest(object):
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {'savedVariantsByGuid': {VARIANT_GUID: {'acmgClassification': variant['variant']['acmgClassification']}}})
 
+        self.assert_no_list_ws_has_al(2)
 
-# Tests for AnVIL access disabled
-class LocalSavedVariantAPITest(AuthenticationTestCase, SavedVariantAPITest):
-    fixtures = ['users', '1kg_project', 'reference_data', 'clickhouse_discovery_variants', 'clickhouse_saved_variants']
-
-
-def assert_no_list_ws_has_al(self, acl_call_count):
-    self.mock_list_workspaces.assert_not_called()
-    self.mock_get_ws_access_level.assert_called_with(mock.ANY,
-        'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-    self.assertEqual(self.mock_get_ws_access_level.call_count, acl_call_count)
-    self.assert_no_extra_anvil_calls()
-
-
-# Test for permissions from AnVIL only
-class AnvilSavedVariantAPITest(AnvilAuthenticationTestCase, SavedVariantAPITest):
-    fixtures = ['users', 'social_auth', '1kg_project', 'reference_data', 'clickhouse_discovery_variants', 'clickhouse_saved_variants']
-
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-        DbnsfpGRCh37SnvIndelMv.refresh()
-        DbnsfpGRCh37SnvIndelDict.reload()
-
-    def test_saved_variant_data(self, *args):
-        super(AnvilSavedVariantAPITest, self).test_saved_variant_data(*args)
-        self.mock_list_workspaces.assert_called_with(self.analyst_user)
-        self.mock_get_ws_access_level.assert_any_call(
-            mock.ANY, 'ext-data', 'empty')
-        self.mock_get_ws_access_level.assert_called_with(
-            mock.ANY, 'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
-        self.assertEqual(self.mock_get_ws_access_level.call_count, 15)
-        self.mock_get_groups.assert_called_with(self.collaborator_user)
-        self.assertEqual(self.mock_get_groups.call_count, 1)
-        self.mock_get_ws_acl.assert_not_called()
-        self.mock_get_group_members.assert_not_called()
-
-    def test_create_saved_variant(self):
-        super(AnvilSavedVariantAPITest, self).test_create_saved_variant()
-        assert_no_list_ws_has_al(self, 3)
-
-    def test_create_saved_sv_variant(self):
-        super(AnvilSavedVariantAPITest, self).test_create_saved_sv_variant()
-        assert_no_list_ws_has_al(self, 2)
-
-    def test_create_saved_compound_hets(self):
-        super(AnvilSavedVariantAPITest, self).test_create_saved_compound_hets()
-        assert_no_list_ws_has_al(self, 2)
-
-    def test_create_update_and_delete_variant_note(self):
-        super(AnvilSavedVariantAPITest, self).test_create_update_and_delete_variant_note()
-        assert_no_list_ws_has_al(self, 8)
-
-    def test_create_partially_saved_compound_het_variant_note(self):
-        super(AnvilSavedVariantAPITest, self).test_create_partially_saved_compound_het_variant_note()
-        assert_no_list_ws_has_al(self, 2)
-
-    def test_create_update_and_delete_compound_hets_variant_note(self):
-        super(AnvilSavedVariantAPITest, self).test_create_update_and_delete_compound_hets_variant_note()
-        assert_no_list_ws_has_al(self, 7)
-
-    def test_update_variant_tags(self):
-        super(AnvilSavedVariantAPITest, self).test_update_variant_tags()
-        assert_no_list_ws_has_al(self, 4)
-
-    def test_update_variant_functional_data(self):
-        super(AnvilSavedVariantAPITest, self).test_update_variant_functional_data()
-        assert_no_list_ws_has_al(self, 2)
-
-    def test_update_compound_hets_variant_tags(self):
-        super(AnvilSavedVariantAPITest, self).test_update_compound_hets_variant_tags()
-        assert_no_list_ws_has_al(self, 3)
-
-    def test_update_compound_hets_variant_functional_data(self):
-        super(AnvilSavedVariantAPITest, self).test_update_compound_hets_variant_functional_data()
-        assert_no_list_ws_has_al(self, 3)
-
-    def test_update_variant_main_transcript(self):
-        super(AnvilSavedVariantAPITest, self).test_update_variant_main_transcript()
-        assert_no_list_ws_has_al(self, 2)
-
-    def test_update_variant_acmg_classification(self):
-        super(AnvilSavedVariantAPITest, self).test_update_variant_acmg_classification()
-        assert_no_list_ws_has_al(self, 2)
+    def assert_no_list_ws_has_al(self, acl_call_count):
+        self.mock_list_workspaces.assert_not_called()
+        self.mock_get_ws_access_level.assert_called_with(mock.ANY,
+            'my-seqr-billing', 'anvil-1kg project n\u00e5me with uni\u00e7\u00f8de')
+        self.assertEqual(self.mock_get_ws_access_level.call_count, acl_call_count)
+        self.assert_no_extra_anvil_calls()

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -997,7 +997,7 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         self.assertEqual(VariantTag.objects.filter(saved_variants__guid__contains=VARIANT_GUID).count(), 0)
         self.assertEqual(SavedVariant.objects.filter(guid=VARIANT_GUID).count(), 1)
         self.assert_json_logs(self.collaborator_user, [
-            ('delete VariantTag VT1708633_2103343353_r0390_100', {'dbUpdate': mock.ANY}),
+            (mock.ANY, {'dbUpdate': {'dbEntity': 'VariantTag', 'entityId': mock.ANY, 'updateType': 'delete'}}),
             (mock.ANY, {'dbUpdate': {'dbEntity': 'VariantTag', 'entityId': mock.ANY, 'updateType': 'delete'}}),
             ('Reloading dictionary seqrdb_excluded_variant_dict', None),
             (None, {'httpRequest': mock.ANY, 'requestBody': mock.ANY}),

--- a/seqr/views/utils/individual_utils.py
+++ b/seqr/views/utils/individual_utils.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from clickhouse_search.models.postgres_dicts import AffectedDict, SexDict
+from clickhouse_search.models.postgres_dicts import AffectedDict, SexDict, IndividualMetadataDict
 from matchmaker.models import MatchmakerSubmission, MatchmakerResult
 from seqr.models import Dataset, IgvSample, RnaSample, Individual, Family, FamilyNote
 from seqr.utils.middleware import ErrorsWarningsException
@@ -25,6 +25,7 @@ def add_or_update_individuals_and_families(project, individual_records, user, ge
     updated_individuals = set()
     updated_affected = set()
     updated_sex = set()
+    updated_metadata = set()
     updated_note_ids = []
     parent_updates = []
     num_created_families = 0
@@ -56,7 +57,7 @@ def add_or_update_individuals_and_families(project, individual_records, user, ge
 
     for record in individual_records:
         created_individual = _update_from_record(
-            record, user, families_by_id, individual_lookup, updated_family_ids, updated_individuals, updated_affected, updated_sex, parent_updates, updated_note_ids, allow_features_update)
+            record, user, families_by_id, individual_lookup, updated_family_ids, updated_individuals, updated_affected, updated_sex, updated_metadata, parent_updates, updated_note_ids, allow_features_update)
         if created_individual:
             num_created_individuals += 1
 
@@ -70,12 +71,14 @@ def add_or_update_individuals_and_families(project, individual_records, user, ge
 
     updated_family_models = Family.objects.filter(id__in=updated_family_ids)
     _remove_pedigree_images(updated_family_models, user)
-    if updated_affected:
+    if updated_affected or num_created_individuals > 0:
         AffectedDict.reload(user)
-        if not skip_gt_stats_rebuild:
+        if updated_affected and not skip_gt_stats_rebuild:
             trigger_rebuild_gt_stats(project, user)
-    if updated_sex:
+    if updated_sex or num_created_individuals > 0:
         SexDict.reload(user)
+    if updated_metadata or num_created_families > 0 or num_created_individuals > 0:
+        IndividualMetadataDict.reload(user)
 
     pedigree_json = None
     if get_update_json:
@@ -90,7 +93,7 @@ def add_or_update_individuals_and_families(project, individual_records, user, ge
     return pedigree_json
 
 
-def _update_from_record(record, user, families_by_id, individual_lookup, updated_family_ids, updated_individuals, updated_affected, updated_sex, parent_updates, updated_note_ids, allow_features_update):
+def _update_from_record(record, user, families_by_id, individual_lookup, updated_family_ids, updated_individuals, updated_affected, updated_sex, updated_metadata, parent_updates, updated_note_ids, allow_features_update):
     family_id = _get_record_family_id(record)
     family = families_by_id.get(family_id)
     created_individual = False
@@ -153,6 +156,8 @@ def _update_from_record(record, user, families_by_id, individual_lookup, updated
             updated_affected.add(individual)
         if 'sex' in updated_fields:
             updated_sex.add(individual)
+        if 'features' in updated_fields:
+            updated_metadata.add(individual)
         if family.pedigree_image:
             updated_family_ids.add(family.id)
 

--- a/seqr/views/utils/json_to_orm_utils.py
+++ b/seqr/views/utils/json_to_orm_utils.py
@@ -15,14 +15,14 @@ def update_project_from_json(project, json, user, allow_unknown_keys=False, upda
                            immutable_keys=['consent_code', 'genome_version', 'workspace_namespace', 'workspace_name'])
 
 
-def update_family_from_json(family, json, user, allow_unknown_keys=False, immutable_keys=None):
+def update_family_from_json(family, json, user, allow_unknown_keys=False, immutable_keys=None, updated_fields=None):
     if json.get('displayName') and json['displayName'] == family.family_id:
         json['displayName'] = ''
 
     immutable_keys = (immutable_keys or []) + ['pedigree_image', 'assigned_analyst', 'case_review_summary', 'case_review_notes', 'guid']
 
     return update_model_from_json(
-        family, json, user=user, allow_unknown_keys=allow_unknown_keys, immutable_keys=immutable_keys,
+        family, json, user=user, allow_unknown_keys=allow_unknown_keys, immutable_keys=immutable_keys, updated_fields=updated_fields,
     )
 
 


### PR DESCRIPTION
This pull request removes a bug where some in-memory dictionaries (used for fast lookups, such as gene IDs and individual metadata) are not being kept in sync with database changes. The main updates ensure that these dictionaries are reloaded automatically whenever relevant reference data or model changes occur, improving data consistency across the application. The changes also add comprehensive logging and expand test coverage to verify that dictionary reloads and audit logs are correctly triggered.

**Dictionary Reload Triggers and Logging**

* Added calls to `IndividualMetadataDict.reload()` and related dictionary reloads (e.g., `GeneIdDict.reload()`, `AffectedDict.reload()`, `SexDict.reload()`) after key updates or deletions in families, individuals, and reference data, ensuring in-memory dictionaries stay in sync with the database. These are now triggered in handlers for family/individual updates, deletions, and project creation.

* Ensured `GeneIdDict.reload()` is called after updating `GeneInfo` reference data, and corresponding log messages are produced.

**Test Coverage and Logging Verification**

* Updated and expanded test cases in `family_api_tests.py` and `individual_api_tests.py` to assert that dictionary reloads are logged as expected and that audit logs reflect the correct update operations. This includes new log assertions after updates, deletions, and bulk operations. 

* Added `databases = '__all__'` to relevant test classes to ensure tests are still able to run  now that application behavior requires access t the clickhouse database

These changes collectively improve the robustness and observability of how reference and metadata dictionaries are managed, ensuring that the application always serves up-to-date information after any relevant data changes.