### PR TITLE
Add validation options to data loading UI

### DIFF
--- a/seqr/utils/add_data_utils.py
+++ b/seqr/utils/add_data_utils.py
@@ -102,7 +102,7 @@ def trigger_data_loading(projects: list[Project], individual_ids: list[int], sam
     conditional_variables = {
         'skip_check_sex_and_relatedness': skip_check_sex_and_relatedness,
         'skip_expect_tdr_metrics': skip_expect_tdr_metrics,
-        'validations_to_skip': validations_to_skip,
+        'validations_to_skip': _valid_validation_to_skip(validations_to_skip, user),
     }
     variables.update({k: v for k, v in conditional_variables.items() if v})
     file_path = _get_pedigree_path(genome_version, sample_type, dataset_type)
@@ -125,6 +125,16 @@ def trigger_data_loading(projects: list[Project], individual_ids: list[int], sam
         ]))
 
     return success
+
+
+def _valid_validation_to_skip(validations_to_skip: list[str], user: User) -> list[str]:
+    invalid_validations = [validation for validation in (validations_to_skip or []) if validation not in {
+        'validate_expected_contig_frequency', 'validate_sample_type', 'validate_no_duplicate_variants',
+    }]
+    if invalid_validations:
+        validations_to_skip = [validation for validation in validations_to_skip if validation not in invalid_validations]
+        logger.error(f'Omitted invalid skip validations from loading request: {", ".join(invalid_validations)}', user)
+    return validations_to_skip
 
 
 def _enqueue_pipeline_request(name: str, variables: dict, user: User, raise_error: bool = True, log_error: bool = True):
