### PR TITLE
cleaner VLM build triggers

### DIFF
--- a/.github/workflows/vlm-unit-tests.yaml
+++ b/.github/workflows/vlm-unit-tests.yaml
@@ -11,14 +11,13 @@ on:
       - dev
     paths:
       - 'vlm/**'
-      - '.github/workflows/*vlm*.yaml'
-      - 'clickhouse_search/fixtures/clickhouse_search.json'
-      - 'seqr/fixtures/1kg_project.json'
+      - '.github/workflows/*vlm-release.yaml'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'vlm/**'
       - '.github/workflows/*vlm*.yaml'
+      - 'clickhouse_search/migrations/*.py'
       - 'clickhouse_search/fixtures/clickhouse_search.json'
       - 'seqr/fixtures/1kg_project.json'
 


### PR DESCRIPTION
We have a github action that runs the VLM unit tests under 2 distinct condition:
- `push` will run the tests whenever there are relevant file changes after a push to dev or master. When tests from this trigger succeed they will in turn trigger a corresponding dev or prod docker and helm release
- `pull_request` will run the tests on any PR with relevant file changes

The use cases for these are different, and it therefore makes sense to use different file paths to trigger these runs. For the PR runs, we want to run the unit tests whenever there are changes to the actual VLM code OR whenever there are changes to the database schema or test database fixtures. This second case is crucial because the VLM uses the same database as seqr, so changes to that database could break the VLM and we would want to catch any inadvertent breaking changes. However, for the `push` trigger that we use to release new VLM versions, we only want to trigger that if there are actual VLM changes to release, and not if there are unrelated non-breaking database changes. This PR therefore adjusts the file paths used for the different triggers to reflect that desired behavior 