### PR TITLE
Metrics dashboard

### DIFF
--- a/seqr/urls.py
+++ b/seqr/urls.py
@@ -125,6 +125,7 @@ from seqr.views.apis.report_api import \
     family_metadata, \
     variant_metadata, \
     gregor_export, \
+    sample_stats_download, \
     seqr_stats
 from seqr.views.apis.summary_data_api import success_story, saved_variants_page, mme_details, hpo_summary_data, \
     bulk_update_family_external_analysis, individual_metadata
@@ -325,6 +326,7 @@ api_endpoints = {
     'report/variant_metadata/(?P<project_guid>[^/]+)': variant_metadata,
     'report/gregor': gregor_export,
     'report/seqr_stats': seqr_stats,
+    'report/sample_stats_download': sample_stats_download,
 
     'data_management/get_all_users': get_all_users,
     'data_management/update_rna_seq': update_rna_seq,

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 from datetime import datetime, timedelta
 from django.db.models import Count, Q, F, Value
+from django.db.models.expressions import Case, When
 from django.contrib.auth.models import User
 from django.contrib.postgres.aggregates import ArrayAgg
 import json
@@ -40,37 +41,26 @@ airtable_enabled_analyst_required = active_user_has_policies_and_passes_test(
 
 @pm_or_analyst_required
 def seqr_stats(request):
-    non_demo_projects = Project.objects.filter(is_demo=False)
-
-    project_models = {
-        'demo': Project.objects.filter(is_demo=True),
-    }
-    if anvil_enabled():
-        is_anvil_q = Q(workspace_namespace='') | Q(workspace_namespace__isnull=True)
-        anvil_projects = non_demo_projects.exclude(is_anvil_q)
-        internal_ids = get_internal_projects().values_list('id', flat=True)
-        project_models.update({
-            'internal': anvil_projects.filter(id__in=internal_ids),
-            'external': anvil_projects.exclude(id__in=internal_ids),
-            'no_anvil': non_demo_projects.filter(is_anvil_q),
-        })
-    else:
-        project_models.update({
-            'non_demo': non_demo_projects,
-        })
+    project_qs, *dataset_qs = _get_project_aggregated_qs()
 
     grouped_sample_counts = defaultdict(dict)
-    for project_key, projects in project_models.items():
-        samples_counts = _get_sample_counts(
-            Dataset.objects.filter(active_individuals__family__project__in=projects),
-            count=Count('active_individuals'),
-        )
-        samples_counts.update(_get_sample_counts(
-            RnaSample.objects.filter(individual__family__project__in=projects, is_active=True).annotate(sample_type=Value('RNA')),
-            data_type_key='data_type', count=Count('*'))
-        )
-        for k, v in samples_counts.items():
-            grouped_sample_counts[k][project_key] = v
+    for qs in dataset_qs:
+        for agg in qs.annotate(count=Count('active_individuals')):
+            grouped_sample_counts[f"{agg['sample_type']}__{agg['dataset_type']}"][_agg_key(agg)] = agg['count']
+
+    project_aggs = project_qs.annotate(
+        count=Count('id', distinct=True),
+        family_count=Count('family', distinct=True),
+        individual_count=Count('family__individual', distinct=True),
+    )
+    project_counts = {}
+    families_count = {}
+    individuals_count = {}
+    for agg in project_aggs:
+        key = _agg_key(agg)
+        project_counts[key] = agg['count']
+        families_count[key] = agg['family_count']
+        individuals_count[key] = agg['individual_count']
 
     user_counts = User.objects.filter(is_active=True).aggregate(
         total=Count('id'),
@@ -81,23 +71,44 @@ def seqr_stats(request):
     )
 
     return create_json_response({
-        'projectsCount': {k: projects.count() for k, projects in project_models.items()},
-        'familiesCount': {
-            k: Family.objects.filter(project__in=projects).count() for k, projects in project_models.items()
-        },
-        'individualsCount': {
-            k: Individual.objects.filter(family__project__in=projects).count() for k, projects in project_models.items()
-        },
+        'projectsCount': project_counts,
+        'familiesCount': families_count,
+        'individualsCount': individuals_count,
         'usersCounts': user_counts,
         'sampleCountsByType': grouped_sample_counts,
     })
 
 
-def _get_sample_counts(sample_q, count=None, data_type_key='dataset_type'):
-    samples_agg = sample_q.values('sample_type', data_type_key).annotate(count=count)
-    return {
-        f'{sample_agg["sample_type"]}__{sample_agg[data_type_key]}': sample_agg['count'] for sample_agg in samples_agg
-    }
+def _get_project_aggregated_qs():
+    prefixes = ['', 'active_individuals__family__project__', 'individual__family__project__']
+    agg_fields = [{'demo': F(f'{prefix}is_demo')} for prefix in prefixes]
+    if anvil_enabled():
+        internal_ids = get_internal_projects().values_list('id', flat=True)
+        for i, prefix in enumerate(prefixes):
+            agg_fields[i].update({
+                'no_anvil': Q(**{f'{prefix}workspace_namespace': ''}) | Q(**{f'{prefix}workspace_namespace__isnull': True}),
+                'is_internal': Case(When(**{f'{prefix}id__in': internal_ids, 'then': Value(True)}), default=Value(False)),
+            })
+
+    model_classes = [
+        (Project.objects, []),
+        (Dataset.objects, ['sample_type', 'dataset_type']),
+        (RnaSample.objects.annotate(sample_type=Value('RNA'), dataset_type=F('data_type'), active_individuals=F('individual_id')), ['sample_type', 'dataset_type']),
+    ]
+    return [
+        models.annotate(**agg_fields[i]).filter(demo__isnull=False).values(*agg_fields[i], *values)
+        for i, (models, values) in enumerate(model_classes)
+    ]
+
+
+def _agg_key(agg):
+    if agg['demo']:
+        return 'demo'
+    elif agg.get('no_anvil'):
+        return 'no_anvil'
+    elif 'is_internal' in agg:
+        return 'internal' if agg['is_internal'] else 'external'
+    return 'non_demo'
 
 
 # AnVIL metadata

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -41,11 +41,11 @@ airtable_enabled_analyst_required = active_user_has_policies_and_passes_test(
 
 @pm_or_analyst_required
 def seqr_stats(request):
-    project_qs, *dataset_qs = _get_project_aggregated_qs()
+    project_qs, dataset_qs = _get_project_aggregated_qs(additional_model=(Project, ''))
 
     grouped_sample_counts = defaultdict(dict)
     for qs in dataset_qs:
-        for agg in qs.annotate(count=Count('active_individuals')):
+        for agg in qs:
             grouped_sample_counts[f"{agg['sample_type']}__{agg['dataset_type']}"][_agg_key(agg)] = agg['count']
 
     project_aggs = project_qs.annotate(
@@ -79,8 +79,10 @@ def seqr_stats(request):
     })
 
 
-def _get_project_aggregated_qs():
-    prefixes = ['', 'active_individuals__family__project__', 'individual__family__project__']
+def _get_project_aggregated_qs(additional_model=None):
+    prefixes = ['active_individuals__family__project__', 'individual__family__project__']
+    if additional_model:
+        prefixes.append(additional_model[1])
     agg_fields = [{'demo': F(f'{prefix}is_demo')} for prefix in prefixes]
     if anvil_enabled():
         internal_ids = get_internal_projects().values_list('id', flat=True)
@@ -90,15 +92,20 @@ def _get_project_aggregated_qs():
                 'is_internal': Case(When(**{f'{prefix}id__in': internal_ids, 'then': Value(True)}), default=Value(False)),
             })
 