@@ -186,7 +196,7 @@ def _upload_data_loading_files(individual_ids: list[int], vcf_sample_id_map: dic
 
 def _write_gene_id_file(user):
     file_name = 'db_id_to_gene_id'
-    if does_file_exist(f'{LOADING_DATASETS_DIR}/{file_name}.csv.gz'):
+    if does_file_exist(f'{LOADING_DATASETS_DIR}/{file_name}.csv.gz', user):
         return
 
     gene_data_loaded = (GeneInfo.objects.filter(gencode_release=int(GeneInfo.CURRENT_VERSION)).exists() and

--- a/seqr/utils/add_data_utils.py
+++ b/seqr/utils/add_data_utils.py
@@ -90,7 +90,7 @@ def trigger_rebuild_gt_stats(project, user):
 
 def trigger_data_loading(projects: list[Project], individual_ids: list[int], sample_type: str, dataset_type: str,
                          genome_version: str, data_path: str, user: User, raise_error: bool = False, skip_expect_tdr_metrics: bool = True,
-                         skip_check_sex_and_relatedness: bool = True, vcf_sample_id_map=None,
+                         skip_check_sex_and_relatedness: bool = True, validations_to_skip: list[str] = None, vcf_sample_id_map=None,
                          success_message: str = None,  error_message: str = None, success_slack_channel: str = SEQR_SLACK_LOADING_NOTIFICATION_CHANNEL):
     variables = {
         'projects_to_run': sorted([p.guid for p in projects]) if projects else None,
@@ -99,11 +99,12 @@ def trigger_data_loading(projects: list[Project], individual_ids: list[int], sam
         'callset_path': data_path,
         'sample_type': sample_type,
     }
-    bool_variables = {
+    conditional_variables = {
         'skip_check_sex_and_relatedness': skip_check_sex_and_relatedness,
         'skip_expect_tdr_metrics': skip_expect_tdr_metrics,
+        'validations_to_skip': validations_to_skip,
     }
-    variables.update({k: v for k, v in bool_variables.items() if v})
+    variables.update({k: v for k, v in conditional_variables.items() if v})
     file_path = _get_pedigree_path(genome_version, sample_type, dataset_type)
     _upload_data_loading_files(individual_ids, vcf_sample_id_map or {}, user, file_path, raise_error)
     _write_gene_id_file(user)

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -306,7 +306,7 @@ def load_data(request):
 
     loading_kwargs = {
         'skip_check_sex_and_relatedness': request_json.get('skipSRChecks', False),
-        'skip_expect_tdr_metrics': False,
+        'skip_expect_tdr_metrics': request_json.get('skipTDR', False),
         'vcf_sample_id_map': vcf_sample_id_map,
         'success_message': f'*{request.user.email}* triggered loading internal {sample_type} {dataset_type} data for {len(individual_ids)} samples in {len(projects)} projects ({"; ".join(sorted(project_counts))})',
         'error_message': f'ERROR triggering internal {sample_type} {dataset_type} loading',
@@ -314,7 +314,8 @@ def load_data(request):
 
     success = trigger_data_loading(
         projects_by_guid.values(), individual_ids, sample_type, dataset_type, request_json['genomeVersion'],
-        _callset_path(request_json), user=request.user, **loading_kwargs,
+        _callset_path(request_json), user=request.user, validations_to_skip=request_json.get('validationsToSkip'),
+        **loading_kwargs,
     )
 
     return create_json_response({'success': success})

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -304,19 +304,17 @@ def load_data(request):
     if errors:
         raise ErrorsWarningsException(errors)
 
-    is_local = True
-    success_message = None
-    error_message = None
-    if AirtableSession.is_airtable_enabled():
-        is_local = False
-        success_message = f'*{request.user.email}* triggered loading internal {sample_type} {dataset_type} data for {len(individual_ids)} samples in {len(projects)} projects ({"; ".join(sorted(project_counts))})'
-        error_message = f'ERROR triggering internal {sample_type} {dataset_type} loading'
+    loading_kwargs = {
+        'skip_check_sex_and_relatedness': request_json.get('skipSRChecks', False),
+        'skip_expect_tdr_metrics': False,
+        'vcf_sample_id_map': vcf_sample_id_map,
+        'success_message': f'*{request.user.email}* triggered loading internal {sample_type} {dataset_type} data for {len(individual_ids)} samples in {len(projects)} projects ({"; ".join(sorted(project_counts))})',
+        'error_message': f'ERROR triggering internal {sample_type} {dataset_type} loading',
+    } if AirtableSession.is_airtable_enabled() else {'raise_error': True}
 
     success = trigger_data_loading(
         projects_by_guid.values(), individual_ids, sample_type, dataset_type, request_json['genomeVersion'],
-        _callset_path(request_json), user=request.user,
-        skip_check_sex_and_relatedness=request_json.get('skipSRChecks', False), vcf_sample_id_map=vcf_sample_id_map,
-        raise_error=is_local, skip_expect_tdr_metrics=is_local, success_message=success_message, error_message=error_message,
+        _callset_path(request_json), user=request.user, **loading_kwargs,
     )
 
     return create_json_response({'success': success})

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1216,7 +1216,7 @@ class DataManagerAPITest(AirtableTest):
         }
         if self.SKIP_TDR:
             body['skip_expect_tdr_metrics'] = True
-        if skip_check_sex_and_relatedness:
+        if skip_check_sex_and_relatedness or self.SKIP_TDR:
             body['skip_check_sex_and_relatedness'] = True
         self.assertDictEqual(json.loads(responses.calls[-1].request.body), body)
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -161,6 +161,7 @@ CORE_REQUEST_BODY = {
     'filePath': '/callset.vcf',
     'sampleType': 'WES',
     'genomeVersion': '38',
+    'validationsToSkip': ['validate_sample_type', 'validate_no_duplicate_variants']
 }
 
 AIRTABLE_SAMPLE_RECORDS = {
@@ -1117,7 +1118,7 @@ class DataManagerAPITest(AirtableTest):
         mock_temp_dir.return_value.__enter__.return_value = '/mock/tmp'
         body = {**self.REQUEST_BODY, 'projects': [
             json.dumps(option) for option in self.PROJECT_OPTIONS + [{'projectGuid': 'R0005_not_project'}]
-        ], 'vcfSamples': self.VCF_SAMPLES, 'skipSRChecks': True}
+        ], 'vcfSamples': self.VCF_SAMPLES}
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self.assertEqual(response.status_code, 400)
         self.assertDictEqual(response.json(), {'error': 'The following projects are invalid: R0005_not_project'})
@@ -1133,7 +1134,7 @@ class DataManagerAPITest(AirtableTest):
         )
         self.assertDictEqual(response.json(), {'success': True})
 
-        self._assert_expected_load_data_requests(sample_type='WES', skip_check_sex_and_relatedness=True)
+        self._assert_expected_load_data_requests(sample_type='WES', skip_check_sex_and_relatedness=True, validations_to_skip=['validate_sample_type', 'validate_no_duplicate_variants'])
         self._has_expected_ped_files(mock_open, mock_gzip_open, mock_mkdir, 'SNV_INDEL', sample_type='WES', has_remap=bool(self.MOCK_AIRTABLE_KEY))
 
         variables = {
@@ -1146,9 +1147,9 @@ class DataManagerAPITest(AirtableTest):
             'callset_path': f'{self.TRIGGER_CALLSET_DIR}/callset.vcf',
             'sample_type': 'WES',
             'skip_check_sex_and_relatedness': True,
+            'skip_expect_tdr_metrics': True,
+            'validations_to_skip': ['validate_sample_type', 'validate_no_duplicate_variants'],
         }
-        if self.SKIP_TDR:
-            variables['skip_expect_tdr_metrics'] = True
         self._assert_success_notification(variables)
 
         # Test loading trigger error
@@ -1159,8 +1160,13 @@ class DataManagerAPITest(AirtableTest):
         responses.calls.reset()
         self.reset_logs()
 
-        del body['skipSRChecks']
+        body.pop('skipSRChecks', None)
+        body.pop('skipTDR', None)
+        del body['validationsToSkip']
         del variables['skip_check_sex_and_relatedness']
+        del variables['validations_to_skip']
+        if not self.SKIP_TDR:
+            del variables['skip_expect_tdr_metrics']
         body.update({'datasetType': 'SV', 'filePath': f'{self.CALLSET_DIR}/sv_callset.vcf'})
         self._trigger_error(url, body, variables, mock_open, mock_gzip_open, mock_mkdir)
 
@@ -1203,7 +1209,7 @@ class DataManagerAPITest(AirtableTest):
         })
         self.assertEqual(len(responses.calls), 0)
 
