### PR TITLE
5384: (elanfisher) Fix header nav items being cut off on smaller screens

### DIFF
--- a/ui/shared/components/page/Header.jsx
+++ b/ui/shared/components/page/Header.jsx
@@ -17,41 +17,22 @@ const HeaderMenu = styled(Menu)`
   padding-left: 100px;
   padding-right: 100px;
 
-  /* 
-    @elanfisher:
-    The nav items need ~1780px at the default gutters, so on smaller screens
-    or when the page is zoomed the right hand items (eg. "Log out") were
-    clipped and thus occluded. Shifted the gutters and search box and then allowed 
-    the bar to wrap rather than overflow.
-  */
   @media (max-width: 1800px) {
     padding-left: 24px;
     padding-right: 24px;
   }
 
-  /*
-    @elanfisher: 
-    Flexbox wraps before it shrinks, so only allow wrapping once the search box
-    has run out of room to give. Above this the bar stays on one line. 
-  */
   @media (max-width: 1400px) {
     flex-wrap: wrap;
   }
+`
 
-  /* 
-    @elanfisher:
-    Keep the search box at its full 350px whenever it fits, and let it be the
-    first thing to give way when it does not. The basis and max are 382px,
-    350px of search plus the menu item's own 2 x 16px padding, so users who
-    were never short of space see exactly the previous layout.
-  */
-  .item.awesomebar {
-    flex: 0 1 382px;
-    min-width: 216px;
-    max-width: 382px;
-  }
+const AwesomeBarMenuItem = styled(Menu.Item)`
+  flex: 0 1 382px !important;
+  min-width: 216px;
+  max-width: 382px;
 
-  .item.awesomebar .ui.search {
+  .ui.search {
     width: 100%;
   }
 `
