### PR TITLE
Permission helper refactor

### DIFF
--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -21,7 +21,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import _get_json_for_model, get_json_for_saved_variants, \
     get_json_for_matchmaker_submission, get_json_for_matchmaker_submissions
 from seqr.views.utils.permissions_utils import check_mme_permissions, check_family_view_permission, analyst_required, \
-    has_project_permissions, login_and_policies_required, get_project_and_check_edit_permission
+    has_family_view_permission, login_and_policies_required, get_project_and_check_edit_permission
 
 from settings import BASE_URL, MME_ACCEPT_HEADER, MME_NODES, MME_DEFAULT_CONTACT_EMAIL, \
     MME_SLACK_SEQR_MATCH_NOTIFICATION_CHANNEL, MME_SLACK_ALERT_NOTIFICATION_CHANNEL, VLM_SEND_EMAIL
@@ -434,7 +434,7 @@ def _parse_mme_results(submission, saved_results, user, additional_genes=None, r
         result['matchStatus'] = _get_json_for_model(result_model)
         if result_model.originating_submission:
             originating_family = result_model.originating_submission.individual.family
-            if has_project_permissions(originating_family.project, user):
+            if has_family_view_permission(originating_family, user):
                 result['originatingSubmission'] = {
                     'originatingSubmissionGuid': result_model.originating_submission.guid,
                     'familyGuid': originating_family.guid,

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -20,7 +20,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import _get_json_for_model, get_json_for_saved_variants, \
     get_json_for_matchmaker_submission, get_json_for_matchmaker_submissions
-from seqr.views.utils.permissions_utils import check_mme_permissions, check_project_permissions, analyst_required, \
+from seqr.views.utils.permissions_utils import check_mme_permissions, check_family_view_permissions, analyst_required, \
     has_project_permissions, login_and_policies_required, get_project_and_check_permissions
 
 from settings import BASE_URL, MME_ACCEPT_HEADER, MME_NODES, MME_DEFAULT_CONTACT_EMAIL, \
@@ -273,7 +273,7 @@ def update_mme_submission(request, submission_guid=None):
         if not individual_guid:
             return create_json_response({}, status=400, reason='Individual is required for a new submission')
         individual = Individual.objects.get(guid=individual_guid)
-        check_project_permissions(individual.family.project, request.user)
+        check_family_view_permissions(individual.family, request.user)
         submission = create_model_from_json(MatchmakerSubmission, {
             'individual': individual,
             'submission_id': individual.guid,

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -20,7 +20,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import _get_json_for_model, get_json_for_saved_variants, \
     get_json_for_matchmaker_submission, get_json_for_matchmaker_submissions
-from seqr.views.utils.permissions_utils import check_mme_permissions, check_family_view_permissions, analyst_required, \
+from seqr.views.utils.permissions_utils import check_mme_permissions, check_family_view_permission, analyst_required, \
     has_project_permissions, login_and_policies_required, get_project_and_check_edit_permission
 
 from settings import BASE_URL, MME_ACCEPT_HEADER, MME_NODES, MME_DEFAULT_CONTACT_EMAIL, \
@@ -273,7 +273,7 @@ def update_mme_submission(request, submission_guid=None):
         if not individual_guid:
             return create_json_response({}, status=400, reason='Individual is required for a new submission')
         individual = Individual.objects.get(guid=individual_guid)
-        check_family_view_permissions(individual.family, request.user)
+        check_family_view_permission(individual.family, request.user)
         submission = create_model_from_json(MatchmakerSubmission, {
             'individual': individual,
             'submission_id': individual.guid,

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -36,7 +36,7 @@ MAX_SUBMISSION_VARIANTS = 5
 @login_and_policies_required
 def get_individual_mme_matches(request, submission_guid):
     submission = MatchmakerSubmission.objects.get(guid=submission_guid)
-    project = check_mme_permissions(submission, request.user)
+    genome_version = check_mme_permissions(submission, request.user)
 
     results = MatchmakerResult.objects.filter(submission=submission)
 
@@ -51,7 +51,7 @@ def get_individual_mme_matches(request, submission_guid):
 
     variants = get_json_for_saved_variants(
         SavedVariant.objects.filter(guid__in=variant_guids), additional_values={
-            'genomeVersion': Value(project.genome_version),
+            'genomeVersion': Value(genome_version),
             'selectedMainTranscript': F('main_transcript'),
             'xposEnd': F('xpos_end'),
         },

--- a/matchmaker/views/matchmaker_api.py
+++ b/matchmaker/views/matchmaker_api.py
@@ -21,7 +21,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import _get_json_for_model, get_json_for_saved_variants, \
     get_json_for_matchmaker_submission, get_json_for_matchmaker_submissions
 from seqr.views.utils.permissions_utils import check_mme_permissions, check_family_view_permissions, analyst_required, \
-    has_project_permissions, login_and_policies_required, get_project_and_check_permissions
+    has_project_permissions, login_and_policies_required, get_project_and_check_edit_permission
 
 from settings import BASE_URL, MME_ACCEPT_HEADER, MME_NODES, MME_DEFAULT_CONTACT_EMAIL, \
     MME_SLACK_SEQR_MATCH_NOTIFICATION_CHANNEL, MME_SLACK_ALERT_NOTIFICATION_CHANNEL, VLM_SEND_EMAIL
@@ -390,7 +390,7 @@ def send_mme_contact_email(request, matchmaker_result_guid):
 
 @login_and_policies_required
 def update_mme_project_contact(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     request_json = json.loads(request.body)
     contact = (request_json.get('contact') or '').strip()

--- a/seqr/views/apis/analysis_group_api.py
+++ b/seqr/views/apis/analysis_group_api.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import PermissionDenied
 import json
 
 from seqr.models import AnalysisGroup, DynamicAnalysisGroup, Family

--- a/seqr/views/apis/analysis_group_api.py
+++ b/seqr/views/apis/analysis_group_api.py
@@ -1,10 +1,11 @@
+from django.core.exceptions import PermissionDenied
 import json
 
 from seqr.models import AnalysisGroup, DynamicAnalysisGroup, Family
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_create_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_analysis_group
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, login_and_policies_required
+from seqr.views.utils.permissions_utils import get_project_and_check_edit_permission, login_and_policies_required
 
 
 REQUIRED_FIELDS = {'name': 'Name', 'familyGuids': 'Families'}
@@ -12,7 +13,7 @@ REQUIRED_FIELDS = {'name': 'Name', 'familyGuids': 'Families'}
 
 def _update_analysis_group(request, project_guid, analysis_group_guid, model_cls, required_fields, is_dynamic=False,
                            validate_body=lambda x: None, post_process_model=lambda x: None):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     request_json = json.loads(request.body)
     missing_fields = [field for field in required_fields.keys() if not request_json.get(field)]
@@ -79,7 +80,7 @@ def update_dynamic_analysis_group_handler(request, project_guid, analysis_group_
 
 @login_and_policies_required
 def delete_analysis_group_handler(request, project_guid, analysis_group_guid, model_cls=AnalysisGroup):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     model_cls.objects.get(guid=analysis_group_guid, project=project).delete_model(request.user, user_can_delete=True)
 
     return create_json_response({'analysisGroupsByGuid': {analysis_group_guid: None}})

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -20,7 +20,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_model,  get_json_fo
 from seqr.views.utils.project_context_utils import add_families_context, families_discovery_tags, add_project_tag_types, \
     MME_TAG_NAME
 from seqr.models import Family, FamilyAnalysedBy, Individual, FamilyNote, Dataset, VariantTag, AnalysisGroup, RnaSeqTpm, \
-    PhenotypePrioritization, Project, RnaSample
+    PhenotypePrioritization, RnaSample
 from seqr.views.utils.permissions_utils import check_project_edit_permission, get_project_and_check_pm_permissions, \
     login_and_policies_required, user_is_analyst, has_case_review_permissions, external_anvil_project_can_edit, \
     get_internal_projects, get_project_guids_user_can_view, check_family_view_permission
@@ -255,7 +255,7 @@ def _set_display_name(family_json, family_model):
 def update_family_assigned_analyst(request, family_guid):
     family = Family.objects.get(guid=family_guid)
     # assigned_analyst can be edited by anyone with access to the family
-    check_family_view_permission(family, request.user, can_edit=False)
+    check_family_view_permission(family, request.user)
 
     request_json = json.loads(request.body)
     assigned_analyst_username = request_json.get('assigned_analyst_username')

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -21,9 +21,9 @@ from seqr.views.utils.project_context_utils import add_families_context, familie
     MME_TAG_NAME
 from seqr.models import Family, FamilyAnalysedBy, Individual, FamilyNote, Dataset, VariantTag, AnalysisGroup, RnaSeqTpm, \
     PhenotypePrioritization, Project, RnaSample
-from seqr.views.utils.permissions_utils import check_project_permissions, get_project_and_check_pm_permissions, \
+from seqr.views.utils.permissions_utils import check_project_edit_permission, get_project_and_check_pm_permissions, \
     login_and_policies_required, user_is_analyst, has_case_review_permissions, external_anvil_project_can_edit, \
-    get_internal_projects, get_project_guids_user_can_view, check_family_view_permissions
+    get_internal_projects, get_project_guids_user_can_view, check_family_view_permission
 from seqr.views.utils.terra_api_utils import anvil_enabled
 from seqr.views.utils.variant_utils import get_phenotype_prioritization, get_omim_intervals_query, DISCOVERY_CATEGORY
 from seqr.utils.xpos_utils import get_chrom_pos
@@ -39,7 +39,7 @@ def family_page_data(request, family_guid):
     families = Family.objects.filter(guid=family_guid)
     family = families.get(guid=family_guid)
     project = family.project
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
     is_analyst = user_is_analyst(request.user)
     has_case_review_perm = has_case_review_permissions(project, request.user)
 
@@ -122,7 +122,7 @@ def _add_parsed_omims(omims, omim_map, intervals=None):
 @login_and_policies_required
 def family_variant_tag_summary(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     response = families_discovery_tags([{'familyGuid': family_guid}])
 
@@ -231,7 +231,7 @@ def update_family_fields_handler(request, family_guid):
     family = Family.objects.get(guid=family_guid)
 
     # check permission - can be edited by anyone with access to the family
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     request_json = json.loads(request.body)
     immutable_keys = [] if external_anvil_project_can_edit(family.project, request.user) else ['family_id']
@@ -255,7 +255,7 @@ def _set_display_name(family_json, family_model):
 def update_family_assigned_analyst(request, family_guid):
     family = Family.objects.get(guid=family_guid)
     # assigned_analyst can be edited by anyone with access to the family
-    check_family_view_permissions(family, request.user, can_edit=False)
+    check_family_view_permission(family, request.user, can_edit=False)
 
     request_json = json.loads(request.body)
     assigned_analyst_username = request_json.get('assigned_analyst_username')
@@ -282,7 +282,7 @@ def update_family_assigned_analyst(request, family_guid):
 def update_family_analysed_by(request, family_guid):
     family = Family.objects.get(guid=family_guid)
     # analysed_by can be edited by anyone with access to the family
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     request_json = json.loads(request.body)
     create_model_from_json(FamilyAnalysedBy, {'family': family, 'data_type': request_json['dataType']}, request.user)
@@ -297,7 +297,7 @@ def update_family_pedigree_image(request, family_guid):
     family = Family.objects.get(guid=family_guid)
 
     # check permission
-    check_project_permissions(family.project, request.user, can_edit=True)
+    check_project_edit_permission(family.project, request.user)
 
     if len(request.FILES) == 0:
         pedigree_image = None
@@ -324,7 +324,7 @@ def update_family_pedigree_image(request, family_guid):
 def update_family_analysis_groups(request, family_guid):
     family = Family.objects.get(guid=family_guid)
     project = family.project
-    check_project_permissions(project, request.user, can_edit=True)
+    check_project_edit_permission(project, request.user)
 
     request_json = json.loads(request.body)
     analysis_group_guids = {ag['analysisGroupGuid'] for ag in request_json.get('analysisGroups', [])}
@@ -430,7 +430,7 @@ def _get_family_column_map(record):
 @login_and_policies_required
 def create_family_note(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     return create_note_handler(
         request, FamilyNote, parent_fields={'family': family}, additional_note_fields=['noteType'],
@@ -456,7 +456,7 @@ def delete_family_note(request, family_guid, note_guid):
 @login_and_policies_required
 def get_family_rna_seq_data(request, family_guid, gene_id):
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     response = defaultdict(lambda:  defaultdict(lambda: {'individualData': {}}))
     tpm_data = RnaSeqTpm.objects.filter(
@@ -484,7 +484,7 @@ def get_family_rna_seq_data(request, family_guid, gene_id):
 @login_and_policies_required
 def get_family_phenotype_gene_scores(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     phenotype_prioritization = get_phenotype_prioritization([family_guid])
     gene_ids = {gene_id for indiv in phenotype_prioritization.values() for gene_id in indiv.keys()}

--- a/seqr/views/apis/family_api.py
+++ b/seqr/views/apis/family_api.py
@@ -23,7 +23,7 @@ from seqr.models import Family, FamilyAnalysedBy, Individual, FamilyNote, Datase
     PhenotypePrioritization, Project, RnaSample
 from seqr.views.utils.permissions_utils import check_project_permissions, get_project_and_check_pm_permissions, \
     login_and_policies_required, user_is_analyst, has_case_review_permissions, external_anvil_project_can_edit, \
-    get_internal_projects, get_project_guids_user_can_view
+    get_internal_projects, get_project_guids_user_can_view, check_family_view_permissions
 from seqr.views.utils.terra_api_utils import anvil_enabled
 from seqr.views.utils.variant_utils import get_phenotype_prioritization, get_omim_intervals_query, DISCOVERY_CATEGORY
 from seqr.utils.xpos_utils import get_chrom_pos
@@ -39,7 +39,7 @@ def family_page_data(request, family_guid):
     families = Family.objects.filter(guid=family_guid)
     family = families.get(guid=family_guid)
     project = family.project
-    check_project_permissions(project, request.user)
+    check_family_view_permissions(family, request.user)
     is_analyst = user_is_analyst(request.user)
     has_case_review_perm = has_case_review_permissions(project, request.user)
 
@@ -122,8 +122,7 @@ def _add_parsed_omims(omims, omim_map, intervals=None):
 @login_and_policies_required
 def family_variant_tag_summary(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    project = family.project
-    check_project_permissions(project, request.user)
+    check_family_view_permissions(family, request.user)
 
     response = families_discovery_tags([{'familyGuid': family_guid}])
 
@@ -135,6 +134,7 @@ def family_variant_tag_summary(request, family_guid):
     response['familyTagTypeCounts'][family_guid][MME_TAG_NAME] = tags.filter(
         saved_variants__matchmakersubmissiongenes__isnull=False).values('saved_variants__guid').distinct().count()
 
+    project = family.project
     response['projectsByGuid'] = {project.guid: {}}
     add_project_tag_types(response['projectsByGuid'], project=project)
 
@@ -230,8 +230,8 @@ def delete_families_handler(request, project_guid):
 def update_family_fields_handler(request, family_guid):
     family = Family.objects.get(guid=family_guid)
 
-    # check permission - can be edited by anyone with access to the project
-    check_project_permissions(family.project, request.user)
+    # check permission - can be edited by anyone with access to the family
+    check_family_view_permissions(family, request.user)
 
     request_json = json.loads(request.body)
     immutable_keys = [] if external_anvil_project_can_edit(family.project, request.user) else ['family_id']
@@ -254,8 +254,8 @@ def _set_display_name(family_json, family_model):
 @login_and_policies_required
 def update_family_assigned_analyst(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    # assigned_analyst can be edited by anyone with access to the project
-    check_project_permissions(family.project, request.user, can_edit=False)
+    # assigned_analyst can be edited by anyone with access to the family
+    check_family_view_permissions(family, request.user, can_edit=False)
 
     request_json = json.loads(request.body)
     assigned_analyst_username = request_json.get('assigned_analyst_username')
@@ -281,8 +281,8 @@ def update_family_assigned_analyst(request, family_guid):
 @login_and_policies_required
 def update_family_analysed_by(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    # analysed_by can be edited by anyone with access to the project
-    check_project_permissions(family.project, request.user, can_edit=False)
+    # analysed_by can be edited by anyone with access to the family
+    check_family_view_permissions(family, request.user)
 
     request_json = json.loads(request.body)
     create_model_from_json(FamilyAnalysedBy, {'family': family, 'data_type': request_json['dataType']}, request.user)
@@ -430,7 +430,7 @@ def _get_family_column_map(record):
 @login_and_policies_required
 def create_family_note(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    check_project_permissions(family.project, request.user)
+    check_family_view_permissions(family, request.user)
 
     return create_note_handler(
         request, FamilyNote, parent_fields={'family': family}, additional_note_fields=['noteType'],
@@ -456,7 +456,7 @@ def delete_family_note(request, family_guid, note_guid):
 @login_and_policies_required
 def get_family_rna_seq_data(request, family_guid, gene_id):
     family = Family.objects.get(guid=family_guid)
-    check_project_permissions(family.project, request.user)
+    check_family_view_permissions(family, request.user)
 
     response = defaultdict(lambda:  defaultdict(lambda: {'individualData': {}}))
     tpm_data = RnaSeqTpm.objects.filter(
@@ -483,12 +483,12 @@ def get_family_rna_seq_data(request, family_guid, gene_id):
 
 @login_and_policies_required
 def get_family_phenotype_gene_scores(request, family_guid):
-    project = Project.objects.get(family__guid=family_guid)
-    check_project_permissions(project, request.user)
+    family = Family.objects.get(guid=family_guid)
+    check_family_view_permissions(family, request.user)
 
     phenotype_prioritization = get_phenotype_prioritization([family_guid])
     gene_ids = {gene_id for indiv in phenotype_prioritization.values() for gene_id in indiv.keys()}
     return create_json_response({
         'phenotypeGeneScores': phenotype_prioritization,
-        'genesById': get_genes_for_variant_display(gene_ids, project.genome_version),
+        'genesById': get_genes_for_variant_display(gene_ids, family.project.genome_version),
     })

--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -15,7 +15,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_sample
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, external_anvil_project_can_edit, \
     login_and_policies_required, pm_or_data_manager_required, get_project_guids_user_can_view, user_is_data_manager, \
-    user_is_pm
+    user_is_pm, get_project_and_check_edit_permission
 
 GS_STORAGE_ACCESS_CACHE_KEY = 'gs_storage_access_cache_entry'
 GS_STORAGE_URL = 'https://storage.googleapis.com'
@@ -92,7 +92,7 @@ def _process_igv_table_handler(parse_uploaded_file, get_valid_matched_individual
 
 @pm_or_data_manager_required
 def receive_igv_table_handler(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     def _get_valid_matched_individuals(individual_dataset_mapping):
         matched_individuals = Individual.objects.filter(

--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -13,7 +13,7 @@ from seqr.views.utils.file_utils import save_uploaded_file, load_uploaded_file
 from seqr.views.utils.json_to_orm_utils import get_or_create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_sample
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, external_anvil_project_can_edit, \
+from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, external_anvil_project_can_edit, \
     login_and_policies_required, pm_or_data_manager_required, get_project_guids_user_can_view, user_is_data_manager, \
     user_is_pm, get_project_and_check_edit_permission
 
@@ -185,7 +185,7 @@ def update_individual_igv_sample(request, individual_guid):
 @login_and_policies_required
 def fetch_igv_track(request, project_guid, igv_track_path):
 
-    get_project_and_check_permissions(project_guid, request.user)
+    get_project_and_check_view_permission(project_guid, request.user)
 
     if igv_track_path.endswith('.bam.bai') and not does_file_exist(igv_track_path, user=request.user):
         igv_track_path = igv_track_path.replace('.bam.bai', '.bai')

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -24,7 +24,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_model, _get_json_fo
     GREGOR_FINDING_TAG_TYPE
 from seqr.views.utils.pedigree_info_utils import parse_pedigree_table, validate_fam_file_records, parse_hpo_terms, \
     get_valid_hpo_terms, JsonConstants, ErrorsWarningsException
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
+from seqr.views.utils.permissions_utils import get_project_and_check_edit_permission, check_project_permissions, \
     get_project_and_check_pm_permissions, login_and_policies_required, has_project_permissions, external_anvil_project_can_edit, \
     pm_or_data_manager_required, check_workspace_perm, check_family_view_permissions
 from seqr.views.utils.project_context_utils import add_project_tag_type_counts
@@ -422,7 +422,7 @@ def receive_individuals_metadata_handler(request, project_guid):
         project_guid (string): project GUID
     """
 
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     def process_records(json_records, filename=''):
         records, errors, warnings = _process_hpo_records(json_records, filename, project, request.user)
@@ -651,7 +651,7 @@ def save_individuals_metadata_table_handler(request, project_guid, upload_file_i
     """
     Handler for 'save' requests to apply HPO terms tables previously uploaded through receive_individuals_metadata_handler
     """
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     json_records, _ = load_uploaded_file(upload_file_id)
 
@@ -698,7 +698,7 @@ def save_individuals_metadata_table_handler(request, project_guid, upload_file_i
 def import_gregor_metadata(request, project_guid):
     request_json = json.loads(request.body)
     sample_type = request_json.get('sampleType', 'genome')
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     workspace_meta = check_workspace_perm(
         request.user, CAN_VIEW, request_json['workspaceNamespace'], request_json['workspaceName'],
         meta_fields=['workspace.bucketName']

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -26,7 +26,7 @@ from seqr.views.utils.pedigree_info_utils import parse_pedigree_table, validate_
     get_valid_hpo_terms, JsonConstants, ErrorsWarningsException
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
     get_project_and_check_pm_permissions, login_and_policies_required, has_project_permissions, external_anvil_project_can_edit, \
-    pm_or_data_manager_required, check_workspace_perm
+    pm_or_data_manager_required, check_workspace_perm, check_family_view_permissions
 from seqr.views.utils.project_context_utils import add_project_tag_type_counts
 from seqr.views.utils.individual_utils import delete_individuals, add_or_update_individuals_and_families
 from seqr.views.utils.variant_utils import bulk_create_tagged_variants, get_saved_variant_annotations
@@ -57,10 +57,10 @@ def update_individual_handler(request, individual_guid):
 
     individual = Individual.objects.get(guid=individual_guid)
 
-    project = individual.family.project
+    family = individual.family.project
 
-    check_project_permissions(project, request.user)
-    can_edit = has_project_permissions(project, request.user, can_edit=True)
+    check_family_view_permissions(family, request.user)
+    can_edit = has_project_permissions(family.project, request.user, can_edit=True)
 
     request_json = json.loads(request.body)
     update_json = request_json if can_edit else {k: v for k, v in request_json.items() if k in {'notes'}}
@@ -883,8 +883,8 @@ def _parse_participant_val(column, value, participant_sample_lookup):
 @login_and_policies_required
 def get_individual_rna_seq_data(request, individual_guid):
     individual = Individual.objects.get(guid=individual_guid)
-    project = individual.family.project
-    check_project_permissions(project, request.user)
+    family = individual.family
+    check_family_view_permissions(family, request.user)
 
     filters = {'sample__individual': individual}
     outlier_data = get_json_for_rna_seq_outliers(filters, significant_only=False, individual_guid=individual_guid)
@@ -892,7 +892,7 @@ def get_individual_rna_seq_data(request, individual_guid):
     genes_to_show = get_genes({
         gene_id for rna_data in outlier_data.get(individual_guid, {}).values() for gene_id, data in rna_data.items()
         if any([d['isSignificant'] for d in (data if isinstance(data, list) else [data])])
-    }, genome_version=project.genome_version)
+    }, genome_version=family.project.genome_version)
 
     return create_json_response({
         'rnaSeqData': outlier_data,

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -24,9 +24,9 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_model, _get_json_fo
     GREGOR_FINDING_TAG_TYPE
 from seqr.views.utils.pedigree_info_utils import parse_pedigree_table, validate_fam_file_records, parse_hpo_terms, \
     get_valid_hpo_terms, JsonConstants, ErrorsWarningsException
-from seqr.views.utils.permissions_utils import get_project_and_check_edit_permission, check_project_permissions, \
+from seqr.views.utils.permissions_utils import get_project_and_check_edit_permission, check_project_edit_permission, \
     get_project_and_check_pm_permissions, login_and_policies_required, has_project_permissions, external_anvil_project_can_edit, \
-    pm_or_data_manager_required, check_workspace_perm, check_family_view_permissions
+    pm_or_data_manager_required, check_workspace_perm, check_family_view_permission
 from seqr.views.utils.project_context_utils import add_project_tag_type_counts
 from seqr.views.utils.individual_utils import delete_individuals, add_or_update_individuals_and_families
 from seqr.views.utils.variant_utils import bulk_create_tagged_variants, get_saved_variant_annotations
@@ -59,7 +59,7 @@ def update_individual_handler(request, individual_guid):
 
     family = individual.family
 
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
     can_edit = has_project_permissions(family.project, request.user, can_edit=True)
 
     request_json = json.loads(request.body)
@@ -84,7 +84,7 @@ def update_individual_hpo_terms(request, individual_guid):
 
     project = individual.family.project
 
-    check_project_permissions(project, request.user, can_edit=True)
+    check_project_edit_permission(project, request.user)
 
     request_json = json.loads(request.body)
 
@@ -884,7 +884,7 @@ def _parse_participant_val(column, value, participant_sample_lookup):
 def get_individual_rna_seq_data(request, individual_guid):
     individual = Individual.objects.get(guid=individual_guid)
     family = individual.family
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     filters = {'sample__individual': individual}
     outlier_data = get_json_for_rna_seq_outliers(filters, significant_only=False, individual_guid=individual_guid)

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -57,7 +57,7 @@ def update_individual_handler(request, individual_guid):
 
     individual = Individual.objects.get(guid=individual_guid)
 
-    family = individual.family.project
+    family = individual.family
 
     check_family_view_permissions(family, request.user)
     can_edit = has_project_permissions(family.project, request.user, can_edit=True)
@@ -422,7 +422,7 @@ def receive_individuals_metadata_handler(request, project_guid):
         project_guid (string): project GUID
     """
 
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
 
     def process_records(json_records, filename=''):
         records, errors, warnings = _process_hpo_records(json_records, filename, project, request.user)
@@ -651,7 +651,7 @@ def save_individuals_metadata_table_handler(request, project_guid, upload_file_i
     """
     Handler for 'save' requests to apply HPO terms tables previously uploaded through receive_individuals_metadata_handler
     """
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
 
     json_records, _ = load_uploaded_file(upload_file_id)
 

--- a/seqr/views/apis/individual_api.py
+++ b/seqr/views/apis/individual_api.py
@@ -25,7 +25,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_model, _get_json_fo
 from seqr.views.utils.pedigree_info_utils import parse_pedigree_table, validate_fam_file_records, parse_hpo_terms, \
     get_valid_hpo_terms, JsonConstants, ErrorsWarningsException
 from seqr.views.utils.permissions_utils import get_project_and_check_edit_permission, check_project_edit_permission, \
-    get_project_and_check_pm_permissions, login_and_policies_required, has_project_permissions, external_anvil_project_can_edit, \
+    get_project_and_check_pm_permissions, login_and_policies_required, has_project_edit_permission, external_anvil_project_can_edit, \
     pm_or_data_manager_required, check_workspace_perm, check_family_view_permission
 from seqr.views.utils.project_context_utils import add_project_tag_type_counts
 from seqr.views.utils.individual_utils import delete_individuals, add_or_update_individuals_and_families
@@ -60,7 +60,7 @@ def update_individual_handler(request, individual_guid):
     family = individual.family
 
     check_family_view_permission(family, request.user)
-    can_edit = has_project_permissions(family.project, request.user, can_edit=True)
+    can_edit = has_project_edit_permission(family.project, request.user)
 
     request_json = json.loads(request.body)
     update_json = request_json if can_edit else {k: v for k, v in request_json.items() if k in {'notes'}}

--- a/seqr/views/apis/individual_api_tests.py
+++ b/seqr/views/apis/individual_api_tests.py
@@ -1060,7 +1060,7 @@ class IndividualAPITest(object):
 
     def test_individuals_metadata_table_handler(self):
         url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])
-        self.check_collaborator_login(url)
+        self.check_manager_login(url)
 
         # Send invalid requests
         header = 'family_id,indiv_id,hpo_term_yes,hpo_term_no'
@@ -1106,7 +1106,7 @@ class IndividualAPITest(object):
         read_tmp_table_logs = self._read_tmp_table_logs('6aea3d1f1bfc295340aa504370102fd5')
         offset = 2 if read_tmp_table_logs else 1
         self.assert_json_logs(None, read_tmp_table_logs, offset=offset)
-        self.assert_json_logs(self.collaborator_user, [
+        self.assert_json_logs(self.manager_user, [
             ('update Individual I000002_na19678', {'dbUpdate': mock.ANY}),
             ('update Individual I000001_na19675', {'dbUpdate': mock.ANY}),
             ('Reloading dictionary seqrdb_individual_metadata_dict', None),
@@ -1114,7 +1114,7 @@ class IndividualAPITest(object):
 
     def test_individuals_metadata_hpo_term_number_table_handler(self):
         url = reverse(receive_individuals_metadata_handler, args=['R0001_1kg'])
-        self.check_collaborator_login(url)
+        self.check_manager_login(url)
 
         header = 'family_id,individual_id,affected,hpo_number,hpo_number,sex,birth,other affected relatives,onset,expected inheritance,maternal ancestry,candidate genes'
         rows = [

--- a/seqr/views/apis/locus_list_api.py
+++ b/seqr/views/apis/locus_list_api.py
@@ -12,7 +12,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
     create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_locus_lists, get_json_for_locus_list
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_locus_list_permissions, \
+from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, check_locus_list_permissions, \
     check_user_created_object_permissions, login_and_policies_required, get_project_guids_user_can_view, \
     get_project_and_check_edit_permission
 
@@ -136,7 +136,7 @@ def delete_locus_list_handler(request, locus_list_guid):
 
 @login_and_policies_required
 def add_project_locus_lists(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     request_json = json.loads(request.body)
     locus_lists = LocusList.objects.filter(guid__in=request_json['locusListGuids'])
     for locus_list in locus_lists:

--- a/seqr/views/apis/locus_list_api.py
+++ b/seqr/views/apis/locus_list_api.py
@@ -13,7 +13,8 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_locus_lists, get_json_for_locus_list
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_locus_list_permissions, \
-    check_user_created_object_permissions, login_and_policies_required, get_project_guids_user_can_view
+    check_user_created_object_permissions, login_and_policies_required, get_project_guids_user_can_view, \
+    get_project_and_check_edit_permission
 
 logger = SeqrLogger(__name__)
 
@@ -151,7 +152,7 @@ def add_project_locus_lists(request, project_guid):
 
 @login_and_policies_required
 def delete_project_locus_lists(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     request_json = json.loads(request.body)
     locus_lists = LocusList.objects.filter(guid__in=request_json['locusListGuids'])
     for locus_list in locus_lists:

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -22,7 +22,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_f
     get_json_for_project_collaborator_list, get_json_for_matchmaker_submissions, \
     get_json_for_family_notes, _get_json_for_individuals, get_json_for_project_collaborator_groups, \
     FAMILY_ADDITIONAL_VALUES
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
+from seqr.views.utils.permissions_utils import get_project_and_check_permissions, get_project_and_check_edit_permission, \
     check_user_created_object_permissions, pm_required, user_is_pm, login_and_policies_required, \
     has_workspace_perm, has_case_review_permissions, is_internal_anvil_project, get_project_and_check_pm_permissions, \
     check_project_pm_permission, user_is_data_manager, external_anvil_project_can_edit, get_project_and_check_edit_permission
@@ -77,9 +77,7 @@ def _is_valid_anvil_workspace(request_json, user):
 
 @login_and_policies_required
 def update_project_handler(request, project_guid):
-    project = Project.objects.get(guid=project_guid)
-
-    check_project_permissions(project, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     request_json = json.loads(request.body)
     updated_fields = set()

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -22,7 +22,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_f
     get_json_for_project_collaborator_list, get_json_for_matchmaker_submissions, \
     get_json_for_family_notes, _get_json_for_individuals, get_json_for_project_collaborator_groups, \
     FAMILY_ADDITIONAL_VALUES
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, get_project_and_check_edit_permission, \
+from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, get_project_and_check_edit_permission, \
     check_user_created_object_permissions, pm_required, user_is_pm, login_and_policies_required, \
     has_workspace_perm, has_case_review_permissions, is_internal_anvil_project, get_project_and_check_pm_permissions, \
     check_project_pm_permission, user_is_data_manager, external_anvil_project_can_edit, get_project_and_check_edit_permission
@@ -129,7 +129,7 @@ def delete_project_handler(request, project_guid):
 
 @login_and_policies_required
 def project_page_data(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     update_project_from_json(project, {'last_accessed_date': timezone.now()}, request.user)
     return create_json_response({
         'projectsByGuid': {
@@ -169,7 +169,7 @@ def _get_formatted_value(value, config, *args):
 
 @login_and_policies_required
 def project_families(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
 
     family_models = Family.objects.filter(project=project)
     families = family_models.values(
@@ -213,7 +213,7 @@ def project_families(request, project_guid):
 
 @login_and_policies_required
 def project_overview(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
 
     datasets = Dataset.objects.filter(
         Q(active_individuals__family__project=project) | Q(inactive_individuals__family__project=project)
@@ -250,7 +250,7 @@ def project_overview(request, project_guid):
 
 @login_and_policies_required
 def project_collaborators(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
 
     return create_json_response({
         'projectsByGuid': {project_guid: {
@@ -262,7 +262,7 @@ def project_collaborators(request, project_guid):
 
 @login_and_policies_required
 def project_individuals(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     individuals = _get_json_for_individuals(
         Individual.objects.filter(family__project=project), user=request.user, project_guid=project_guid,
         add_hpo_details=True, has_case_review_perm=has_case_review_permissions(project, request.user))
@@ -274,7 +274,7 @@ def project_individuals(request, project_guid):
 
 @login_and_policies_required
 def project_analysis_groups(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
 
     return create_json_response({
         'analysisGroupsByGuid': get_project_analysis_groups([project], project_guid)
@@ -283,7 +283,7 @@ def project_analysis_groups(request, project_guid):
 
 @login_and_policies_required
 def project_locus_lists(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     locus_list_json, _ = get_project_locus_lists([project], request.user, include_metadata=True)
 
     return create_json_response({
@@ -294,7 +294,7 @@ def project_locus_lists(request, project_guid):
 
 @login_and_policies_required
 def project_family_notes(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     family_notes = get_json_for_family_notes(FamilyNote.objects.filter(family__project=project), is_analyst=False)
 
     return create_json_response({
@@ -303,7 +303,7 @@ def project_family_notes(request, project_guid):
 
 @login_and_policies_required
 def project_mme_submisssions(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     models = MatchmakerSubmission.objects.filter(
         individual__family__project=project).prefetch_related('matchmakersubmissiongenes_set')
 
@@ -323,7 +323,7 @@ def project_mme_submisssions(request, project_guid):
 
 @login_and_policies_required
 def project_notifications(request, project_guid, read_status):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     is_subscriber = project.subscribers.user_set.filter(id=request.user.id).exists()
     if not is_subscriber:
         max_loaded = _project_notifications(
@@ -358,14 +358,14 @@ def _project_notifications(project, notifications):
 
 @login_and_policies_required
 def mark_read_project_notifications(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     _project_notifications(project, request.user.notifications).mark_all_as_read()
     return create_json_response({'readCount': request.user.notifications.read().count(), 'unreadNotifications': []})
 
 
 @login_and_policies_required
 def subscribe_project_notifications(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     request.user.groups.add(project.subscribers)
     return create_json_response({'isSubscriber': True})
 

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -25,7 +25,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_f
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
     check_user_created_object_permissions, pm_required, user_is_pm, login_and_policies_required, \
     has_workspace_perm, has_case_review_permissions, is_internal_anvil_project, get_project_and_check_pm_permissions, \
-    check_project_pm_permission, user_is_data_manager, external_anvil_project_can_edit
+    check_project_pm_permission, user_is_data_manager, external_anvil_project_can_edit, get_project_and_check_edit_permission
 from seqr.views.utils.project_context_utils import families_discovery_tags, \
     add_project_tag_type_counts, get_project_analysis_groups, get_project_locus_lists
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated, anvil_enabled
@@ -106,7 +106,7 @@ def update_project_workspace(request, project_guid):
     if not is_anvil_authenticated(request.user):
         raise PermissionDenied()
 
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     request_json = json.loads(request.body)
     if not _is_valid_anvil_workspace(request_json, request.user):

--- a/seqr/views/apis/project_api.py
+++ b/seqr/views/apis/project_api.py
@@ -25,7 +25,7 @@ from seqr.views.utils.orm_to_json_utils import _get_json_for_project, get_json_f
 from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, get_project_and_check_edit_permission, \
     check_user_created_object_permissions, pm_required, user_is_pm, login_and_policies_required, \
     has_workspace_perm, has_case_review_permissions, is_internal_anvil_project, get_project_and_check_pm_permissions, \
-    check_project_pm_permission, user_is_data_manager, external_anvil_project_can_edit, get_project_and_check_edit_permission
+    check_project_pm_permission, user_is_data_manager, external_anvil_project_can_edit
 from seqr.views.utils.project_context_utils import families_discovery_tags, \
     add_project_tag_type_counts, get_project_analysis_groups, get_project_locus_lists
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated, anvil_enabled

--- a/seqr/views/apis/project_categories_api.py
+++ b/seqr/views/apis/project_categories_api.py
@@ -1,18 +1,15 @@
 import json
 
-from seqr.models import Project, ProjectCategory
+from seqr.models import ProjectCategory
 from seqr.views.utils.json_to_orm_utils import create_model_from_json
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import _get_json_for_project
-from seqr.views.utils.permissions_utils import check_project_permissions, login_and_policies_required
+from seqr.views.utils.permissions_utils import get_project_and_check_edit_permission, login_and_policies_required
 
 
 @login_and_policies_required
 def update_project_categories_handler(request, project_guid):
-    project = Project.objects.get(guid=project_guid)
-
-    # check permissions
-    check_project_permissions(project, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     request_json = json.loads(request.body)
 

--- a/seqr/views/apis/report_api.py
+++ b/seqr/views/apis/report_api.py
@@ -22,7 +22,7 @@ from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, anvil_ex
 from seqr.views.utils.export_utils import export_multiple_files, write_multiple_files, export_table
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_queryset
-from seqr.views.utils.permissions_utils import user_is_analyst, get_project_and_check_permissions, \
+from seqr.views.utils.permissions_utils import user_is_analyst, get_project_and_check_view_permission, \
     get_project_guids_user_can_view, get_internal_projects, pm_or_analyst_required, active_user_has_policies_and_passes_test
 from seqr.views.utils.terra_api_utils import anvil_enabled
 from seqr.views.utils.variant_utils import DISCOVERY_CATEGORY
@@ -185,7 +185,7 @@ PHENOTYPE_PROJECT_CATEGORIES = [
 
 @airtable_enabled_analyst_required
 def anvil_export(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
 
     parsed_rows = defaultdict(list)
     family_id_map = {}
@@ -1031,7 +1031,7 @@ def _get_metadata_projects(project_guid, user):
         return get_internal_projects().filter(guid__in=get_project_guids_user_can_view(user))
     if project_guid == GREGOR_CATEGORY.lower():
         return Project.objects.filter(projectcategory__name=GREGOR_CATEGORY)
-    return [get_project_and_check_permissions(project_guid, user)]
+    return [get_project_and_check_view_permission(project_guid, user)]
 
 
 ANALYSIS_DATA_TYPE_LOOKUP = dict(FamilyAnalysedBy.DATA_TYPE_CHOICES)

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 
 from clickhouse_search.models.postgres_dicts import DiscoveryVariantDict, ExcludedVariantDict
 from seqr.models import SavedVariant, VariantTagType, VariantTag, VariantNote, VariantFunctionalData,\
-    Family, GeneNote, Project, Dataset
+    Family, GeneNote, Dataset
 from seqr.utils.xpos_utils import get_xpos
 from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_create_model_from_json, \
     create_model_from_json
@@ -13,7 +13,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_variant_note, \
     get_json_for_saved_variants_child_entities, get_json_for_gene_notes_by_gene_id, STRUCTURED_METADATA_TAG_TYPES
 from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, check_project_edit_permission, \
-    login_and_policies_required, check_family_view_permission, check_projects_view_permission
+    login_and_policies_required, check_family_view_permission, check_families_view_permission
 from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json, DISCOVERY_CATEGORY
 
 
@@ -180,8 +180,8 @@ def _create_variant_note(saved_variants, note_json, user):
 @login_and_policies_required
 def update_variant_note_handler(request, variant_guids, note_guid):
     note = VariantNote.objects.get(guid=note_guid)
-    projects = Project.objects.filter(family__in=note.saved_variants.values_list('family_id', flat=True)).distinct()
-    check_projects_view_permission(projects, request.user)
+    families = Family.objects.filter(id__in=note.saved_variants.values_list('family_id', flat=True))
+    check_families_view_permission(families, request.user)
     request_json = json.loads(request.body)
     update_model_from_json(note, request_json, user=request.user, allow_unknown_keys=True)
 
@@ -197,8 +197,8 @@ def update_variant_note_handler(request, variant_guids, note_guid):
 def delete_variant_note_handler(request, variant_guids, note_guid):
     variant_guids = variant_guids.split(',')
     note = VariantNote.objects.get(guid=note_guid)
-    projects = Project.objects.filter(family__in=note.saved_variants.values_list('family_id', flat=True)).distinct()
-    check_projects_view_permission(projects, request.user)
+    families = Family.objects.filter(id__in=note.saved_variants.values_list('family_id', flat=True))
+    check_families_view_permission(families, request.user)
     note.delete_model(request.user, user_can_delete=True)
 
     saved_variants_by_guid = {}

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -13,7 +13,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_variant_note, \
     get_json_for_saved_variants_child_entities, get_json_for_gene_notes_by_gene_id, STRUCTURED_METADATA_TAG_TYPES
 from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
-    login_and_policies_required
+    login_and_policies_required, check_family_view_permissions
 from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json, DISCOVERY_CATEGORY
 
 
@@ -51,7 +51,7 @@ def saved_variant_data(request, project_guid, variant_guids=None):
 @login_and_policies_required
 def create_manual_saved_variant_handler(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    check_project_permissions(family.project, request.user)
+    check_family_view_permissions(family, request.user)
 
     variant_json = json.loads(request.body)
     tags = variant_json.pop('tags', [])
@@ -98,7 +98,7 @@ def create_saved_variant_handler(request):
     family_guid = variant_json['familyGuid']
 
     family = Family.objects.get(guid=family_guid)
-    check_project_permissions(family.project, request.user)
+    check_family_view_permissions(family, request.user)
 
     variants_json = variant_json['variant']
     if not isinstance(variant_json['variant'], list):
@@ -130,7 +130,7 @@ def create_variant_note_handler(request, variant_guids):
 
     family_guid = request_json.pop('familyGuid')
     family = Family.objects.get(guid=family_guid)
-    check_project_permissions(family.project, request.user)
+    check_family_view_permissions(family, request.user)
 
     all_variant_guids = variant_guids.split(',')
     saved_variants = SavedVariant.objects.filter(guid__in=all_variant_guids)
@@ -180,9 +180,9 @@ def _create_variant_note(saved_variants, note_json, user):
 @login_and_policies_required
 def update_variant_note_handler(request, variant_guids, note_guid):
     note = VariantNote.objects.get(guid=note_guid)
-    projects = {saved_variant.family.project for saved_variant in note.saved_variants.all()}
-    for project in projects:
-        check_project_permissions(project, request.user)
+    families = {saved_variant.family for saved_variant in note.saved_variants.all()}
+    for family in families:
+        check_family_view_permissions(family, request.user)
     request_json = json.loads(request.body)
     update_model_from_json(note, request_json, user=request.user, allow_unknown_keys=True)
 
@@ -198,9 +198,9 @@ def update_variant_note_handler(request, variant_guids, note_guid):
 def delete_variant_note_handler(request, variant_guids, note_guid):
     variant_guids = variant_guids.split(',')
     note = VariantNote.objects.get(guid=note_guid)
-    projects = {saved_variant.family.project for saved_variant in note.saved_variants.all()}
-    for project in projects:
-        check_project_permissions(project, request.user)
+    families = {saved_variant.family for saved_variant in note.saved_variants.all()}
+    for family in families:
+        check_family_view_permissions(family, request.user)
     note.delete_model(request.user, user_can_delete=True)
 
     saved_variants_by_guid = {}
@@ -238,7 +238,7 @@ def update_variant_acmg_classification_handler(request, variant_guid):
 
 def _update_variant_acmg_classification(request, variant_guid):
     saved_variant = SavedVariant.objects.get(guid=variant_guid)
-    check_project_permissions(saved_variant.family.project, request.user)
+    check_family_view_permissions(saved_variant.family, request.user)
 
     request_json = json.loads(request.body)
     variant = request_json.get('variant')
@@ -263,8 +263,8 @@ def _update_variant_tag_models(request, variant_guids, tag_key, model_cls, get_t
     request_json = json.loads(request.body)
 
     family_guid = request_json.pop('familyGuid')
-    project = Project.objects.get(family__guid=family_guid)
-    check_project_permissions(project, request.user)
+    family = Family.objects.get(guid=family_guid)
+    check_family_view_permissions(family, request.user)
 
     all_variant_guids = set(variant_guids.split(','))
     saved_variants = SavedVariant.objects.filter(guid__in=all_variant_guids)

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -12,7 +12,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_variant_note, \
     get_json_for_saved_variants_child_entities, get_json_for_gene_notes_by_gene_id, STRUCTURED_METADATA_TAG_TYPES
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_edit_permission, \
+from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, check_project_edit_permission, \
     login_and_policies_required, check_family_view_permission
 from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json, DISCOVERY_CATEGORY
 
@@ -23,7 +23,7 @@ INCLUDE_LOCUS_LISTS_PARAM = 'includeLocusLists'
 
 @login_and_policies_required
 def saved_variant_data(request, project_guid, variant_guids=None):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     family_guids = request.GET['families'].split(',') if request.GET.get('families') else None
     variant_guids = variant_guids.split(',') if variant_guids else None
 

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -12,8 +12,8 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_variant_note, \
     get_json_for_saved_variants_child_entities, get_json_for_gene_notes_by_gene_id, STRUCTURED_METADATA_TAG_TYPES
-from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_permissions, \
-    login_and_policies_required, check_family_view_permissions
+from seqr.views.utils.permissions_utils import get_project_and_check_permissions, check_project_edit_permission, \
+    login_and_policies_required, check_family_view_permission
 from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json, DISCOVERY_CATEGORY
 
 
@@ -51,7 +51,7 @@ def saved_variant_data(request, project_guid, variant_guids=None):
 @login_and_policies_required
 def create_manual_saved_variant_handler(request, family_guid):
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     variant_json = json.loads(request.body)
     tags = variant_json.pop('tags', [])
@@ -98,7 +98,7 @@ def create_saved_variant_handler(request):
     family_guid = variant_json['familyGuid']
 
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     variants_json = variant_json['variant']
     if not isinstance(variant_json['variant'], list):
@@ -130,7 +130,7 @@ def create_variant_note_handler(request, variant_guids):
 
     family_guid = request_json.pop('familyGuid')
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     all_variant_guids = variant_guids.split(',')
     saved_variants = SavedVariant.objects.filter(guid__in=all_variant_guids)
@@ -182,7 +182,7 @@ def update_variant_note_handler(request, variant_guids, note_guid):
     note = VariantNote.objects.get(guid=note_guid)
     families = {saved_variant.family for saved_variant in note.saved_variants.all()}
     for family in families:
-        check_family_view_permissions(family, request.user)
+        check_family_view_permission(family, request.user)
     request_json = json.loads(request.body)
     update_model_from_json(note, request_json, user=request.user, allow_unknown_keys=True)
 
@@ -200,7 +200,7 @@ def delete_variant_note_handler(request, variant_guids, note_guid):
     note = VariantNote.objects.get(guid=note_guid)
     families = {saved_variant.family for saved_variant in note.saved_variants.all()}
     for family in families:
-        check_family_view_permissions(family, request.user)
+        check_family_view_permission(family, request.user)
     note.delete_model(request.user, user_can_delete=True)
 
     saved_variants_by_guid = {}
@@ -238,7 +238,7 @@ def update_variant_acmg_classification_handler(request, variant_guid):
 
 def _update_variant_acmg_classification(request, variant_guid):
     saved_variant = SavedVariant.objects.get(guid=variant_guid)
-    check_family_view_permissions(saved_variant.family, request.user)
+    check_family_view_permission(saved_variant.family, request.user)
 
     request_json = json.loads(request.body)
     variant = request_json.get('variant')
@@ -264,7 +264,7 @@ def _update_variant_tag_models(request, variant_guids, tag_key, model_cls, get_t
 
     family_guid = request_json.pop('familyGuid')
     family = Family.objects.get(guid=family_guid)
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     all_variant_guids = set(variant_guids.split(','))
     saved_variants = SavedVariant.objects.filter(guid__in=all_variant_guids)
@@ -357,7 +357,7 @@ def _update_tags(saved_variants, tags_json, user, tag_key='tags', model_cls=Vari
 @login_and_policies_required
 def update_variant_main_transcript(request, variant_guid, transcript_id):
     saved_variant = SavedVariant.objects.get(guid=variant_guid)
-    check_project_permissions(saved_variant.family.project, request.user, can_edit=True)
+    check_project_edit_permission(saved_variant.family.project, request.user)
 
     update_model_from_json(saved_variant, {
         'selected_main_transcript_id': transcript_id,

--- a/seqr/views/apis/saved_variant_api.py
+++ b/seqr/views/apis/saved_variant_api.py
@@ -13,7 +13,7 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_variant_note, \
     get_json_for_saved_variants_child_entities, get_json_for_gene_notes_by_gene_id, STRUCTURED_METADATA_TAG_TYPES
 from seqr.views.utils.permissions_utils import get_project_and_check_view_permission, check_project_edit_permission, \
-    login_and_policies_required, check_family_view_permission
+    login_and_policies_required, check_family_view_permission, check_projects_view_permission
 from seqr.views.utils.variant_utils import get_variants_response, parse_saved_variant_json, DISCOVERY_CATEGORY
 
 
@@ -180,9 +180,8 @@ def _create_variant_note(saved_variants, note_json, user):
 @login_and_policies_required
 def update_variant_note_handler(request, variant_guids, note_guid):
     note = VariantNote.objects.get(guid=note_guid)
-    families = {saved_variant.family for saved_variant in note.saved_variants.all()}
-    for family in families:
-        check_family_view_permission(family, request.user)
+    projects = Project.objects.filter(family__in=note.saved_variants.values_list('family_id', flat=True)).distinct()
+    check_projects_view_permission(projects, request.user)
     request_json = json.loads(request.body)
     update_model_from_json(note, request_json, user=request.user, allow_unknown_keys=True)
 
@@ -198,9 +197,8 @@ def update_variant_note_handler(request, variant_guids, note_guid):
 def delete_variant_note_handler(request, variant_guids, note_guid):
     variant_guids = variant_guids.split(',')
     note = VariantNote.objects.get(guid=note_guid)
-    families = {saved_variant.family for saved_variant in note.saved_variants.all()}
-    for family in families:
-        check_family_view_permission(family, request.user)
+    projects = Project.objects.filter(family__in=note.saved_variants.values_list('family_id', flat=True)).distinct()
+    check_projects_view_permission(projects, request.user)
     note.delete_model(request.user, user_can_delete=True)
 
     saved_variants_by_guid = {}

--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -786,7 +786,10 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         new_variant_note = VariantNote.objects.filter(guid=updated_note_response['noteGuid'])
         self.assertEqual(len(new_variant_note), 0)
 
-        self.assert_no_list_ws_has_al(8)
+        self.mock_list_workspaces.assert_called_with(self.collaborator_user)
+        self.assertEqual(self.mock_list_workspaces.call_count, 2)
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 6)
+        self.assert_no_extra_anvil_calls()
 
     def test_create_partially_saved_compound_het_variant_note(self):
         # compound het 5 is not saved, whereas compound het 1 is saved
@@ -940,7 +943,10 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         variants = SavedVariant.objects.filter(guid__in=[COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID])
         self.assertEqual(len(variants), 0)
 
-        self.assert_no_list_ws_has_al(7)
+        self.mock_list_workspaces.assert_called_with(self.collaborator_user)
+        self.assertEqual(self.mock_list_workspaces.call_count, 3)
+        self.assertEqual(self.mock_get_ws_access_level.call_count, 4)
+        self.assert_no_extra_anvil_calls()
 
     def test_update_variant_tags(self):
         variant_tags = VariantTag.objects.filter(saved_variants__guid__contains=VARIANT_GUID)

--- a/seqr/views/apis/summary_data_api.py
+++ b/seqr/views/apis/summary_data_api.py
@@ -22,7 +22,7 @@ from seqr.utils.logging_utils import SeqrLogger
 from seqr.views.utils.orm_to_json_utils import get_json_for_matchmaker_submissions, get_json_for_saved_variants,\
     add_individual_hpo_details, INDIVIDUAL_DISPLAY_NAME_EXPR, AIP_TAG_TYPE
 from seqr.views.utils.permissions_utils import analyst_required, user_is_analyst, get_project_guids_user_can_view, \
-    login_and_policies_required, get_project_and_check_permissions, get_internal_projects
+    login_and_policies_required, get_project_and_check_view_permission, get_internal_projects
 from seqr.views.utils.anvil_metadata_utils import parse_anvil_metadata, anvil_export_airtable_fields, FAMILY_ROW_TYPE, SUBJECT_ROW_TYPE, DISCOVERY_ROW_TYPE
 from seqr.views.utils.variant_utils import get_variants_response, bulk_create_tagged_variants, get_saved_variant_annotations, DISCOVERY_CATEGORY
 from settings import SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL
@@ -305,7 +305,7 @@ def _get_metadata_projects(request, project_guid):
             raise PermissionDenied()
         projects = Project.objects.filter(projectcategory__name__iexact=GREGOR_CATEGORY)
     else:
-        projects = [get_project_and_check_permissions(project_guid, request.user)]
+        projects = [get_project_and_check_view_permission(project_guid, request.user)]
     return projects, include_airtable
 
 

--- a/seqr/views/apis/users_api.py
+++ b/seqr/views/apis/users_api.py
@@ -15,7 +15,8 @@ from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_user, get_json_for_project_collaborator_list, \
     get_project_collaborators_by_username, get_json_for_project_collaborator_groups, PROJECT_ACCESS_GROUP_NAMES
 from seqr.views.utils.permissions_utils import get_project_guids_user_can_view, get_project_and_check_permissions, \
-    login_and_policies_required, login_active_required, active_user_has_policies_and_passes_test
+    login_and_policies_required, login_active_required, active_user_has_policies_and_passes_test, \
+    get_project_and_check_edit_permission
 from seqr.views.utils.terra_api_utils import oauth_enabled, anvil_enabled
 from settings import BASE_URL, SEQR_TOS_VERSION, SEQR_PRIVACY_VERSION
 
@@ -136,7 +137,7 @@ def update_policies(request):
 
 @require_anvil_disabled
 def create_project_collaborator(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
 
     request_json = json.loads(request.body)
     if not request_json.get('email'):
@@ -185,7 +186,7 @@ def _update_existing_user(user, project, request_json):
 
 @require_anvil_disabled
 def update_project_collaborator(request, project_guid, username):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     user = User.objects.get(username=username)
 
     request_json = json.loads(request.body)
@@ -194,7 +195,7 @@ def update_project_collaborator(request, project_guid, username):
 
 @require_anvil_disabled
 def delete_project_collaborator(request, project_guid, username):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     user = User.objects.get(username=username)
 
     project.can_view_group.user_set.remove(user)
@@ -207,7 +208,7 @@ def delete_project_collaborator(request, project_guid, username):
 
 @require_anvil_disabled
 def update_project_collaborator_group(request, project_guid, name):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     group = Group.objects.get(name=name)
     request_json = json.loads(request.body)
 
@@ -224,7 +225,7 @@ def update_project_collaborator_group(request, project_guid, name):
 
 @require_anvil_disabled
 def delete_project_collaborator_group(request, project_guid, name):
-    project = get_project_and_check_permissions(project_guid, request.user, can_edit=True)
+    project = get_project_and_check_edit_permission(project_guid, request.user)
     group = Group.objects.get(name=name)
 
     remove_perm(user_or_group=group, perm=CAN_VIEW, obj=project)

--- a/seqr/views/apis/users_api.py
+++ b/seqr/views/apis/users_api.py
@@ -14,7 +14,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.json_utils import create_json_response
 from seqr.views.utils.orm_to_json_utils import get_json_for_user, get_json_for_project_collaborator_list, \
     get_project_collaborators_by_username, get_json_for_project_collaborator_groups, PROJECT_ACCESS_GROUP_NAMES
-from seqr.views.utils.permissions_utils import get_project_guids_user_can_view, get_project_and_check_permissions, \
+from seqr.views.utils.permissions_utils import get_project_guids_user_can_view, get_project_and_check_view_permission, \
     login_and_policies_required, login_active_required, active_user_has_policies_and_passes_test, \
     get_project_and_check_edit_permission
 from seqr.views.utils.terra_api_utils import oauth_enabled, anvil_enabled
@@ -49,7 +49,7 @@ def get_all_user_group_options(request):
 
 @login_and_policies_required
 def get_project_collaborator_options(request, project_guid):
-    project = get_project_and_check_permissions(project_guid, request.user)
+    project = get_project_and_check_view_permission(project_guid, request.user)
     user_fields = {'display_name', 'username', 'email'}
     users = get_project_collaborators_by_username(
         request.user, project, fields=user_fields, expand_user_groups=True,

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -276,7 +276,7 @@ MAX_FAMILIES_PER_ROW = 1000
 @login_and_policies_required
 def get_variant_gene_breakdown(request, search_hash):
     results_model = VariantSearchResults.objects.get(search_hash=search_hash)
-    projects = _check_results_permission(results_model, request.user)
+    genome_version = _check_results_permission(results_model, request.user)
 
     results = _get_variants_with_cache(_get_search_cache_key, _query_variants, results_model, request.user)
     flat_variants = [
@@ -292,7 +292,7 @@ def get_variant_gene_breakdown(request, search_hash):
 
     return create_json_response({
         'searchGeneBreakdown': {search_hash: gene_counts},
-        'genesById': get_genes_for_variant_display(list(gene_counts.keys()), projects.first().genome_version),
+        'genesById': get_genes_for_variant_display(list(gene_counts.keys()), genome_version),
     })
 
 
@@ -518,7 +518,7 @@ def _check_results_permission(results_model, user, project_perm_check=None):
         for project in {f.project for f in families.prefetch_related('project')}:
             if not project_perm_check(project):
                 raise PermissionDenied()
-    return projects
+    return families.first().project.genome_version
 
 
 def _get_search_context(results_model):

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -29,7 +29,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_saved_search,\
     get_json_for_saved_searches, FAMILY_ADDITIONAL_VALUES
 from seqr.views.utils.permissions_utils import check_family_view_permission, get_project_guids_user_can_view, \
-    login_and_policies_required, check_user_created_object_permissions, check_projects_view_permission, user_is_analyst
+    login_and_policies_required, check_user_created_object_permissions, check_families_view_permission, user_is_analyst
 from seqr.views.utils.project_context_utils import get_projects_child_entities
 from seqr.views.utils.variant_utils import get_variants_response, variant_dataset_type
 from seqr.views.utils.vlm_utils import vlm_lookup
@@ -392,29 +392,30 @@ def search_context_handler(request):
     response = _get_saved_searches(request.user)
     context = json.loads(request.body)
 
-    projects = None
+    families = None
     if context.get('projectGuid'):
-        projects = Project.objects.filter(guid=context.get('projectGuid'))
+        families = Family.objects.filter(project__guid=context.get('projectGuid'))
     elif context.get('familyGuid'):
-        projects = Project.objects.filter(family__guid=context.get('familyGuid'))
+        families = Family.objects.filter(guid=context.get('familyGuid'))
     elif context.get('analysisGroupGuid'):
-        projects = Project.objects.filter(analysisgroup__guid=context.get('analysisGroupGuid'))
+        families = Family.objects.filter(analysisgroup__guid=context.get('analysisGroupGuid'))
     elif context.get('projectCategoryGuid'):
-        projects = Project.objects.filter(projectcategory__guid=context.get('projectCategoryGuid'))
+        families = Family.objects.filter(project__projectcategory__guid=context.get('projectCategoryGuid'))
     elif context.get('searchHash'):
         search_context = context.get('searchParams')
         try:
             results_model = _get_or_create_results_model(context['searchHash'], search_context, request.user)
         except Exception as e:
             return create_json_response({'error': str(e)}, status=400, reason=str(e))
-        projects = Project.objects.filter(family__in=results_model.families.all()).distinct()
+        families = results_model.families.all()
 
-    if not projects:
+    if not families:
         error = 'Invalid context params: {}'.format(json.dumps(context))
         return create_json_response({'error': error}, status=400, reason=error)
 
-    check_projects_view_permission(projects, request.user)
+    check_families_view_permission(families, request.user)
 
+    projects = Project.objects.filter(family__in=families).distinct()
     project_guid = projects[0].guid if len(projects) == 1 else None
     response.update(get_projects_child_entities(projects, project_guid, request.user))
 
@@ -511,10 +512,10 @@ def delete_saved_search_handler(request, saved_search_guid):
 
 
 def _check_results_permission(results_model, user, project_perm_check=None):
-    projects = Project.objects.filter(family__variantsearchresults=results_model)
-    check_projects_view_permission(projects, user)
+    families = Family.objects.filter(variantsearchresults=results_model)
+    check_families_view_permission(families, user)
     if project_perm_check:
-        for project in projects:
+        for project in {f.project for f in families.prefetch_related('project')}:
             if not project_perm_check(project):
                 raise PermissionDenied()
     return projects

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -28,7 +28,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
     create_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_saved_search,\
     get_json_for_saved_searches, FAMILY_ADDITIONAL_VALUES
-from seqr.views.utils.permissions_utils import check_family_view_permissions, get_project_guids_user_can_view, \
+from seqr.views.utils.permissions_utils import check_family_view_permission, get_project_guids_user_can_view, \
     login_and_policies_required, check_user_created_object_permissions, check_projects_view_permission, user_is_analyst
 from seqr.views.utils.project_context_utils import get_projects_child_entities
 from seqr.views.utils.variant_utils import get_variants_response, variant_dataset_type
@@ -173,7 +173,7 @@ def _get_exclude_keys(search_hash, user):
 def query_single_variant_handler(request, variant_id):
     families = Family.objects.filter(guid=request.GET.get('familyGuid'))
     family = families.first()
-    check_family_view_permissions(family, request.user)
+    check_family_view_permission(family, request.user)
 
     variants = get_clickhouse_variants(families, request.user, raw_variant_items=variant_id, variant_ids=[variant_id])
     if not variants:

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -28,7 +28,7 @@ from seqr.views.utils.json_to_orm_utils import update_model_from_json, get_or_cr
     create_model_from_json
 from seqr.views.utils.orm_to_json_utils import get_json_for_saved_variants_with_tags, get_json_for_saved_search,\
     get_json_for_saved_searches, FAMILY_ADDITIONAL_VALUES
-from seqr.views.utils.permissions_utils import check_project_permissions, get_project_guids_user_can_view, \
+from seqr.views.utils.permissions_utils import check_family_view_permissions, get_project_guids_user_can_view, \
     login_and_policies_required, check_user_created_object_permissions, check_projects_view_permission, user_is_analyst
 from seqr.views.utils.project_context_utils import get_projects_child_entities
 from seqr.views.utils.variant_utils import get_variants_response, variant_dataset_type
@@ -173,7 +173,7 @@ def _get_exclude_keys(search_hash, user):
 def query_single_variant_handler(request, variant_id):
     families = Family.objects.filter(guid=request.GET.get('familyGuid'))
     family = families.first()
-    check_project_permissions(family.project, request.user)
+    check_family_view_permissions(family, request.user)
 
     variants = get_clickhouse_variants(families, request.user, raw_variant_items=variant_id, variant_ids=[variant_id])
     if not variants:

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -518,7 +518,8 @@ def _check_results_permission(results_model, user, project_perm_check=None):
         for project in {f.project for f in families.prefetch_related('project')}:
             if not project_perm_check(project):
                 raise PermissionDenied()
-    return families.first().project.genome_version
+    family = families.first()
+    return family.project.genome_version if family else None
 
 
 def _get_search_context(results_model):

--- a/seqr/views/utils/orm_to_json_utils.py
+++ b/seqr/views/utils/orm_to_json_utils.py
@@ -12,7 +12,7 @@ from seqr.models import GeneNote, VariantNote, VariantTag, VariantFunctionalData
     get_audit_field_names, RnaSeqOutlier, RnaSeqSpliceOutlier, VariantSearchResults
 from seqr.utils.xpos_utils import get_chrom_pos
 from seqr.views.utils.json_utils import _to_camel_case
-from seqr.views.utils.permissions_utils import has_project_permissions, \
+from seqr.views.utils.permissions_utils import has_project_edit_permission, \
     project_has_anvil, get_workspace_collaborator_perms, user_is_analyst, user_is_data_manager, user_is_pm, \
     is_internal_anvil_project, get_anvil_analyst_user_emails
 from seqr.views.utils.terra_api_utils import is_anvil_authenticated, anvil_enabled
@@ -154,7 +154,7 @@ def get_json_for_projects(projects, user=None, is_analyst=None, add_project_cate
             'isAnalystProject': is_internal_anvil_project(project),
         })
         if add_permissions:
-            result['canEdit'] = has_project_permissions(project, user, can_edit=True)
+            result['canEdit'] = has_project_edit_permission(project, user)
         if add_project_category_guids_field:
             result['projectCategoryGuids'] = list(project.projectcategory_set.values_list('guid', flat=True))
 

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -245,8 +245,8 @@ def _get_all_can_view_project_guids_set(user):
     return set(get_project_guids_user_can_view(user, limit_data_manager=False))
 
 
-def check_projects_view_permission(projects, user):
-    no_access_projects = set(projects.values_list('guid', flat=True)) - _get_all_can_view_project_guids_set(user)
+def check_families_view_permission(families, user):
+    no_access_projects = set(families.values_list('project__guid', flat=True).distinct()) - _get_all_can_view_project_guids_set(user)
     if no_access_projects:
         raise PermissionDenied(f"{user} does not have sufficient permissions for {','.join(no_access_projects)}")
 

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -210,6 +210,11 @@ def check_project_permissions(project, user, **kwargs):
         user=user, project=project))
 
 
+def check_family_view_permissions(family, user):
+    check_project_permissions(family.project, user)
+    # TODO check analysis group perms
+
+
 def _is_user_created_object(obj, user):
     return obj.created_by == user
 
@@ -268,11 +273,12 @@ def get_project_guids_user_can_view(user, limit_data_manager=True):
 
 
 def check_mme_permissions(submission, user):
-    project = submission.individual.family.project
-    check_project_permissions(project, user)
+    family = submission.individual.family
+    project = family.project
+    check_family_view_permissions(family, user)
     if not (project.is_mme_enabled and not project.is_demo):
         raise PermissionDenied('Matchmaker is not enabled')
-    return project
+    return project.genome_version
 
 def has_case_review_permissions(project, user):
     if not project.has_case_review:

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -126,7 +126,7 @@ def _get_project_and_check_permissions(project_guid, user, _check_permission_fun
     return project
 
 def check_project_pm_permission(project, user, override_permission_func=None, **kwargs):
-    if user_is_pm(user) or (project.has_case_review and has_project_permissions(project, user, can_edit=True)):
+    if user_is_pm(user) or (project.has_case_review and has_project_edit_permission(project, user)):
         return
 
     if override_permission_func and override_permission_func(project, user):
@@ -140,7 +140,7 @@ def project_has_anvil(project):
 
 
 def external_anvil_project_can_edit(project, user):
-    return project_has_anvil(project) and has_project_permissions(project, user, can_edit=True) and not \
+    return project_has_anvil(project) and has_project_edit_permission(project, user) and not \
         is_internal_anvil_project(project)
 
 
@@ -188,14 +188,19 @@ def get_workspace_collaborator_perms(user, workspace_namespace, workspace_name):
     return permission_levels
 
 
-def has_project_permissions(project, user, can_edit=False):
-    permission_level = CAN_VIEW
-    if can_edit:
-        permission_level = CAN_EDIT
+def has_project_edit_permission(project, user):
+    return _has_project_permissions(project, user, CAN_EDIT)
 
-    return user_is_data_manager(user) or \
-           (not can_edit and project.all_user_demo and project.is_demo) or \
-           _user_project_permission(user, permission_level, project)
+def _has_project_view_permission(project, user):
+    if project.all_user_demo and project.is_demo:
+        return True
+    return _has_project_permissions(project, user, CAN_VIEW)
+
+def has_family_view_permission(family, user):
+    return _has_project_view_permission(family.project, user)
+
+def _has_project_permissions(project, user, permission_level):
+    return user_is_data_manager(user) or _user_project_permission(user, permission_level, project)
 
 
 def _user_project_permission(user, permission_level, project):
@@ -205,7 +210,7 @@ def _user_project_permission(user, permission_level, project):
 
 
 def check_project_edit_permission(project, user):
-    if has_project_permissions(project, user, can_edit=True):
+    if has_project_edit_permission(project, user):
         return
 
     raise PermissionDenied("{user} does not have sufficient permissions for {project}".format(
@@ -213,16 +218,17 @@ def check_project_edit_permission(project, user):
 
 
 def _check_project_view_permission(project, user):
-    if has_project_permissions(project, user):
+    if _has_project_view_permission(project, user):
         return
 
-    raise PermissionDenied("{user} does not have sufficient permissions for {project}".format(
-        user=user, project=project))
+    raise PermissionDenied(f'{user} does not have sufficient permissions for {project}')
 
 
 def check_family_view_permission(family, user):
-    _check_project_view_permission(family.project, user)
-    # TODO check analysis group perms
+    if has_family_view_permission(family, user):
+        return
+
+    raise PermissionDenied(f'{user} does not have sufficient permissions for {family}')
 
 
 def _is_user_created_object(obj, user):
@@ -293,4 +299,4 @@ def check_mme_permissions(submission, user):
 def has_case_review_permissions(project, user):
     if not project.has_case_review:
         return False
-    return has_project_permissions(project, user, can_edit=True)
+    return has_project_edit_permission(project, user)

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -111,9 +111,9 @@ def get_internal_projects():
     return Project.objects.all()
 
 def get_project_and_check_edit_permission(project_guid, user):
-    return _get_project_and_check_permissions(project_guid, user, check_project_edit_permission,)
+    return _get_project_and_check_permissions(project_guid, user, check_project_edit_permission)
 
-def get_project_and_check_permissions(project_guid, user):
+def get_project_and_check_view_permission(project_guid, user):
     return _get_project_and_check_permissions(project_guid, user, _check_project_view_permission)
 
 def get_project_and_check_pm_permissions(project_guid, user, override_permission_func=None):

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -110,9 +110,11 @@ def get_internal_projects():
         return Project.objects.filter(workspace_namespace__in=INTERNAL_NAMESPACES)
     return Project.objects.all()
 
+def get_project_and_check_edit_permission(project_guid, user):
+    return _get_project_and_check_permissions(project_guid, user, check_project_permissions, can_edit=True)
 
-def get_project_and_check_permissions(project_guid, user, **kwargs):
-    return _get_project_and_check_permissions(project_guid, user, check_project_permissions, **kwargs)
+def get_project_and_check_permissions(project_guid, user):
+    return _get_project_and_check_permissions(project_guid, user, check_project_permissions)
 
 def get_project_and_check_pm_permissions(project_guid, user, override_permission_func=None):
     return _get_project_and_check_permissions(project_guid, user, check_project_pm_permission,
@@ -202,7 +204,7 @@ def _user_project_permission(user, permission_level, project):
     return user.has_perm(permission_level, project)
 
 
-def check_project_permissions(project, user, **kwargs):
+def check_project_permissions(project, user, **kwargs): # TODO edit/view split helper
     if has_project_permissions(project, user, **kwargs):
         return
 

--- a/seqr/views/utils/permissions_utils.py
+++ b/seqr/views/utils/permissions_utils.py
@@ -111,10 +111,10 @@ def get_internal_projects():
     return Project.objects.all()
 
 def get_project_and_check_edit_permission(project_guid, user):
-    return _get_project_and_check_permissions(project_guid, user, check_project_permissions, can_edit=True)
+    return _get_project_and_check_permissions(project_guid, user, check_project_edit_permission,)
 
 def get_project_and_check_permissions(project_guid, user):
-    return _get_project_and_check_permissions(project_guid, user, check_project_permissions)
+    return _get_project_and_check_permissions(project_guid, user, _check_project_view_permission)
 
 def get_project_and_check_pm_permissions(project_guid, user, override_permission_func=None):
     return _get_project_and_check_permissions(project_guid, user, check_project_pm_permission,
@@ -204,16 +204,24 @@ def _user_project_permission(user, permission_level, project):
     return user.has_perm(permission_level, project)
 
 
-def check_project_permissions(project, user, **kwargs): # TODO edit/view split helper
-    if has_project_permissions(project, user, **kwargs):
+def check_project_edit_permission(project, user):
+    if has_project_permissions(project, user, can_edit=True):
         return
 
     raise PermissionDenied("{user} does not have sufficient permissions for {project}".format(
         user=user, project=project))
 
 
-def check_family_view_permissions(family, user):
-    check_project_permissions(family.project, user)
+def _check_project_view_permission(project, user):
+    if has_project_permissions(project, user):
+        return
+
+    raise PermissionDenied("{user} does not have sufficient permissions for {project}".format(
+        user=user, project=project))
+
+
+def check_family_view_permission(family, user):
+    _check_project_view_permission(family.project, user)
     # TODO check analysis group perms
 
 
@@ -277,7 +285,7 @@ def get_project_guids_user_can_view(user, limit_data_manager=True):
 def check_mme_permissions(submission, user):
     family = submission.individual.family
     project = family.project
-    check_family_view_permissions(family, user)
+    check_family_view_permission(family, user)
     if not (project.is_mme_enabled and not project.is_demo):
         raise PermissionDenied('Matchmaker is not enabled')
     return project.genome_version


### PR DESCRIPTION
As part of the planned work for https://github.com/broadinstitute/seqr/issues/5490 we will be adding the ability to have users who have "view" permissions on some families without having any project-level permissions at all. This PR is a no-op PR that refactors many of our permission check functions to be more explicitly scoped, to clearly specify whether they are checking view or edit permission and also to change wherever possible the "view" permission check from the project to the family level.  This PR is safe to merge on its own but does not really do much, it mostly is going to help ensure that the PR that truly changes access is more readable and to make it clear what are semantic vs functional changes

See below copilot comment for for detailed change breakdown