-    def _assert_expected_load_data_requests(self, dataset_type='SNV_INDEL', sample_type='WGS', trigger_error=False, skip_project=False, skip_check_sex_and_relatedness=False):
+    def _assert_expected_load_data_requests(self, dataset_type='SNV_INDEL', sample_type='WGS', trigger_error=False, skip_project=False, skip_check_sex_and_relatedness=False, validations_to_skip=None):
         projects = [PROJECT_GUID, NON_ANALYST_PROJECT_GUID]
         if skip_project:
             projects = projects[1:]
@@ -1214,9 +1220,10 @@ class DataManagerAPITest(AirtableTest):
             'dataset_type': dataset_type,
             'reference_genome': 'GRCh38',
         }
-        if self.SKIP_TDR:
-            body['skip_expect_tdr_metrics'] = True
+        if validations_to_skip:
+            body['validations_to_skip'] = validations_to_skip
         if skip_check_sex_and_relatedness or self.SKIP_TDR:
+            body['skip_expect_tdr_metrics'] = True
             body['skip_check_sex_and_relatedness'] = True
         self.assertDictEqual(json.loads(responses.calls[-1].request.body), body)
 
@@ -1474,6 +1481,8 @@ class AnvilDataManagerAPITest(AnvilAuthenticationTestCase, DataManagerAPITest):
         **CORE_REQUEST_BODY,
         'filePath': CALLSET_DIR + CORE_REQUEST_BODY['filePath'],
         'datasetType': 'SNV_INDEL',
