### PR TITLE
Tiered access tweaks

### DIFF
--- a/ui/pages/Dashboard/selectors.js
+++ b/ui/pages/Dashboard/selectors.js
@@ -29,8 +29,10 @@ export const getVisibleProjects = createSelector(
   (projectsByGuid, projectCategoriesByGuid, analysisGroupsByGuid, projectFilter) => {
     const filterFunc = createProjectFilter(projectFilter)
     const visibleProjects = [
-      ...Object.values(projectsByGuid),
-      ...Object.values(analysisGroupsByGuid).filter(({ projectGuid }) => projectGuid && !projectsByGuid[projectGuid]),
+      ...Object.values(projectsByGuid).filter(({ partialAccess }) => !partialAccess),
+      ...Object.values(analysisGroupsByGuid).filter(
+        ({ projectGuid }) => projectGuid && (!projectsByGuid[projectGuid] || projectsByGuid[projectGuid].partialAccess),
+      ),
     ].filter(filterFunc)
     return visibleProjects.map((project) => {
       const projectCategories = (project.projectCategoryGuids || []).map(

--- a/ui/pages/Dashboard/selectors.test.js
+++ b/ui/pages/Dashboard/selectors.test.js
@@ -26,4 +26,24 @@ describe('tests', () => {
     expect(visibleProjects[2].projectGuid).toBe('R0001_1kg')
     expect(visibleProjects[2].analysisGroupGuid).toBe('AG0000184_test_access')
   })
+
+  test('getVisibleProjects when partial access project is loaded', () => {
+    const visibleProjects = getVisibleProjects({
+      ...STATE1,
+      projectsByGuid: {
+        ...STATE1.projectsByGuid,
+        R0202_tutorial: { ...STATE1.projectsByGuid.R0202_tutorial, partialAccess: true },
+      },
+      analysisGroupsByGuid: {
+        ...STATE1.analysisGroupsByGuid,
+        AG0000184_test_access: { ...STATE1.analysisGroupsByGuid.AG0000184_test_access, projectGuid: 'R0202_tutorial' },
+      },
+    })
+
+    expect(visibleProjects.length).toBe(2)
+    expect(visibleProjects[0].projectGuid).toBe('R0237_1000_genomes_demo')
+    expect(visibleProjects[0].analysisGroupGuid).toBe(undefined)
+    expect(visibleProjects[1].projectGuid).toBe('R0202_tutorial')
+    expect(visibleProjects[1].analysisGroupGuid).toBe('AG0000184_test_access')
+  })
 })

--- a/ui/pages/Project/components/AnalysisGroups.jsx
+++ b/ui/pages/Project/components/AnalysisGroups.jsx
@@ -7,65 +7,88 @@ import { connect } from 'react-redux'
 import { getAnalysisGroupIsLoading } from 'redux/selectors'
 import OptionFieldView from 'shared/components/panel/view-fields/OptionFieldView'
 import DataLoader from 'shared/components/DataLoader'
-import { HelpIcon } from 'shared/components/StyledComponents'
+import { HelpIcon, SectionHeader } from 'shared/components/StyledComponents'
 import { ANVIL_URL, FAMILY_FIELD_NAME_LOOKUP, CATEGORY_FAMILY_FILTERS } from 'shared/utils/constants'
 import { compareObjects } from 'shared/utils/sortUtils'
 import { loadCurrentProjectAnalysisGroups } from '../reducers'
-import { getProjectAnalysisGroupsByGuid, getProjectGuid } from '../selectors'
+import { getProjectAnalysisGroupsByGuid } from '../selectors'
 import { UpdateAnalysisGroupButton, DeleteAnalysisGroupButton } from './AnalysisGroupButtons'
 
-const AnalysisGroups = React.memo(({ projectGuid, load, loading, analysisGroupsByGuid, analysisGroupGuid }) => (
-  <DataLoader load={load} loading={loading} content={analysisGroupsByGuid}>
-    {(analysisGroupsByGuid[analysisGroupGuid] ? [analysisGroupsByGuid[analysisGroupGuid]] : Object.values(analysisGroupsByGuid).sort(compareObjects('name'))).map(ag => (
-      <div key={ag.name}>
-        {ag.criteria && <Icon name="sync" size="small" />}
-        <Link to={`/project/${projectGuid}/analysis_group/${ag.analysisGroupGuid}`}>{ag.name}</Link>
-        <Popup
-          position="right center"
-          trigger={<HelpIcon />}
-          content={ag.criteria ? Object.keys(ag.criteria).map(category => (
-            <OptionFieldView
-              key={category}
-              field={category}
-              initialValues={ag.criteria}
-              fieldName={FAMILY_FIELD_NAME_LOOKUP[category]}
-              tagOptions={CATEGORY_FAMILY_FILTERS[category]}
-              multiple
-            />
-          )) : (
+const AnalysisGroup = ({ ag }) => (
+  <div>
+    {ag.criteria && <Icon name="sync" size="small" />}
+    <Link to={`/project/${ag.projectGuid}/analysis_group/${ag.analysisGroupGuid}`}>{ag.name}</Link>
+    <Popup
+      position="right center"
+      trigger={<HelpIcon />}
+      content={ag.criteria ? Object.keys(ag.criteria).map(category => (
+        <OptionFieldView
+          key={category}
+          field={category}
+          initialValues={ag.criteria}
+          fieldName={FAMILY_FIELD_NAME_LOOKUP[category]}
+          tagOptions={CATEGORY_FAMILY_FILTERS[category]}
+          multiple
+        />
+      )) : (
+        <div>
+          <b>{`${ag.familyGuids?.length} Families`}</b>
+          <br />
+          <i>{ag.description}</i>
+          {ag.workspaceName && (
             <div>
-              <b>{`${ag.familyGuids?.length} Families`}</b>
-              <br />
-              <i>{ag.description}</i>
-              {ag.workspaceName && (
-                <div>
-                  Access Control Workspace:&nbsp;
-                  <a href={`${ANVIL_URL}/#workspaces/${ag.workspaceNamespace}/${ag.workspaceName}`} target="_blank" rel="noreferrer">
-                    {`${ag.workspaceNamespace}/${ag.workspaceName}`}
-                  </a>
-                </div>
-              )}
+              Access Control Workspace:&nbsp;
+              <a href={`${ANVIL_URL}/#workspaces/${ag.workspaceNamespace}/${ag.workspaceName}`} target="_blank" rel="noreferrer">
+                {`${ag.workspaceNamespace}/${ag.workspaceName}`}
+              </a>
             </div>
           )}
-          size="tiny"
-        />
-        <UpdateAnalysisGroupButton analysisGroup={ag} iconOnly />
-        <DeleteAnalysisGroupButton analysisGroup={ag} iconOnly size="tiny" />
-      </div>
-    ))}
+        </div>
+      )}
+      size="tiny"
+    />
+    <UpdateAnalysisGroupButton analysisGroup={ag} iconOnly />
+    <DeleteAnalysisGroupButton analysisGroup={ag} iconOnly size="tiny" />
+  </div>
+)
+
+AnalysisGroup.propTypes = {
+  ag: PropTypes.object.isRequired,
+}
+
+const AnalysisGroupsList = ({ analysisGroupsByGuid }) => {
+  const allGroups = Object.values(analysisGroupsByGuid).sort(compareObjects('name'))
+  const accessGroups = allGroups.filter(({ workspaceName }) => workspaceName)
+  const mainGroups = allGroups.filter(({ workspaceName }) => !workspaceName)
+  return (
+    <div>
+      {mainGroups.map(ag => <AnalysisGroup key={ag.name} ag={ag} />)}
+      {accessGroups.length > 0 && <SectionHeader>Access Groups</SectionHeader>}
+      {accessGroups.map(ag => <AnalysisGroup key={ag.name} ag={ag} />)}
+    </div>
+  )
+}
+
+AnalysisGroupsList.propTypes = {
+  analysisGroupsByGuid: PropTypes.object.isRequired,
+}
+
+const AnalysisGroups = React.memo(({ load, loading, analysisGroupsByGuid, analysisGroupGuid }) => (
+  <DataLoader load={load} loading={loading} content={analysisGroupsByGuid}>
+    {analysisGroupsByGuid[analysisGroupGuid] ?
+      <AnalysisGroup ag={analysisGroupsByGuid[analysisGroupGuid]} /> :
+      <AnalysisGroupsList analysisGroupsByGuid={analysisGroupsByGuid} />}
   </DataLoader>
 ))
 
 AnalysisGroups.propTypes = {
   analysisGroupGuid: PropTypes.string,
-  projectGuid: PropTypes.string,
   analysisGroupsByGuid: PropTypes.object.isRequired,
   loading: PropTypes.bool,
   load: PropTypes.func,
 }
 
 const mapStateToProps = state => ({
-  projectGuid: getProjectGuid(state),
   analysisGroupsByGuid: getProjectAnalysisGroupsByGuid(state),
   loading: getAnalysisGroupIsLoading(state),
 })

--- a/ui/pages/Project/components/AnalysisGroups.jsx
+++ b/ui/pages/Project/components/AnalysisGroups.jsx
@@ -34,7 +34,7 @@ const AnalysisGroups = React.memo(({ projectGuid, load, loading, analysisGroupsB
             />
           )) : (
             <div>
-              <b>{`${ag.familyGuids.length} Families`}</b>
+              <b>{`${ag.familyGuids?.length} Families`}</b>
               <br />
               <i>{ag.description}</i>
               {ag.workspaceName && (

--- a/ui/pages/Project/components/PageHeader.jsx
+++ b/ui/pages/Project/components/PageHeader.jsx
@@ -72,6 +72,7 @@ const PageHeader = React.memo((
       entityGuidLinkPath="project_page"
       breadcrumb={breadcrumb}
       entityLinks={entityLinks}
+      entityLinkDisabled={project.partialAccess}
       {...headerProps}
     />
   )

--- a/ui/pages/Project/components/PageHeader.jsx
+++ b/ui/pages/Project/components/PageHeader.jsx
@@ -72,7 +72,7 @@ const PageHeader = React.memo((
       entityGuidLinkPath="project_page"
       breadcrumb={breadcrumb}
       entityLinks={entityLinks}
-      entityLinkDisabled={project.partialAccess}
+      entityGuidLinkDisabled={project.partialAccess}
       {...headerProps}
     />
   )

--- a/ui/pages/Project/selectors.js
+++ b/ui/pages/Project/selectors.js
@@ -826,7 +826,7 @@ export const getPageHeaderEntityLinks = createSelector(
         null,
 
     }]
-    if (project.hasCaseReview) {
+    if (project.hasCaseReview && !project.partialAccess) {
       entityLinks.push({
         to: `/project/${project.projectGuid}/case_review`,
         content: 'Case Review',

--- a/ui/shared/components/page/PageHeaderLayout.jsx
+++ b/ui/shared/components/page/PageHeaderLayout.jsx
@@ -33,14 +33,14 @@ export const useSeqrTitle = title => useTitle(`seqr: ${snakecaseToTitlecase(titl
 
 const PageHeaderLayout = React.memo(({
   entity, entityGuid, breadcrumb, breadcrumbId, breadcrumbIdSections, title, entityLinkPath, entityGuidLinkPath,
-  entityLinks, button, description,
+  entityLinks, button, description, entityLinkDisabled,
 }) => {
   let breadcrumbSections = [
     { content: snakecaseToTitlecase(entity), link: entityLinkPath === undefined ? `/${entity}` : entityLinkPath },
   ]
   if (entityGuid) {
     breadcrumbSections.push(
-      { content: title || entityGuid, link: `/${entity}/${entityGuid}${entityGuidLinkPath ? `/${entityGuidLinkPath}` : ''}` },
+      { content: title || entityGuid, link: entityLinkDisabled ? null : `/${entity}/${entityGuid}${entityGuidLinkPath ? `/${entityGuidLinkPath}` : ''}` },
     )
   }
   if (breadcrumbIdSections) {
@@ -125,6 +125,7 @@ PageHeaderLayout.propTypes = {
   entityLinks: PropTypes.arrayOf(PropTypes.object),
   button: PropTypes.node,
   description: PropTypes.string,
+  entityLinkDisabled: PropTypes.bool,
 }
 
 export default PageHeaderLayout

--- a/ui/shared/components/page/PageHeaderLayout.jsx
+++ b/ui/shared/components/page/PageHeaderLayout.jsx
@@ -33,14 +33,14 @@ export const useSeqrTitle = title => useTitle(`seqr: ${snakecaseToTitlecase(titl
 
 const PageHeaderLayout = React.memo(({
   entity, entityGuid, breadcrumb, breadcrumbId, breadcrumbIdSections, title, entityLinkPath, entityGuidLinkPath,
-  entityLinks, button, description, entityLinkDisabled,
+  entityLinks, button, description, entityGuidLinkDisabled,
 }) => {
   let breadcrumbSections = [
     { content: snakecaseToTitlecase(entity), link: entityLinkPath === undefined ? `/${entity}` : entityLinkPath },
   ]
   if (entityGuid) {
     breadcrumbSections.push(
-      { content: title || entityGuid, link: entityLinkDisabled ? null : `/${entity}/${entityGuid}${entityGuidLinkPath ? `/${entityGuidLinkPath}` : ''}` },
+      { content: title || entityGuid, link: entityGuidLinkDisabled ? null : `/${entity}/${entityGuid}${entityGuidLinkPath ? `/${entityGuidLinkPath}` : ''}` },
     )
   }
   if (breadcrumbIdSections) {
@@ -125,7 +125,7 @@ PageHeaderLayout.propTypes = {
   entityLinks: PropTypes.arrayOf(PropTypes.object),
   button: PropTypes.node,
   description: PropTypes.string,
-  entityLinkDisabled: PropTypes.bool,
+  entityGuidLinkDisabled: PropTypes.bool,
 }
 
 export default PageHeaderLayout


### PR DESCRIPTION
## Pull request overview

This PR adjusts the UI behavior for “partial access” (tiered access) projects by removing or disabling navigation paths that users can’t reach, and by changing how partial-access content is surfaced in the dashboard and project header areas.

**Changes:**
- Disable the project-name breadcrumb link in the project header when `project.partialAccess` is true.
- Hide “Case Review” entry points for partial-access projects.
- Update Dashboard project visibility logic to suppress partial-access projects and include analysis-group rows instead
- Refactor Analysis Groups list UI to separate “Access Groups”