### PR TITLE
Vlm lift bug

### DIFF
--- a/vlm/match.py
+++ b/vlm/match.py
@@ -303,10 +303,14 @@ LIFTOVERS = {
 
 
 def _liftover_variant(chrom: str, pos: int, genome_build: str) -> Optional[Tuple[str, int, str]]:
-    liftover_genome_build = GENOME_VERSION_GRCh38 if genome_build == GENOME_VERSION_GRCh37 else GENOME_VERSION_GRCh37
+    if genome_build == GENOME_VERSION_GRCh38:
+        liftover_genome_build = GENOME_VERSION_GRCh37
+        chrom = f'chr{chrom}'
+    else:
+        liftover_genome_build = GENOME_VERSION_GRCh38
     if not LIFTOVERS[genome_build]:
         LIFTOVERS[genome_build] = LiftOver(
             f'{LIFTOVER_DIR}/{genome_build.lower()}_to_{liftover_genome_build.lower()}.over.chain.gz'
         )
-    lifted_coord = LIFTOVERS[genome_build].convert_coordinate(f'chr{chrom}', pos)
+    lifted_coord = LIFTOVERS[genome_build].convert_coordinate(chrom, pos)
     return (lifted_coord[0][0].replace('chr', ''), lifted_coord[0][1], liftover_genome_build) if lifted_coord and lifted_coord[0] else None

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -816,6 +816,11 @@ class VlmTestCase(AioHTTPTestCase):
             self._caplog.messages,
         )
 
+        async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh37&referenceName=1&start=39190091&referenceBases=T&alternateBases=G', headers=headers) as resp:
+            self.assertEqual(resp.status, 200)
+            resp_json = await resp.json()
+        self.assertDictEqual(resp_json, response)
+
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=hg19&referenceName=chr7&start=143270172&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()


### PR DESCRIPTION
## Pull request overview

Fixes a VLM liftover issue by adjusting chromosome naming passed into `pyliftover` so GRCh37/GRCh38 coordinate conversion works correctly, and adds a regression test to cover GRCh37 requests that rely on liftover.

**Changes:**
- Update `_liftover_variant` to use build-specific chromosome prefixing when calling `LiftOver.convert_coordinate`.
- Add a test request exercising `assemblyId=GRCh37` that should return results via liftover (lifotver was previously tested but only for lifting 38->37)