+        'skipSRChecks': True,
+        'skipTDR': True
     }
     VCF_SAMPLES = [s for s in VCF_SAMPLES if s != 'NA21234']
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1147,9 +1147,10 @@ class DataManagerAPITest(AirtableTest):
             'callset_path': f'{self.TRIGGER_CALLSET_DIR}/callset.vcf',
             'sample_type': 'WES',
             'skip_check_sex_and_relatedness': True,
-            'skip_expect_tdr_metrics': True,
             'validations_to_skip': ['validate_sample_type', 'validate_no_duplicate_variants'],
         }
+        if self.SKIP_TDR:
+            variables['skip_expect_tdr_metrics'] = True
         self._assert_success_notification(variables)
 
         # Test loading trigger error
@@ -1161,12 +1162,11 @@ class DataManagerAPITest(AirtableTest):
         self.reset_logs()
 
         body.pop('skipSRChecks', None)
-        body.pop('skipTDR', None)
         del body['validationsToSkip']
+        body['skipTDR'] = True
         del variables['skip_check_sex_and_relatedness']
         del variables['validations_to_skip']
-        if not self.SKIP_TDR:
-            del variables['skip_expect_tdr_metrics']
+        variables['skip_expect_tdr_metrics'] = True
         body.update({'datasetType': 'SV', 'filePath': f'{self.CALLSET_DIR}/sv_callset.vcf'})
         self._trigger_error(url, body, variables, mock_open, mock_gzip_open, mock_mkdir)
 
@@ -1177,6 +1177,7 @@ class DataManagerAPITest(AirtableTest):
         mock_mkdir.reset_mock()
         body.update({'sampleType': 'WGS', 'projects': [json.dumps(self.PROJECT_OPTION)], 'vcfSamples': VCF_SAMPLES})
         del body['datasetType']
+        del body['skipTDR']
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
         self._test_load_single_project(mock_open, mock_gzip_open, mock_mkdir, response, url=url, body=body)
 
@@ -1209,7 +1210,7 @@ class DataManagerAPITest(AirtableTest):
         })
         self.assertEqual(len(responses.calls), 0)
 
-    def _assert_expected_load_data_requests(self, dataset_type='SNV_INDEL', sample_type='WGS', trigger_error=False, skip_project=False, skip_check_sex_and_relatedness=False, validations_to_skip=None):
+    def _assert_expected_load_data_requests(self, dataset_type='SNV_INDEL', sample_type='WGS', trigger_error=False, skip_project=False, skip_check_sex_and_relatedness=False, skip_tdr=False, validations_to_skip=None):
         projects = [PROJECT_GUID, NON_ANALYST_PROJECT_GUID]
         if skip_project:
             projects = projects[1:]
@@ -1222,15 +1223,16 @@ class DataManagerAPITest(AirtableTest):
         }
         if validations_to_skip:
             body['validations_to_skip'] = validations_to_skip
-        if skip_check_sex_and_relatedness or self.SKIP_TDR:
+        if skip_tdr or self.SKIP_TDR:
             body['skip_expect_tdr_metrics'] = True
+        if skip_check_sex_and_relatedness or self.SKIP_TDR:
             body['skip_check_sex_and_relatedness'] = True
         self.assertDictEqual(json.loads(responses.calls[-1].request.body), body)
 
     def _trigger_error(self, url, body, variables, mock_open, mock_gzip_open, mock_mkdir):
         responses.add(responses.POST, PIPELINE_RUNNER_URL, status=400)
         response = self.client.post(url, content_type='application/json', data=json.dumps(body))
-        self._assert_expected_load_data_requests(trigger_error=True, dataset_type='GCNV', sample_type='WES')
+        self._assert_expected_load_data_requests(trigger_error=True, dataset_type='GCNV', sample_type='WES', skip_tdr=True)
         self._assert_trigger_error(response, body, variables, response_body={
             'error': f'400 Client Error: Bad Request for url: {PIPELINE_RUNNER_URL}'
         })
@@ -1482,7 +1484,6 @@ class AnvilDataManagerAPITest(AnvilAuthenticationTestCase, DataManagerAPITest):
         'filePath': CALLSET_DIR + CORE_REQUEST_BODY['filePath'],
         'datasetType': 'SNV_INDEL',
         'skipSRChecks': True,
