### PR TITLE
only update variants with caids

### DIFF
--- a/clickhouse_search/fixtures/variant_details_for_update.json
+++ b/clickhouse_search/fixtures/variant_details_for_update.json
@@ -83,7 +83,7 @@
         "key": 6,
         "variant_id": "1-94818-T-C",
         "rsid": null,
-        "caid": null,
+        "caid": "CA16717153",
         "lifted_over_chrom": "1",
         "lifted_over_pos": 94818,
         "sorted_regulatory_feature_consequences": [],

--- a/clickhouse_search/management/commands/register_caids.py
+++ b/clickhouse_search/management/commands/register_caids.py
@@ -224,7 +224,7 @@ def handle_api_response(
 def register_caids(
     genome_version: Literal[GENOME_VERSION_GRCh37, GENOME_VERSION_GRCh38],
     variants: Union[list[VariantDetailsGRCh37SnvIndel], list[VariantDetailsSnvIndel]],
-) -> int:
+) -> tuple[int, Union[list[VariantDetailsGRCh37SnvIndel], list[VariantDetailsSnvIndel]]]:
     rows = list(ALLELE_REGISTRY_HEADERS[genome_version]) # NB: new copy of the list
     for variant in variants:
         chrom, pos, ref, alt = variant.variant_id.split("-")
@@ -254,10 +254,14 @@ def register_caids(
     )
     mapped_variants = handle_api_response(genome_version, res)
     max_key_id = -1
+    update_variants = []
     for variant in variants:
-        variant.caid = mapped_variants.get(variant.variant_id, None)
+        caid = mapped_variants.get(variant.variant_id)
+        if caid:
+            variant.caid = caid
+            update_variants.append(variant)
         max_key_id = max(max_key_id, variant.key_id)
-    return max_key_id
+    return max_key_id, update_variants
 
 def join_series(model: Union[VariantDetailsSnvIndel, VariantDetailsGRCh37SnvIndel], min_: int, max_: int):
     table = model._meta.db_table
@@ -316,8 +320,8 @@ class Command(BaseCommand):
                     break
 
                 try:
-                    max_key = register_caids(genome_version, variants)
-                    variant_details_model.objects.using('clickhouse_write').bulk_update(variants, ["caid"])
+                    max_key, update_variants = register_caids(genome_version, variants)
+                    variant_details_model.objects.using('clickhouse_write').bulk_update(update_variants, ["caid"])
                     # Save current key on every iteration
                     curr_key = max_key
                     version_obj.version = curr_key

--- a/clickhouse_search/management/tests/register_caids_tests.py
+++ b/clickhouse_search/management/tests/register_caids_tests.py
@@ -269,8 +269,16 @@ class RegisterCaidsTest(TestCase):
             'MESSAGE: 1\t10469\trs370233998\tC\tG\t.\t.\t.\n'
             'INPUT_LINE: Cannot align NC_000001.10 [10468,10469).',
         )
-        vd = VariantDetailsSnvIndel.objects.get(variant_id='1-91511686-T-G')
-        self.assertEqual(vd.caid, 'CA997563840')
+        self.assertListEqual(list(VariantDetailsSnvIndel.objects.order_by('key').values_list('variant_id', 'caid')), [
+            ('1-10439-AC-A', 'CA16717152'),
+            ('1-38724419-T-G', None),
+            ('1-91502721-G-A', None),
+            ('1-91511686-T-G', 'CA997563840'),
+            ('1-10146-ACC-A', 'CA997563845'),
+            ('1-94818-T-C', 'CA16717153'),
+            ('7-143270172-A-G', None),
+            ('7-9310123-T-C', None)
+        ])
 
         # Ensure re-calling is a no-op
         responses.reset()


### PR DESCRIPTION
As reported in [this bug ticket](https://github.com/broadinstitute/seqr-private/issues/1752), all the CAIDS got cleared somehow. While I can't track down exactly where this happens, it does seem safer not to have code that could bulk clear CAIDS for variants, plus this will be slightly more efficient code when working as normal