### PR TITLE
cleaner logging for skipped migrations

### DIFF
--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -82,16 +82,21 @@ class Command(BaseCommand):
             run_dir: run_details for run_dir, run_details in runs.items()
             if run_dir in success_run_dirs and run_details['run_version'] not in loaded_runs
         }
+        num_new_runs = len(new_runs)
+        new_runs = {
+            run_dir: run_details for run_dir, run_details in new_runs.items()
+            if CLICKHOUSE_MIGRATION_SENTINEL not in run_details["run_version"]
+        }
+        num_migrations = num_new_runs - len(new_runs)
+        if num_migrations:
+            logging.info(f'Skipping {num_migrations} ClickHouse migrations')
         if not new_runs:
             logger.info(f'Data already loaded for all {len(success_run_dirs)} runs')
             return
 
-        logger.info(f'Loading new samples from {len(success_run_dirs)} run(s)')
+        logger.info(f'Loading new samples from {len(new_runs)} run(s)')
         for run_dir, run_details in new_runs.items():
             try:
-                if CLICKHOUSE_MIGRATION_SENTINEL in run_details["run_version"]:
-                    logging.info(f'Skipping ClickHouse migration {run_details["genome_version"]}/{run_details["dataset_type"]}: {run_details["run_version"]}')
-                    continue
                 metadata_path = os.path.join(run_dir, 'metadata.json')
                 self._load_new_samples(metadata_path, **run_details)
             except Exception as e:

--- a/seqr/management/commands/check_for_new_samples_from_pipeline.py
+++ b/seqr/management/commands/check_for_new_samples_from_pipeline.py
@@ -82,14 +82,17 @@ class Command(BaseCommand):
             run_dir: run_details for run_dir, run_details in runs.items()
             if run_dir in success_run_dirs and run_details['run_version'] not in loaded_runs
         }
-        num_new_runs = len(new_runs)
-        new_runs = {
-            run_dir: run_details for run_dir, run_details in new_runs.items()
-            if CLICKHOUSE_MIGRATION_SENTINEL not in run_details["run_version"]
+        migration_runs = {
+            run_dir: f'{run_details["genome_version"]}/{run_details["dataset_type"]}/{run_details["run_version"]}'
+            for run_dir, run_details in new_runs.items() if CLICKHOUSE_MIGRATION_SENTINEL in run_details["run_version"]
         }
-        num_migrations = num_new_runs - len(new_runs)
-        if num_migrations:
-            logging.info(f'Skipping {num_migrations} ClickHouse migrations')
+        if migration_runs:
+            logger.info(f'Skipping {len(migration_runs)} ClickHouse migrations', extra={
+                'detail': sorted(migration_runs.values()),
+            })
+            new_runs = {
+                run_dir: run_details for run_dir, run_details in new_runs.items() if run_dir not in migration_runs
+            }
         if not new_runs:
             logger.info(f'Data already loaded for all {len(success_run_dirs)} runs')
             return

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -435,7 +435,9 @@ class CheckNewSamplesTest(object):
         if single_call:
             runs = runs[:1]
         else:
-            logs.insert(-1, ('Skipping 1 ClickHouse migrations', None))
+            logs.insert(-1, ('Skipping 1 ClickHouse migrations', {'detail': [
+                'GRCh38/SNV_INDEL/hail_search_to_clickhouse_migration_WGS_R0877_neptune',
+            ]}))
         for data_type, version in runs:
             logs.append((f'Loading new samples from {data_type}: {version}', None))
             logs += self._additional_loading_logs(data_type, version)

--- a/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
+++ b/seqr/management/tests/check_for_new_samples_from_pipeline_tests.py
@@ -418,7 +418,7 @@ class CheckNewSamplesTest(object):
 
         Dataset.objects.filter(guid=OLD_DATA_DATASET_GUID).update(sample_type='WES')
 
-    def _test_call(self, error_logs=None, run_loading_logs=None, num_runs=6):
+    def _test_call(self, error_logs=None, run_loading_logs=None, num_runs=5):
         self._set_loading_files()
         self.reset_logs()
 
@@ -431,14 +431,12 @@ class CheckNewSamplesTest(object):
         runs = [
             ('GRCh38/SNV_INDEL', 'auto__2023-08-09'), ('GRCh37/SNV_INDEL', 'manual__2023-11-02'),
             ('GRCh38/MITO', 'auto__2024-08-12'), ('GRCh38/MITO', 'auto__2025-12-02'), ('GRCh38/SV', 'auto__2024-09-14'),
-            ('GRCh38/SNV_INDEL', 'hail_search_to_clickhouse_migration_WGS_R0877_neptune'),
         ]
         if single_call:
             runs = runs[:1]
+        else:
+            logs.insert(-1, ('Skipping 1 ClickHouse migrations', None))
         for data_type, version in runs:
-            if 'hail_search_to_clickhouse_migration' in version:
-                logs.append((f'Skipping ClickHouse migration {data_type}: {version}', None))
-                continue
             logs.append((f'Loading new samples from {data_type}: {version}', None))
             logs += self._additional_loading_logs(data_type, version)
             if (run_loading_logs or {}).get(data_type):
@@ -740,7 +738,7 @@ The following 1 families failed sex check:
         airtable_logs = []
         if self.AIRTABLE_LOGS:
             airtable_logs = self.AIRTABLE_LOGS + [('Fetched 1 AnVIL Seqr Loading Requests Tracking records from airtable', None)]
-        self._test_call(num_runs=2, run_loading_logs={
+        self._test_call(num_runs=1, run_loading_logs={
             'GRCh38/SNV_INDEL': [
                 ('Loading 4 WES SNV_INDEL samples in 2 projects', None),
                 ('create Dataset D0000159_snv_indel_wes_2025_09', {'dbUpdate': mock.ANY}),


### PR DESCRIPTION
Reading the logs for check samples job has gotten difficult due to bloated unhelpful logs about skipped migrations. 

## Pull request overview

This PR refines how `check_for_new_samples_from_pipeline` logs ClickHouse migration runs that are intentionally skipped, moving from per-run skip logs to a cleaner aggregate message and aligning test expectations.

**Changes:**
- Filter out ClickHouse migration “runs” before loading, and emit a single summary log for skipped migrations.
- Update the command’s “Loading new samples…” run count to reflect only loadable (non-migration) runs.
- Adjust the management command tests to match the new logging behavior and run counts.