### PR TITLE
fix gene breakdown results in external projects

### DIFF
--- a/clickhouse_search/all_search_tests.py
+++ b/clickhouse_search/all_search_tests.py
@@ -2408,7 +2408,7 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
             cached_variant_fields=[{'selectedTranscript': CACHED_CONSEQUENCES_BY_KEY[4][1]}],
             annotations=annotations, freqs=freqs, locus=locus, project_families=[], export_data=[
                 EXPORT_DATA[0][:27], EXPORT_DATA[4][:24] + ['3 Families', '', ''],
-            ],
+            ], gene_counts={'ENSG00000097046': {'total': 1, 'families': {}}},
         )
 
         freqs = {'callset': freqs['callset']}
@@ -2443,6 +2443,10 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
                 {'selectedTranscript': CACHED_CONSEQUENCES_BY_KEY[4][1]},
             ],
             annotations=annotations, freqs=freqs, locus=locus, inheritance_mode='de_novo', project_families=[],
+            gene_counts={
+                'ENSG00000097046': {'total': 2, 'families': {}},
+                'ENSG00000177000': {'total': 1, 'families': {}},
+            },
         )
 
         self.login_collaborator()
@@ -2455,7 +2459,10 @@ class ClickhouseSearchTests(ClickhouseSearchTestCase):
                 {'selectedTranscript': CACHED_CONSEQUENCES_BY_KEY[3][3]},
                 {'selectedTranscript': CACHED_CONSEQUENCES_BY_KEY[4][1]},
             ],
-            annotations=annotations, freqs=freqs, locus=locus, inheritance_mode='de_novo',
+            annotations=annotations, freqs=freqs, locus=locus, inheritance_mode='de_novo', gene_counts={
+                'ENSG00000097046': {'total': 2, 'families': {'F000002_2': 1, 'F000003_3': 1}},
+                'ENSG00000177000': {'total': 1, 'families': {'F000003_3': 1}},
+            },
         )
 
         locus['rawItems'] = 'ENSG00000171621'

--- a/seqr/views/apis/variant_search_api.py
+++ b/seqr/views/apis/variant_search_api.py
@@ -287,7 +287,7 @@ def get_variant_gene_breakdown(request, search_hash):
         gene_ids = var['transcripts'].keys() if 'transcripts' in var else {t['geneId'] for t in var['sortedTranscriptConsequences']}
         for gene_id in gene_ids:
             gene_counts[gene_id]['total'] += 1
-            for family_guid in var['familyGuids']:
+            for family_guid in var.get('familyGuids', []):
                 gene_counts[gene_id]['families'][family_guid] += 1
 
     return create_json_response({


### PR DESCRIPTION
## Pull request overview

Fixes a crash in the variant gene-breakdown API when variant results (notably from external/no-access projects) omit `familyGuids`, and updates ClickHouse search tests to cover the corrected behavior.

**Changes:**
- Make `get_variant_gene_breakdown` tolerant of missing `familyGuids` by iterating over an empty list when absent.
- Extend `test_gene_variant_lookup` to assert gene-breakdown responses in scenarios where `familyGuids` is intentionally removed from returned variants.