-        'skipTDR': True
     }
     VCF_SAMPLES = [s for s in VCF_SAMPLES if s != 'NA21234']
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -161,7 +161,7 @@ CORE_REQUEST_BODY = {
     'filePath': '/callset.vcf',
     'sampleType': 'WES',
     'genomeVersion': '38',
-    'validationsToSkip': ['validate_sample_type', 'validate_no_duplicate_variants']
+    'validationsToSkip': ['validate_sample_type', 'validate_no_duplicate_variants', 'validate_something_else']
 }
 
 AIRTABLE_SAMPLE_RECORDS = {
@@ -1134,8 +1134,8 @@ class DataManagerAPITest(AirtableTest):
         )
         self.assertDictEqual(response.json(), {'success': True})
 
-        self._assert_expected_load_data_requests(sample_type='WES', skip_check_sex_and_relatedness=True, validations_to_skip=['validate_sample_type', 'validate_no_duplicate_variants'])
-        self._has_expected_ped_files(mock_open, mock_gzip_open, mock_mkdir, 'SNV_INDEL', sample_type='WES', has_remap=bool(self.MOCK_AIRTABLE_KEY))
+        load_data_logs = self._assert_expected_load_data_requests(sample_type='WES', skip_check_sex_and_relatedness=True, validations_to_skip=['validate_sample_type', 'validate_no_duplicate_variants'])
+        ped_file_logs = self._has_expected_ped_files(mock_open, mock_gzip_open, mock_mkdir, 'SNV_INDEL', sample_type='WES', has_remap=bool(self.MOCK_AIRTABLE_KEY))
 
         variables = {
             'projects_to_run': [
@@ -1152,6 +1152,15 @@ class DataManagerAPITest(AirtableTest):
         if self.SKIP_TDR:
             variables['skip_expect_tdr_metrics'] = True
         self._assert_success_notification(variables)
+
+        self.assert_json_logs(self.data_manager_user if load_data_logs else self.pm_user, [
+            (log, None) for log in load_data_logs
+        ] + [
+            ('Omitted invalid skip validations from loading request: validate_something_else', {
+                'severity': 'ERROR',
+                '@type': 'type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent',
+            }),
+        ] + ped_file_logs + [('Triggered Loading Pipeline', {'detail': variables})])
 
         # Test loading trigger error
         self._set_file_not_found(has_mv_commands=True)
@@ -1228,6 +1237,7 @@ class DataManagerAPITest(AirtableTest):
         if skip_check_sex_and_relatedness or self.SKIP_TDR:
             body['skip_check_sex_and_relatedness'] = True
         self.assertDictEqual(json.loads(responses.calls[-1].request.body), body)
+        return []
 
     def _trigger_error(self, url, body, variables, mock_open, mock_gzip_open, mock_mkdir):
         responses.add(responses.POST, PIPELINE_RUNNER_URL, status=400)
@@ -1284,6 +1294,7 @@ class DataManagerAPITest(AirtableTest):
             ['R0004_non_analyst_project', 'F000014_14', 'fam14', 'NA21234', '', '', 'F'] + (['ABC123'] if has_remap else []),
             ['R0004_non_analyst_project', 'F000014_14', 'fam14', 'NA21987', '', '', 'M'] + ([''] if has_remap else []),
         ])
+        return []
 
     def _test_load_single_project(self, mock_open, mock_gzip_open, mock_mkdir, response, *args, **kwargs):
         self.assertEqual(response.status_code, 200)
@@ -1397,23 +1408,23 @@ class LocalDataManagerAPITest(AuthenticationTestCase, DataManagerAPITest):
 
     def _assert_expected_load_data_requests(self, *args, **kwargs):
         self.assertEqual(len(responses.calls), 1)