@@ -69,8 +50,7 @@ const PageHeader = React.memo(({ user, oauthLoginProvider, onSubmit, lastFeature
         <Menu.Item key="summary_data" as={Link} to="/summary_data" content="Summary Data" />,
         (user.isAnalyst || user.isPm) ? <Menu.Item key="report" as={Link} to="/report" content="Reports" /> : null,
         (user.isDataManager || user.isPm) ? <Menu.Item key="data_management" as={Link} to="/data_management" content="Data Management" /> : null,
-        // @elanfisher: Made the searchbar flex properly rather than be fixed at 350px.
-        <Menu.Item key="awesomebar" className="awesomebar" fitted="vertically"><AwesomeBar newWindow inputwidth="350px" /></Menu.Item>,
+        <AwesomeBarMenuItem key="awesomebar" fitted="vertically"><AwesomeBar newWindow inputwidth="350px" /></AwesomeBarMenuItem>,
       ] : null }
       <Menu.Item key="spacer" position="right" />
       <Menu.Item key="feature_updates">
@@ -98,8 +78,6 @@ const PageHeader = React.memo(({ user, oauthLoginProvider, onSubmit, lastFeature
               formFields={USER_NAME_FIELDS}
               onSubmit={onSubmit}
             />
-            {/* @elanfisher: I moved the "Log Out" button into this drop down as it seemed
-            to fit a bit nicer here and reduce the header clutter. */}
             <Dropdown.Item as="a" href="/logout" icon="sign out" text="Log out" />
           </Dropdown.Menu>
         </Dropdown>,

--- a/ui/shared/components/page/Header.jsx
+++ b/ui/shared/components/page/Header.jsx
@@ -16,6 +16,44 @@ import AwesomeBar from './AwesomeBar'
 const HeaderMenu = styled(Menu)`
   padding-left: 100px;
   padding-right: 100px;
+
+  /* 
+    @elanfisher:
+    The nav items need ~1780px at the default gutters, so on smaller screens
+    or when the page is zoomed the right hand items (eg. "Log out") were
+    clipped and thus occluded. Shifted the gutters and search box and then allowed 
+    the bar to wrap rather than overflow.
+  */
+  @media (max-width: 1800px) {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  /*
+    @elanfisher: 
+    Flexbox wraps before it shrinks, so only allow wrapping once the search box
+    has run out of room to give. Above this the bar stays on one line. 
+  */
+  @media (max-width: 1400px) {
+    flex-wrap: wrap;
+  }
+
+  /* 
+    @elanfisher:
+    Keep the search box at its full 350px whenever it fits, and let it be the
+    first thing to give way when it does not. The basis and max are 382px,
+    350px of search plus the menu item's own 2 x 16px padding, so users who
+    were never short of space see exactly the previous layout.
+  */
+  .item.awesomebar {
+    flex: 0 1 382px;
+    min-width: 216px;
+    max-width: 382px;
+  }
+
+  .item.awesomebar .ui.search {
+    width: 100%;
+  }
 `
 
 const PageHeader = React.memo(({ user, oauthLoginProvider, onSubmit, lastFeatureUpdate }) => {
@@ -31,7 +69,8 @@ const PageHeader = React.memo(({ user, oauthLoginProvider, onSubmit, lastFeature
         <Menu.Item key="summary_data" as={Link} to="/summary_data" content="Summary Data" />,
         (user.isAnalyst || user.isPm) ? <Menu.Item key="report" as={Link} to="/report" content="Reports" /> : null,
         (user.isDataManager || user.isPm) ? <Menu.Item key="data_management" as={Link} to="/data_management" content="Data Management" /> : null,
-        <Menu.Item key="awesomebar" fitted="vertically"><AwesomeBar newWindow inputwidth="350px" /></Menu.Item>,
+        // @elanfisher: Made the searchbar flex properly rather than be fixed at 350px.
+        <Menu.Item key="awesomebar" className="awesomebar" fitted="vertically"><AwesomeBar newWindow inputwidth="350px" /></Menu.Item>,
       ] : null }
       <Menu.Item key="spacer" position="right" />
       <Menu.Item key="feature_updates">
@@ -59,9 +98,11 @@ const PageHeader = React.memo(({ user, oauthLoginProvider, onSubmit, lastFeature
               formFields={USER_NAME_FIELDS}
               onSubmit={onSubmit}
             />
+            {/* @elanfisher: I moved the "Log Out" button into this drop down as it seemed
+            to fit a bit nicer here and reduce the header clutter. */}
+            <Dropdown.Item as="a" href="/logout" icon="sign out" text="Log out" />
           </Dropdown.Menu>
         </Dropdown>,
-        <Menu.Item key="logout" as="a" href="/logout">Log out</Menu.Item>,
       ] :
       <Menu.Item as="a" href={loginUrl}>Log in</Menu.Item> }
     </HeaderMenu>

--- a/ui/shared/components/page/Header.test.js
+++ b/ui/shared/components/page/Header.test.js
@@ -1,27 +1,44 @@
 import React from 'react'
 import { shallow, configure } from 'enzyme'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import { LOCAL_LOGIN_URL } from 'shared/utils/constants'
 import { PageHeaderComponent } from './Header'
 
 configure({ adapter: new Adapter() })
+
+const USER = {
+  date_joined: '2015-02-19T20:22:50.633Z',
+  email: 'test@broadinstitute.org',
+  first_name: '',
+  id: 1,
+  is_active: true,
+  last_login: '2017-03-14T17:44:53.403Z',
+  last_name: '',
+  username: 'test',
+}
 
 test('shallow-render without crashing', () => {
   /*
     user: PropTypes.object.isRequired,
    */
 
-  const props = {
-    user: {
-      date_joined: '2015-02-19T20:22:50.633Z',
-      email: 'test@broadinstitute.org',
-      first_name: '',
-      id: 1,
-      is_active: true,
-      last_login: '2017-03-14T17:44:53.403Z',
-      last_name: '',
-      username: 'test',
-    },
-  }
+  shallow(<PageHeaderComponent user={USER} />)
+})
 
-  shallow(<PageHeaderComponent {...props} />)
+test('log out is inside the user dropdown rather than a top level menu item', () => {
+  const wrapper = shallow(<PageHeaderComponent user={USER} />)
+
+  const logoutLinks = wrapper.findWhere(node => node.prop('href') === '/logout')
+  // Make sure its of length one
+  expect(logoutLinks).toHaveLength(1)
+  expect(logoutLinks.first().name()).toEqual('DropdownItem')
+})
+
+test('logged out users are offered a log in link and no user dropdown', () => {
+  const wrapper = shallow(<PageHeaderComponent user={{}} />)
+
+  expect(wrapper.findWhere(node => node.prop('href') === '/logout')).toHaveLength(0)
+  // Make sure there isnt a length because were logged out
+  expect(wrapper.find('Dropdown')).toHaveLength(0)
+  expect(wrapper.findWhere(node => node.prop('href') === LOCAL_LOGIN_URL)).toHaveLength(1)
 })

--- a/ui/shared/components/page/Header.test.js
+++ b/ui/shared/components/page/Header.test.js
@@ -29,7 +29,6 @@ test('log out is inside the user dropdown rather than a top level menu item', ()
   const wrapper = shallow(<PageHeaderComponent user={USER} />)
 
   const logoutLinks = wrapper.findWhere(node => node.prop('href') === '/logout')
-  // Make sure its of length one
   expect(logoutLinks).toHaveLength(1)
   expect(logoutLinks.first().name()).toEqual('DropdownItem')
 })
@@ -38,7 +37,6 @@ test('logged out users are offered a log in link and no user dropdown', () => {
   const wrapper = shallow(<PageHeaderComponent user={{}} />)
 
   expect(wrapper.findWhere(node => node.prop('href') === '/logout')).toHaveLength(0)
-  // Make sure there isnt a length because were logged out
   expect(wrapper.find('Dropdown')).toHaveLength(0)
   expect(wrapper.findWhere(node => node.prop('href') === LOCAL_LOGIN_URL)).toHaveLength(1)
 })


### PR DESCRIPTION
Fixes #5384

At 1512px, the width in the ticket's screenshot, the header overflows by 178px and "Log out" ends up 164px past the right edge where you can't click it. Zooming does the same since it shrinks the viewport.

The header reserves 100px gutters either side plus a fixed 350px search box. This lets the search shrink when space runs out, trims the gutters below 1800px, and only lets the bar wrap below 1400px. That last part matters because flexbox wraps before it shrinks, so wrapping unconditionally gives two rows at widths where shrinking alone was fine. I also moved "Log out" into the user dropdown, which is both convention and 77px of headroom. 
**Let me know if you want me to move it back out as it did declutter the header but was slightly outside of the scope of the issue.**

You mentioned manager fixes shouldn't come at the cost of the core user base, so I checked both roles. See screenshots below, I tried to be complete.

Managers go from 178px clipped to a single row, and at 1280px the bar wraps rather than clipping anything. Non-managers keep the same 350px search box and 100px gutters they have today, with "Log out" now in the dropdown.

Below 1400px the nav doesn't fit on one line. An overflow menu might be better long term if thats more in the style of the rest of the `seqr` repo. Id be happy to take that up if needed.

Lint is clean and all 86 suites and 165 tests pass when I ran them. I also added including two new ones in Header.test.js just to be safe.


Non-Manager (100% zoom):
<img width="1708" height="193" alt="image" src="https://github.com/user-attachments/assets/8c5ed43a-2044-4ff2-b510-7417275d0e3a" />

Non-Manager (150% zoom):
<img width="1710" height="264" alt="image" src="https://github.com/user-attachments/assets/346824c6-a02e-40b0-b132-aef9de7a0b5b" />

Non-Manager Migrated Login Drop down:
<img width="774" height="290" alt="image" src="https://github.com/user-attachments/assets/b5498d02-ce6f-460a-9e61-c8cc6f70122b" />

<img width="532" height="181" alt="image" src="https://github.com/user-attachments/assets/b61b6b5d-a2d7-4d93-a510-5cc475879982" />

Manager View (100% zoom):
<img width="1710" height="236" alt="image" src="https://github.com/user-attachments/assets/b8376a12-0ff5-41e8-a254-4802be42e022" />

Manager View (150% zoom):
<img width="1710" height="340" alt="image" src="https://github.com/user-attachments/assets/8a9b4e89-92e1-444e-a31e-b131bb794082" />