-    model_classes = [
-        (Project.objects, []),
-        (Dataset.objects, ['sample_type', 'dataset_type']),
-        (RnaSample.objects.annotate(sample_type=Value('RNA'), dataset_type=F('data_type'), active_individuals=F('individual_id')), ['sample_type', 'dataset_type']),
+    dataset_qs = [
+        models.annotate(**agg_fields[i]).filter(demo__isnull=False).values(
+            'sample_type', 'dataset_type', *agg_fields[i],
+        ).annotate(count=Count('active_individuals')) for i, models in enumerate([
+            Dataset.objects,
+            RnaSample.objects.annotate(sample_type=Value('RNA'), dataset_type=F('data_type'), active_individuals=F('individual_id')),
+        ])
     ]
-    return [
-        models.annotate(**agg_fields[i]).filter(demo__isnull=False).values(*agg_fields[i], *values)
-        for i, (models, values) in enumerate(model_classes)
-    ]
+
+    if additional_model:
+        fields = agg_fields[-1]
+        return additional_model[0].objects.annotate(**fields).values(*fields), dataset_qs
+
+    return dataset_qs
 
 
 def _agg_key(agg):

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 from datetime import datetime, timedelta
 from django.db.models import Count, Q, F, Value
+from django.contrib.auth.models import User
 from django.contrib.postgres.aggregates import ArrayAgg
 import json
 import re
@@ -71,6 +72,14 @@ def seqr_stats(request):
         for k, v in samples_counts.items():
             grouped_sample_counts[k][project_key] = v
 
+    user_counts = User.objects.filter(is_active=True).aggregate(
+        total=Count('id'),
+        multipleLogins=Count('id', filter=Q(last_login__isnull=False) & ~Q(last_login=F('date_joined'))),
+        lastMonth=Count('id', filter=Q(last_login__gte=datetime.now() - timedelta(days=30))),
+        lastYear=Count('id', filter=Q(last_login__gte=datetime.now() - timedelta(days=365))),
+        thisYear=Count('id', filter=Q(last_login__gte=datetime(datetime.now().year, 1, 1))),
+    )
+
     return create_json_response({
         'projectsCount': {k: projects.count() for k, projects in project_models.items()},
         'familiesCount': {
@@ -79,6 +88,7 @@ def seqr_stats(request):
         'individualsCount': {
             k: Individual.objects.filter(family__project__in=projects).count() for k, projects in project_models.items()
         },
+        'usersCounts': user_counts,
         'sampleCountsByType': grouped_sample_counts,
     })
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -63,12 +63,13 @@ def seqr_stats(request):
         families_count[key] = agg['family_count']
         individuals_count[key] = agg['individual_count']
 
+    now = datetime.now()
     user_counts = User.objects.filter(is_active=True).aggregate(
         total=Count('id'),
         multipleLogins=Count('id', filter=Q(last_login__isnull=False) & ~Q(last_login=F('date_joined'))),
-        lastMonth=Count('id', filter=Q(last_login__gte=datetime.now() - timedelta(days=30))),
-        lastYear=Count('id', filter=Q(last_login__gte=datetime.now() - timedelta(days=365))),
-        thisYear=Count('id', filter=Q(last_login__gte=datetime(datetime.now().year, 1, 1))),
+        lastMonth=Count('id', filter=Q(last_login__gte=now - timedelta(days=30))),
+        lastYear=Count('id', filter=Q(last_login__gte=now - timedelta(days=365))),
+        thisYear=Count('id', filter=Q(last_login__gte=datetime(now.year, 1, 1))),
     )
 
     return create_json_response({
@@ -97,7 +98,7 @@ def _get_project_aggregated_qs(additional_model=None, additional_aggs=None):
         models.annotate(**agg_fields[i], **(additional_aggs or {})).filter(demo__isnull=False).values(
             'sample_type', 'dataset_type', *agg_fields[i], *(additional_aggs or []),
         ).annotate(count=Count('active_individuals')) for i, models in enumerate([
-            Dataset.objects, RnaSample.objects.annotate(
+            Dataset.objects, RnaSample.objects.filter(is_active=True).annotate(
                 sample_type=Value('RNA'), dataset_type=F('data_type'), active_individuals=F('individual_id'), loaded_date=F('created_date'),
             ),
         ])
@@ -143,11 +144,11 @@ def sample_stats_download(request):
     return export_table('seqr_sample_loading', header, rows, file_format)
 
 
-def _format_export_row(loaded, count, sample_type, dataset_type, demo, no_anvil=0, is_internal=0):
+def _format_export_row(loaded, count, sample_type, dataset_type, demo, no_anvil='', is_internal=''):
     row = [loaded.strftime('%Y-%m-%d'), count, sample_type, DATASET_TYPE_LOOKUP.get(dataset_type, 'Unknown'), demo]
     if no_anvil:
         row.append('No AnVIL')
-    elif is_internal is not 0:
+    elif is_internal != '':
         row.append('Internal' if is_internal else 'External')
     return row
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -130,7 +130,10 @@ DATASET_TYPE_LOOKUP = {
 @pm_or_analyst_required
 def sample_stats_download(request):
     dataset_qs_list = _get_project_aggregated_qs(additional_aggs={'loaded': TruncDate('loaded_date')})
-    rows = sorted([_format_export_row(**item) for qs in dataset_qs_list for item in qs], key=lambda row: row[0])
+    rows = sorted(
+        [_format_export_row(**item) for qs in dataset_qs_list for item in qs],
+        key=lambda row: (row[0], -row[1], *row[2:]),
+    )
 
     header = HEADER
     if anvil_enabled():

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -41,10 +41,10 @@ airtable_enabled_analyst_required = active_user_has_policies_and_passes_test(
 
 @pm_or_analyst_required
 def seqr_stats(request):
-    project_qs, dataset_qs = _get_project_aggregated_qs(additional_model=(Project, ''))
+    project_qs, dataset_qs_list = _get_project_aggregated_qs(additional_model=(Project, ''))
 
     grouped_sample_counts = defaultdict(dict)
-    for qs in dataset_qs:
+    for qs in dataset_qs_list:
         for agg in qs:
             grouped_sample_counts[f"{agg['sample_type']}__{agg['dataset_type']}"][_agg_key(agg)] = agg['count']
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from django.db.models import Count, Q, F, Value
 from django.db.models.expressions import Case, When
+from django.db.models.functions import TruncDate
 from django.contrib.auth.models import User
 from django.contrib.postgres.aggregates import ArrayAgg
 import json
@@ -18,7 +19,7 @@ from seqr.views.utils.airtable_utils import AirtableSession
 from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, anvil_export_airtable_fields, \
     FAMILY_ROW_TYPE, SUBJECT_ROW_TYPE, SAMPLE_ROW_TYPE, DISCOVERY_ROW_TYPE, PARTICIPANT_TABLE, PHENOTYPE_TABLE, \
     EXPERIMENT_TABLE, EXPERIMENT_LOOKUP_TABLE, FINDINGS_TABLE, GENE_COLUMN, FAMILY_INDIVIDUAL_FIELDS
-from seqr.views.utils.export_utils import export_multiple_files, write_multiple_files
+from seqr.views.utils.export_utils import export_multiple_files, write_multiple_files, export_table
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_queryset
 from seqr.views.utils.permissions_utils import user_is_analyst, get_project_and_check_permissions, \
@@ -79,7 +80,7 @@ def seqr_stats(request):
     })
 
 
-def _get_project_aggregated_qs(additional_model=None):
+def _get_project_aggregated_qs(additional_model=None, additional_aggs=None):
     prefixes = ['active_individuals__family__project__', 'individual__family__project__']
     if additional_model:
         prefixes.append(additional_model[1])
@@ -93,11 +94,12 @@ def _get_project_aggregated_qs(additional_model=None):
             })
 
     dataset_qs = [
-        models.annotate(**agg_fields[i]).filter(demo__isnull=False).values(
-            'sample_type', 'dataset_type', *agg_fields[i],
+        models.annotate(**agg_fields[i], **(additional_aggs or {})).filter(demo__isnull=False).values(
+            'sample_type', 'dataset_type', *agg_fields[i], *(additional_aggs or []),
         ).annotate(count=Count('active_individuals')) for i, models in enumerate([
-            Dataset.objects,
-            RnaSample.objects.annotate(sample_type=Value('RNA'), dataset_type=F('data_type'), active_individuals=F('individual_id')),
+            Dataset.objects, RnaSample.objects.annotate(
+                sample_type=Value('RNA'), dataset_type=F('data_type'), active_individuals=F('individual_id'), loaded_date=F('created_date'),
+            ),
         ])
     ]
 
@@ -116,6 +118,35 @@ def _agg_key(agg):
     elif 'is_internal' in agg:
         return 'internal' if agg['is_internal'] else 'external'
     return 'non_demo'
+
+
+HEADER = ['date_loaded', 'num_samples', 'sample_type', 'dataset_type', 'is_demo']
+DATASET_TYPE_LOOKUP = {
+    **RnaSample.DATA_TYPE_LOOKUP,
+    **{k: v.split(' ')[0] for k, v in Dataset.DATASET_TYPE_LOOKUP.items()},
+}
+
+
+@pm_or_analyst_required
+def sample_stats_download(request):
+    dataset_qs_list = _get_project_aggregated_qs(additional_aggs={'loaded': TruncDate('loaded_date')})
+    rows = sorted([_format_export_row(**item) for qs in dataset_qs_list for item in qs], key=lambda row: row[0])
+
+    header = HEADER
+    if anvil_enabled():
+        header = header + ['anvil_status']
+
+    file_format = request.GET.get('file_format', 'tsv')
+    return export_table('seqr_sample_loading', header, rows, file_format)
+
+
+def _format_export_row(loaded, count, sample_type, dataset_type, demo, no_anvil=0, is_internal=0):
+    row = [loaded.strftime('%Y-%m-%d'), count, sample_type, DATASET_TYPE_LOOKUP.get(dataset_type, 'Unknown'), demo]
+    if no_anvil:
+        row.append('No AnVIL')
+    elif is_internal is not 0:
+        row.append('Internal' if is_internal else 'External')
+    return row
 
 
 # AnVIL metadata

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -44,24 +44,24 @@ airtable_enabled_analyst_required = active_user_has_policies_and_passes_test(
 def seqr_stats(request):
     project_qs, dataset_qs_list = _get_project_aggregated_qs(additional_model=(Project, ''))
 
-    grouped_sample_counts = defaultdict(dict)
+    grouped_sample_counts = defaultdict(lambda: defaultdict(int))
     for qs in dataset_qs_list:
         for agg in qs:
-            grouped_sample_counts[f"{agg['sample_type']}__{agg['dataset_type']}"][_agg_key(agg)] = agg['count']
+            grouped_sample_counts[f"{agg['sample_type']}__{agg['dataset_type']}"][_agg_key(agg)] += agg['count']
 
     project_aggs = project_qs.annotate(
         count=Count('id', distinct=True),
         family_count=Count('family', distinct=True),
         individual_count=Count('family__individual', distinct=True),
     )
-    project_counts = {}
-    families_count = {}
-    individuals_count = {}
+    project_counts = defaultdict(int)
+    families_count = defaultdict(int)
+    individuals_count = defaultdict(int)
     for agg in project_aggs:
         key = _agg_key(agg)
-        project_counts[key] = agg['count']
-        families_count[key] = agg['family_count']
-        individuals_count[key] = agg['individual_count']
+        project_counts[key] += agg['count']
+        families_count[key] += agg['family_count']
+        individuals_count[key] += agg['individual_count']
 
     now = datetime.now()
     user_counts = User.objects.filter(is_active=True).aggregate(

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -683,11 +683,14 @@ class ReportAPITest(AirtableTest):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_json = response.json()
-        self.assertSetEqual(set(response_json.keys()), {'projectsCount', 'individualsCount', 'familiesCount', 'sampleCountsByType'})
+        self.assertSetEqual(set(response_json.keys()), {'projectsCount', 'individualsCount', 'familiesCount', 'sampleCountsByType', 'usersCounts'})
         self.assertDictEqual(response_json['projectsCount'], self.STATS_DATA['projectsCount'])
         self.assertDictEqual(response_json['individualsCount'], self.STATS_DATA['individualsCount'])
         self.assertDictEqual(response_json['familiesCount'], self.STATS_DATA['familiesCount'])
         self.assertDictEqual(response_json['sampleCountsByType'], self.STATS_DATA['sampleCountsByType'])
+        self.assertDictEqual(response_json['usersCounts'], {
+            'total': 10, 'multipleLogins': 7, 'lastMonth': 5, 'lastYear': 5, 'thisYear': 5,
+        })
 
         self.check_no_analyst_no_access(url, has_override=self.HAS_PM_OVERRIDE)
 

--- a/seqr/views/apis/report_api_tests.py
+++ b/seqr/views/apis/report_api_tests.py
@@ -5,7 +5,7 @@ import responses
 from settings import AIRTABLE_URL
 
 from seqr.models import Project, RnaSample
-from seqr.views.apis.report_api import seqr_stats, anvil_export, gregor_export, family_metadata, variant_metadata
+from seqr.views.apis.report_api import seqr_stats, sample_stats_download, anvil_export, gregor_export, family_metadata, variant_metadata
 from seqr.views.utils.test_utils import AuthenticationTestCase, AnvilAuthenticationTestCase, AirtableTest
 
 
@@ -691,6 +691,22 @@ class ReportAPITest(AirtableTest):
         self.assertDictEqual(response_json['usersCounts'], {
             'total': 10, 'multipleLogins': 7, 'lastMonth': 5, 'lastYear': 5, 'thisYear': 5,
         })
+
+        self.check_no_analyst_no_access(url, has_override=self.HAS_PM_OVERRIDE)
+
+    def test_sample_stats_download(self):
+        no_access_project = Project.objects.get(id=3)
+        no_access_project.workspace_namespace = None
+        no_access_project.save()
+
+        url = reverse(sample_stats_download)
+        self.check_analyst_login(url)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            [line.split('\t') for line in response.content.decode().strip('\n').split('\n')], self.EXPORT_DATA,
+        )
 
         self.check_no_analyst_no_access(url, has_override=self.HAS_PM_OVERRIDE)
 
@@ -1560,6 +1576,17 @@ class LocalReportAPITest(AuthenticationTestCase, ReportAPITest):
             'RNA__E': {'non_demo': 1},
         },
     }
+    EXPORT_DATA = [
+        ['date_loaded', 'num_samples', 'sample_type', 'dataset_type', 'is_demo'],
+        ['2017-02-05', '7', 'WES', 'Variant', 'False'],
+        ['2017-02-05', '3', 'RNA', 'Splice Outlier', 'False'],
+        ['2017-02-05', '2', 'RNA', 'TPM', 'False'],
+        ['2017-02-05', '1', 'RNA', 'Expression Outlier', 'False'],
+        ['2018-02-05', '3', 'WES', 'SV', 'False'],
+        ['2018-02-05', '3', 'WGS', 'SV', 'False'],
+        ['2020-02-05', '1', 'WGS', 'Variant', 'True'],
+        ['2022-02-05', '1', 'WES', 'Mitochondria', 'False'],
+    ]
 
     def _check_anvil_export_response(self, response, *args):
         self.assertEqual(response.status_code, 403)
@@ -1587,3 +1614,15 @@ class AnvilReportAPITest(AnvilAuthenticationTestCase, ReportAPITest):
             'RNA__E': {'internal': 1},
         },
     }
+    EXPORT_DATA = [
+        ['date_loaded', 'num_samples', 'sample_type', 'dataset_type', 'is_demo', 'anvil_status'],
+        ['2017-02-05', '7', 'WES', 'Variant', 'False', 'Internal'],
+        ['2017-02-05', '2', 'RNA', 'Splice Outlier', 'False', 'Internal'],
+        ['2017-02-05', '2', 'RNA', 'TPM', 'False', 'Internal'],
+        ['2017-02-05', '1', 'RNA', 'Expression Outlier', 'False', 'Internal'],
+        ['2017-02-05', '1', 'RNA', 'Splice Outlier', 'False', 'External'],
+        ['2018-02-05', '3', 'WES', 'SV', 'False', 'Internal'],
+        ['2018-02-05', '3', 'WGS', 'SV', 'False', 'External'],
+        ['2020-02-05', '1', 'WGS', 'Variant', 'True', 'No AnVIL'],
+        ['2022-02-05', '1', 'WES', 'Mitochondria', 'False', 'Internal'],
+    ]

--- a/ui/pages/Report/components/SeqrStats.jsx
+++ b/ui/pages/Report/components/SeqrStats.jsx
@@ -76,13 +76,15 @@ const SeqrStats = React.memo(({ stats, error, loading, load, user }) => (
                   <Table.HeaderCell />
                   <Table.HeaderCell content="Users" />
                 </Table.Row>
+              </Table.Header>
+              <Table.Body>
                 {USER_ROWS.map(({ title, key }) => (
                   <Table.Row key={key}>
                     <Table.HeaderCell textAlign="right" content={title} />
                     <Table.Cell content={(stats.usersCounts || {})[key]} />
                   </Table.Row>
                 ))}
-              </Table.Header>
+              </Table.Body>
             </Table>
           </Grid.Column>
         </Grid.Row>

--- a/ui/pages/Report/components/SeqrStats.jsx
+++ b/ui/pages/Report/components/SeqrStats.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
-import { Header, Table } from 'semantic-ui-react'
+import { Header, Table, Grid } from 'semantic-ui-react'
 
 import { getUser } from 'redux/selectors'
 import DataLoader from 'shared/components/DataLoader'
@@ -22,38 +22,67 @@ const COLUMN_MAP = {
     DEMO_COLUMN,
   ],
 }
+const USER_ROWS = [
+  { title: 'Total', key: 'total' },
+  { title: 'Logged In More Than Once', key: 'multipleLogins' },
+  { title: 'Logged In Within 30 Days', key: 'lastMonth' },
+  { title: 'Logged In Within 365 Days', key: 'lastYear' },
+  { title: 'Logged In This Year', key: 'thisYear' },
+]
 
 const SeqrStats = React.memo(({ stats, error, loading, load, user }) => (
   <div>
     <Header size="large" content="Seqr Stats:" />
     <DataLoader load={load} content={Object.keys(stats).length} loading={loading} errorMessage={error}>
-      <Table collapsing basic="very" textAlign="right">
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell />
-            {COLUMN_MAP[user.isAnvil].map(({ title }) => <Table.HeaderCell key={title} content={title} />)}
-          </Table.Row>
-        </Table.Header>
-        {['Projects', 'Families', 'Individuals'].map(field => (
-          <Table.Row key={field}>
-            <Table.HeaderCell textAlign="right" content={field} />
-            {COLUMN_MAP[user.isAnvil].map(({ key }) => (
-              <Table.Cell key={key} content={(stats[`${field.toLowerCase()}Count`] || {})[key]} />
-            ))}
-          </Table.Row>
-        ))}
-        {Object.keys(stats.sampleCountsByType || {}).sort().map(sampleTypes => (
-          <Table.Row key={sampleTypes}>
-            <Table.HeaderCell
-              textAlign="right"
-              content={`${sampleTypes.split('__')[0]}${DATASET_TITLE_LOOKUP[sampleTypes.split('__')[1]] || ''} samples`}
-            />
-            {COLUMN_MAP[user.isAnvil].map(({ key }) => (
-              <Table.Cell key={key} content={stats.sampleCountsByType[sampleTypes][key]} />
-            ))}
-          </Table.Row>
-        ))}
-      </Table>
+      <Grid columns={2}>
+        <Grid.Row>
+          <Grid.Column>
+            <Table collapsing basic="very" textAlign="right">
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell />
+                  {COLUMN_MAP[user.isAnvil].map(({ title }) => <Table.HeaderCell key={title} content={title} />)}
+                </Table.Row>
+              </Table.Header>
+              {['Projects', 'Families', 'Individuals'].map(field => (
+                <Table.Row key={field}>
+                  <Table.HeaderCell textAlign="right" content={field} />
+                  {COLUMN_MAP[user.isAnvil].map(({ key }) => (
+                    <Table.Cell key={key} content={(stats[`${field.toLowerCase()}Count`] || {})[key]} />
+                  ))}
+                </Table.Row>
+              ))}
+              {Object.keys(stats.sampleCountsByType || {}).sort().map(sampleTypes => (
+                <Table.Row key={sampleTypes}>
+                  <Table.HeaderCell
+                    textAlign="right"
+                    content={`${sampleTypes.split('__')[0]}${DATASET_TITLE_LOOKUP[sampleTypes.split('__')[1]] || ''} samples`}
+                  />
+                  {COLUMN_MAP[user.isAnvil].map(({ key }) => (
+                    <Table.Cell key={key} content={stats.sampleCountsByType[sampleTypes][key]} />
+                  ))}
+                </Table.Row>
+              ))}
+            </Table>
+          </Grid.Column>
+          <Grid.Column>
+            <Table collapsing basic="very" textAlign="right">
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell />
+                  <Table.HeaderCell content="Users" />
+                </Table.Row>
+                {USER_ROWS.map(({ title, key }) => (
+                  <Table.Row key={key}>
+                    <Table.HeaderCell textAlign="right" content={title} />
+                    <Table.Cell content={(stats.usersCounts || {})[key]} />
+                  </Table.Row>
+                ))}
+              </Table.Header>
+            </Table>
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
     </DataLoader>
   </div>
 ))

--- a/ui/pages/Report/components/SeqrStats.jsx
+++ b/ui/pages/Report/components/SeqrStats.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { Header, Table, Grid } from 'semantic-ui-react'
 
 import { getUser } from 'redux/selectors'
+import ExportTableButton from 'shared/components/buttons/ExportTableButton'
 import DataLoader from 'shared/components/DataLoader'
 import { DATASET_TITLE_LOOKUP } from 'shared/utils/constants'
 import { getSeqrStatsLoading, getSeqrStatsLoadingError, getSeqrStats } from '../selectors'
@@ -29,6 +30,8 @@ const USER_ROWS = [
   { title: 'Logged In Within 365 Days', key: 'lastYear' },
   { title: 'Logged In This Year', key: 'thisYear' },
 ]
+
+const EXPORT_SAMPLES_CONFIG = [{ name: 'Sample History', url: '/api/report/sample_stats_download' }]
 
 const SeqrStats = React.memo(({ stats, error, loading, load, user }) => (
   <div>
@@ -64,6 +67,7 @@ const SeqrStats = React.memo(({ stats, error, loading, load, user }) => (
                 </Table.Row>
               ))}
             </Table>
+            <ExportTableButton downloads={EXPORT_SAMPLES_CONFIG} buttonText="Download Sample Loading History" />
           </Grid.Column>
           <Grid.Column>
             <Table collapsing basic="very" textAlign="right">


### PR DESCRIPTION
## Pull request overview

Adds new metrics and export functionality to the Report “Seqr Stats” view, expanding the dashboard to include user login/activity counts and enabling download of sample loading history.

**Changes:**
- Updated Seqr stats API aggregation to return user activity counts and to support grouped sample-load exports.
- Added a new `sample_stats_download` API endpoint (wired into URLs) that exports daily sample load counts (TSV/XLS).
- Updated the Seqr Stats UI to show a Users table and provide an export button for sample loading history.