-        super()._assert_expected_load_data_requests(*args, **kwargs)
+        return super()._assert_expected_load_data_requests(*args, **kwargs)
 
     @staticmethod
     def _local_pedigree_path(dataset_type, sample_type):
         return f'/local_datasets/GRCh38/{dataset_type}/pedigrees/{sample_type}'
 
     def _has_expected_ped_files(self, mock_open, mock_gzip_open, mock_mkdir, dataset_type, *args, sample_type='WGS', has_gene_id_file=False, **kwargs):
-        super()._has_expected_ped_files(mock_open, mock_gzip_open, mock_mkdir, dataset_type,  *args, sample_type, has_gene_id_file=has_gene_id_file, **kwargs)
+        logs = super()._has_expected_ped_files(mock_open, mock_gzip_open, mock_mkdir, dataset_type,  *args, sample_type, has_gene_id_file=has_gene_id_file, **kwargs)
         call_paths = [self._local_pedigree_path(dataset_type, sample_type)]
         if not has_gene_id_file:
             call_paths.append(self.LOCAL_WRITE_DIR)
         self.assertEqual(mock_mkdir.call_count, len(call_paths))
         mock_mkdir.assert_has_calls([mock.call(call_path, exist_ok=True) for call_path in call_paths])
+        return logs
 
     def _assert_success_notification(self, variables):
-        self.maxDiff = None
-        self.assert_json_logs(self.pm_user, [('Triggered Loading Pipeline', {'detail': variables})])
+        pass
 
     def _trigger_error(self, url, body, variables, mock_open, mock_gzip_open, mock_mkdir):
         super()._trigger_error(url, body, variables, mock_open, mock_gzip_open, mock_mkdir)
@@ -1567,6 +1578,7 @@ class AnvilDataManagerAPITest(AnvilAuthenticationTestCase, DataManagerAPITest):
         self.assert_json_logs(self.pm_user, [
             ('PermissionDenied: Error: To access RDG airtable user must login with Broad email.', {'severity': 'WARNING'})
         ])
+        self.reset_logs()
         self.login_data_manager_user()
         return super()._assert_expected_pm_access(get_response, *args, **kwargs)
 
@@ -1574,15 +1586,19 @@ class AnvilDataManagerAPITest(AnvilAuthenticationTestCase, DataManagerAPITest):
         num_calls = 1
         is_gcnv = dataset_type == 'GCNV'
         required_sample_field = 'gCNV_CallsetPath' if is_gcnv else None
+        logs = []
         if not skip_project:
             self._assert_expected_airtable_call(required_sample_field, 'R0001_1kg')
             num_calls += 1
+            logs += ['Fetching Samples records 0-2 from airtable', 'Fetched 6 Samples records from airtable']
         if (not is_gcnv) and (not skip_project):
             self._assert_expected_airtable_vcf_id_call(required_sample_field, call_index=1)
             num_calls += 1
+            logs += ['Fetching Samples records 0-4 from airtable', 'Fetched 6 Samples records from airtable']
 
         self.assertEqual(len(responses.calls), num_calls)
         super()._assert_expected_load_data_requests(*args, dataset_type=dataset_type, skip_project=skip_project, **kwargs)
