### PR TITLE
handle updated hpo download values

### DIFF
--- a/reference_data/management/tests/update_hpo_tests.py
+++ b/reference_data/management/tests/update_hpo_tests.py
@@ -58,7 +58,7 @@ PHO_DATA = [
     'xref: SNOMEDCT_US:204962002\n',
     'xref: SNOMEDCT_US:82525005\n',
     'xref: UMLS:C3714581\n',
-    'is_a: HP:0000001 ! Renal cyst\n',
+    'is_a: HP:0000001 {xref="PMID:31677808"} ! Renal cyst\n',
     '\n',
     '[Term]\n', # no is_a
     'id: HP:0000005\n',

--- a/reference_data/models.py
+++ b/reference_data/models.py
@@ -188,7 +188,7 @@ class HumanPhenotypeOntology(LoadableModel):
                     'is_category': False,
                 }
             elif line.startswith('is_a: '):
-                is_a = value.split(' ! ')[0]
+                is_a = value.split(' ')[0]
                 if is_a == 'HP:0000118':
                     record['is_category'] = True
                 record['parent_id'] = is_a


### PR DESCRIPTION
Our update for HPO broke over the weekend because the format for one of the fields in the download has changed to allow new values that do not work with our current parsing logic. This updates the parsing and unit tests to support the real data