+        return logs
 
     def _assert_expected_airtable_call(self, required_sample_field, project_guid, call_index=0, additional_filter=None, additional_pdo_statuses='', additional_fields=None):
         airtable_filters = [
@@ -1707,19 +1723,22 @@ Loading pipeline should be triggered with:
         super()._has_expected_ped_files(mock_open, mock_gzip_open, mock_mkdir, dataset_type, sample_type, has_gene_id_file=has_gene_id_file, **kwargs)
 
         mock_mkdir.assert_not_called()
-        expected_calls = [mock.call(
+        expected_calls = [
             f'gsutil mv /mock/tmp/* gs://seqr-loading-temp/v3.1/GRCh38/{dataset_type}/pedigrees/{sample_type}/',
-            stdout=-1, stderr=-2, shell=True,  # nosec
-        ), mock.call(
-            'gsutil ls gs://seqr-loading-temp/v3.1/db_id_to_gene_id.csv.gz', stdout=-1, stderr=-2, shell=True, # nosec
-        )]
+            'gsutil ls gs://seqr-loading-temp/v3.1/db_id_to_gene_id.csv.gz',
+        ]
         if not has_gene_id_file:
-            expected_calls.append(mock.call(
-                'gsutil mv /mock/tmp/* gs://seqr-loading-temp/v3.1/', stdout=-1, stderr=-2, shell=True, # nosec
-            ))
+            expected_calls.append(
+                'gsutil mv /mock/tmp/* gs://seqr-loading-temp/v3.1/',
+            )
         self.assertEqual(self.mock_subprocess.call_count, len(expected_calls))
-        self.mock_subprocess.assert_has_calls(expected_calls)
+        self.mock_subprocess.assert_has_calls([
+            mock.call(call, stdout=-1, stderr=-2, shell=True) for call in expected_calls # nosec
+        ])
         self.mock_subprocess.reset_mock()
+        logs = [(f'==> {call}', None) for call in expected_calls]
+        logs.insert(2, ('CommandException: One or more URLs matched no objects', {'severity': 'WARNING'}))
+        return logs
 
     def _assert_write_pedigree_error(self, response):
         self.assertEqual(response.status_code, 200)

--- a/ui/pages/DataManagement/components/LoadData.jsx
+++ b/ui/pages/DataManagement/components/LoadData.jsx
@@ -6,7 +6,7 @@ import { FormSpy } from 'react-final-form'
 import { getUser } from 'redux/selectors'
 import { validators } from 'shared/components/form/FormHelpers'
 import FormWizard from 'shared/components/form/FormWizard'
-import { ButtonRadioGroup, InlineToggle } from 'shared/components/form/Inputs'
+import { ButtonRadioGroup, CheckboxGroup, InlineToggle } from 'shared/components/form/Inputs'
 import LoadOptionsSelect from 'shared/components/form/LoadOptionsSelect'
 import {
   SAMPLE_TYPE_EXOME,
@@ -55,16 +55,48 @@ const FILE_PATH_FIELD = {
 
 const CALLSET_PAGE_FIELDS = [
   {
-    ...GENOME_VERSION_FIELD,
-    component: ButtonRadioGroup,
-    validate: validators.required,
-  },
-  {
     name: 'sampleType',
     label: 'Sample Type',
     component: ButtonRadioGroup,
     options: [SAMPLE_TYPE_EXOME, SAMPLE_TYPE_GENOME].map(value => ({ value, text: value })),
     validate: validators.required,
+  },
+  {
+    ...GENOME_VERSION_FIELD,
+    component: ButtonRadioGroup,
+    validate: validators.required,
+  },
+  {
+    name: 'validationsToSkip',
+    label: 'Skip Validations',
+    component: CheckboxGroup,
+    options: [
+      {
+        value: 'validate_expected_contig_frequency',
+        text: 'Chromosome Frequency',
+        description: `By default, VCFs will be checked to ensure they have a reasonable number of variants in each 
+          chromosome, and loading will fail if some chromosomes are missing data. If there is a known reason why some 
+          chromosomes may be missing variants, such as with gene panel data, this validation may be safely skipped.`,
+      },
+      {
+        value: 'validate_sample_type',
+        text: 'Sample Type',
+        description: `By default, VCFs will be checked for a representative sample of coding and non-coding SNPs which 
+          will then be used to assess whether the selected Sample Type aligns with the provided data. If there is a 
+          known reason why this validation would fail, such as WES data that uses broader capture regions, this 
+          validation may be safely skipped.`,
+      },
+      {
+        value: 'validate_no_duplicate_variants',
+        text: 'Duplicate Variants (modifies data before loading)',
+        description: `By default, VCFs will be checked to ensure they have no duplicate variants, as all supported  
+          calling pipelines should have a single row per variant. While there are no well supported reasons why a VCF 
+          with duplicate data should be loaded to seqr, we do provide this option to skip that validation and instead 
+          deduplicate the data before running. NOTE: By selecting this option, variants will be ARBITRARILY DEDUPLICATED. 
+          This means duplicate rows will be dropped at random to leave only one row per variant. If you want a more 
+          deterministic approach to merging/ deduplicating your data, this should be done outside of seqr.`,
+      },
+    ],
   },
 ]
 
@@ -92,13 +124,6 @@ const MULTI_DATA_TYPE_CALLSET_PAGE = {
       ...FILE_PATH_FIELD,
     },
     {
-      name: 'skipSRChecks',
-      label: 'Skip Sex and Relatedness Checks',
-      component: InlineToggle,
-      asFormInput: true,
-    },
-    ...CALLSET_PAGE_FIELDS,
-    {
       name: 'datasetType',
       label: 'Dataset Type',
       component: ButtonRadioGroup,
@@ -108,6 +133,19 @@ const MULTI_DATA_TYPE_CALLSET_PAGE = {
         DATASET_TYPE_MITO_CALLS,
       ].map(value => ({ value, text: value.replace('_', '/') })),
       validate: validators.required,
+    },
+    ...CALLSET_PAGE_FIELDS,
+    {
+      name: 'skipSRChecks',
+      label: 'Skip Sex and Relatedness Checks',
+      component: InlineToggle,
+      asFormInput: true,
+    },
+    {
+      name: 'skipTDR',
+      label: 'Skip TDR Metrics',
+      component: InlineToggle,
+      asFormInput: true,
     },
   ],
 }

--- a/ui/shared/components/form/Inputs.jsx
+++ b/ui/shared/components/form/Inputs.jsx
@@ -315,7 +315,7 @@ const InlineFormGroup = styled(Form.Group).attrs({ inline: true })`
 `
 
 const selectAll = (onChange, value, options) => ({ checked }) => {
-  const remainValue = value.filter(val => !options.find(opt => opt.value === val))
+  const remainValue = (value || []).filter(val => !options.find(opt => opt.value === val))
   if (checked) {
     onChange(options.map(option => option.value).concat(remainValue))
   } else {
@@ -325,9 +325,9 @@ const selectAll = (onChange, value, options) => ({ checked }) => {
 
 const selectCheckbox = (onChange, value, option) => ({ checked }) => {
   if (checked) {
-    onChange([...value, option.value])
+    onChange([...(value || []), option.value])
   } else {
-    onChange(value.filter(val => val !== option.value))
+    onChange((value || []).filter(val => val !== option.value))
   }
 }
 
@@ -340,7 +340,7 @@ const chunkArray = (arr, maxChunkSize) => {
 export const CheckboxGroup = React.memo((props) => {
   const { value, label, groupLabel, onChange, maxOptionsPerColumn, inline, ...baseProps } = props
   const options = props.options.map(styledOption)
-  const numSelected = options.filter(opt => value.includes(opt.value)).length
+  const numSelected = options.filter(opt => value?.includes(opt.value)).length
   const optionGroups = maxOptionsPerColumn && options.length > maxOptionsPerColumn ?
     chunkArray(options, maxOptionsPerColumn) : [options]
   const optionLists = optionGroups.map(optionGroup => (
@@ -350,7 +350,7 @@ export const CheckboxGroup = React.memo((props) => {
           <BaseSemanticInput
             {...baseProps}
             inputType="Checkbox"
-            checked={value.includes(option.value)}
+            checked={value?.includes(option.value)}
             label={helpLabel(option.text, option.description)}
             onChange={selectCheckbox(onChange, value, option)}
           />


### PR DESCRIPTION
## Pull request overview

Adds support for selectively skipping specific VCF validations during data loading, wiring the selected skip options from the Data Management UI through the `load_data` API into the pipeline trigger payload. Also extends intenral Broad load controls to include skipping TDR metrics and updates API tests accordingly.

**Changes:**
- UI: adds a “Skip Validations” multi-select (checkbox group) and adds a “Skip TDR Metrics” toggle for Broad internal load flow.
- API: forwards `validationsToSkip` to `trigger_data_loading` as `validations_to_skip`, and refactors kwargs passed to the loader trigger.
- Tests/utilities: updates test request bodies and expected pipeline trigger variables; updates loader utility to conditionally include `validations_to_skip`.
