### PR TITLE
fix invalid filtering for project tagged variants

### DIFF
--- a/seqr/views/apis/saved_variant_api_tests.py
+++ b/seqr/views/apis/saved_variant_api_tests.py
@@ -180,9 +180,9 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         self.assertSetEqual(set(variants.keys()), {'21-3343353-GAGA-G'})
         variant = variants['21-3343353-GAGA-G']
         variant_fields = {
-            *SAVED_VARIANT_FIELDS, 'mainTranscriptId',  'genomeVersion', 'tagGuids', 'functionalDataGuids', 'noteGuids',
-            'genotypes', 'transcripts', 'acmgClassification',
+            *SAVED_VARIANT_FIELDS, 'mainTranscriptId',  'genomeVersion', 'genotypes', 'transcripts', 'acmgClassification',
         }
+        variant_fields.remove('variantGuid')
         self.assertSetEqual(set(variant.keys()), variant_fields)
         self.assertListEqual(variant['familyGuids'], ['F000001_1'])
         self.assertSetEqual(set(variant['genotypes'].keys()), {'I000003_na19679', 'I000001_na19675', 'I000002_na19678'})
@@ -295,7 +295,7 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         variants = response.json()['savedVariantsByGuid']
         self.assertSetEqual(set(variants.keys()), {COMPOUND_HET_1_GUID, COMPOUND_HET_2_GUID})
         self.assertListEqual(variants[COMPOUND_HET_1_GUID]['tagGuids'], [])
-        self.assertListEqual(variant['noteGuids'], [])
+        self.assertListEqual(variants[COMPOUND_HET_1_GUID]['noteGuids'], [])
 
         # filter by variant guid
         response = self.client.get('{}{}'.format(url, VARIANT_GUID))
@@ -416,7 +416,7 @@ class SavedVariantAPITest(ClickhouseSearchTestCase):
         self.assertSetEqual(set(response_json['savedVariantsByGuid']['SV0000002_1248367227_r0390_100'].keys()), fields)
         self.assertSetEqual(set(response_json['variantsById']['1-248367227-TC-T'].keys()), {
             *variant_fields, *SAVED_VARIANT_DETAIL_FIELDS, 'discoveryTags', 'noAccessDiscoveryFamilies', 'screenRegionType', 'sortedRegulatoryFeatureConsequences', 'sortedMotifFeatureConsequences',
-        })
+        } - {'variantGuid', 'tagGuids', 'functionalDataGuids', 'noteGuids'})
 
         self.mock_list_workspaces.assert_called_with(self.analyst_user)
         self.mock_get_ws_access_level.assert_any_call(

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -478,6 +478,8 @@ def get_variants_response(request, saved_variants, response_variants=None, add_a
 
     return response
 
+OMIT_AGGREGATE_FIELDS = {'variantGuid', 'tagGuids', 'functionalDataGuids', 'noteGuids'}
+
 def _get_clickhouse_variant_annotations(variants, genome_version):
     variant_keys_by_genome_version_dataset_type = defaultdict(lambda: defaultdict(set))
     variants_by_id = defaultdict(dict)
@@ -488,7 +490,7 @@ def _get_clickhouse_variant_annotations(variants, genome_version):
         xpos_end = variant.pop('xposEnd')
         variants_by_id[variant['variantId']] = {
             **variants_by_id[variant['variantId']],
-            **{k: v for k, v in variant.items() if k not in {'variantGuid', 'tagGuids', 'functionalDataGuids', 'noteGuids'}},
+            **{k: v for k, v in variant.items() if k not in OMIT_AGGREGATE_FIELDS},
             'familyGuids': variant['familyGuids'] + variants_by_id[variant['variantId']].get('familyGuids', []),
             'genotypes': {**variant['genotypes'], **variants_by_id[variant['variantId']].get('genotypes', {})},
         }

--- a/seqr/views/utils/variant_utils.py
+++ b/seqr/views/utils/variant_utils.py
@@ -488,7 +488,7 @@ def _get_clickhouse_variant_annotations(variants, genome_version):
         xpos_end = variant.pop('xposEnd')
         variants_by_id[variant['variantId']] = {
             **variants_by_id[variant['variantId']],
-            **variant,
+            **{k: v for k, v in variant.items() if k not in {'variantGuid', 'tagGuids', 'functionalDataGuids', 'noteGuids'}},
             'familyGuids': variant['familyGuids'] + variants_by_id[variant['variantId']].get('familyGuids', []),
             'genotypes': {**variant['genotypes'], **variants_by_id[variant['variantId']].get('genotypes', {})},
         }

--- a/ui/pages/Project/fixtures.js
+++ b/ui/pages/Project/fixtures.js
@@ -651,7 +651,6 @@ export const STATE_WITH_2_FAMILIES = {
       chrom: "22",
       clinvar: { clinsig: "", variantId: null },
       familyGuids: ["F011652_1"],
-      functionalDataGuids: [],
       genomeVersion: "37",
       genotypes: {
         I021475_na19675_1: {
@@ -698,14 +697,11 @@ export const STATE_WITH_2_FAMILIES = {
         lofFilter: "", lofFlags: "SINGLE_EXON", proteinPosition: "287", symbol: "OR2M3", geneId: 'ENSG00000228198',
         majorConsequence: 'frameshift_variant', transcriptId: 'ENST00000456743'
       }]},
-      noteGuids: ['VN0727076_116042722_r0390_1000'],
       origAltAlleles: ["T"],
       pos: 45919065,
       projectGuid: 'R0237_1000_genomes_demo',
       ref: "TTTC",
-      tagGuids: ['VT1726942_1248367227_r0390_101'],
       variantId: "22-45919065-TTTC-T",
-      variantGuid: "SV0000004_116042722_r0390_1000",
       xpos: 22045919065,
     },
     "1-248367227-TC-T": {
@@ -754,22 +750,18 @@ export const STATE_WITH_2_FAMILIES = {
       liftedOverChrom: "",
       liftedOverGenomeVersion: "38",
       liftedOverPos: "",
-      noteGuids: [],
       origAltAlleles: ["T"],
       mainTranscriptId: 'ENST00000262738',
       transcripts: {ENSG00000228198: [{transcriptId: 'ENST00000262738',  majorConsequence: 'missense_variant'}]},
       pos: 248367227,
       ref: "TC",
-      tagGuids: ["VT1726942_1248367227_r0390_100", "VT1708635_1248367227_r0390_100"],
       variantId: "1-248367227-TC-T",
-      variantGuid: "SV0000002_1248367227_r0390_100",
       xpos: 1248367227,
     },
     "batch_123_DEL": {
       alt: null,
       chrom: "1",
       familyGuids: ["F011652_1"],
-      functionalDataGuids: [],
       genomeVersion: "37",
       geneIds: ['ENSG00000228198', 'ENSG00000164458'],
       genotypes: {
@@ -790,7 +782,6 @@ export const STATE_WITH_2_FAMILIES = {
       liftedOverChrom: "",
       liftedOverGenomeVersion: "38",
       liftedOverPos: "",
-      noteGuids: [],
       projectGuid: 'R0237_1000_genomes_demo',
       pos: 248367227,
       end: 248369100,
@@ -804,7 +795,6 @@ export const STATE_WITH_2_FAMILIES = {
       },
       predictions: { strvctvre: '0.272' },
       ref: null,
-      tagGuids: [],
       transcripts: {
         ENSG00000164458: [
           {
@@ -818,7 +808,6 @@ export const STATE_WITH_2_FAMILIES = {
         ],
       },
       variantId: "batch_123_DEL",
-      variantGuid: "SV0000002_SV48367227_r0390_100",
       xpos: 1248367227,
     },
     "22-248367227-C-T": {
@@ -826,7 +815,6 @@ export const STATE_WITH_2_FAMILIES = {
       chrom: "22",
       clinvar: { clinsig: "", variantId: null },
       familyGuids: ["F011652_2"],
-      functionalDataGuids: [],
       genomeVersion: "37",
       genotypes: {
         I021475_na19675_1: {
@@ -869,14 +857,11 @@ export const STATE_WITH_2_FAMILIES = {
       liftedOverPos: "",
       mainTranscriptId: null,
       transcripts: {},
-      noteGuids: [],
       origAltAlleles: ["T"],
       pos: 248367227,
       projectGuid: 'R0237_1000_genomes_demo',
       ref: "C",
-      tagGuids: ['VT1726942_1248367227_r0390_102'],
       variantId: "22-248367227-C-T",
-      variantGuid: "SV0000003_2246859832_r0390_100",
       xpos: 22046859832,
     },
     "22-248367228-C-T": {
@@ -884,7 +869,6 @@ export const STATE_WITH_2_FAMILIES = {
       chrom: "22",
       clinvar: { clinsig: "", variantId: null },
       familyGuids: ["F011652_2"],
-      functionalDataGuids: [],
       genomeVersion: "37",
       genotypes: {
         I021475_na19675_1: {
@@ -927,14 +911,11 @@ export const STATE_WITH_2_FAMILIES = {
       liftedOverPos: "",
       mainTranscriptId: null,
       transcripts: {},
-      noteGuids: [],
       origAltAlleles: ["T"],
       pos: 248367228,
       projectGuid: 'R0237_1000_genomes_demo',
       ref: "C",
-      tagGuids: ['VT1726942_1248367227_r0390_102'],
       variantId: "22-248367228-C-T",
-      variantGuid: "SV0000005_2246859833_r0390_100",
       xpos: 22046859833,
     },
   },

--- a/ui/shared/components/panel/variants/selectors.js
+++ b/ui/shared/components/panel/variants/selectors.js
@@ -140,7 +140,7 @@ export const getPairedSelectedSavedVariants = createSelector(
     const [variantFilter, pairedFilters] = projectVariants || summaryDataVariants
 
     let variants = Object.values(savedVariants).map(
-      variant => ({ ...variant, ...(variantsById[variant.variantId] || {}) }),
+      variant => ({ ...(variantsById[variant.variantId] || {}), ...variant }),
     )
     if (variantFilter) {
       variants = variants.filter(variantFilter)


### PR DESCRIPTION
## Pull request overview

This PR addresses a bug in which variants tagged in multiple families in a given project are incorrectly hidden in the project tagged variants view due to incorrect aggregation of GUID-related data being return in `variantsById`. Fixing this bug revealed an underlying bug in the UI rendering for these variants with multiple families as the list of all possible families being sourced from `variantsById` was overriding the desired tag-specfic families, which is resolved by ensuring saved-variant fields take precedence when combining saved-variant and variant-annotation objects.

**Changes:**
- Update UI selector merge precedence so `savedVariantsByGuid` fields override `variantsById` fields when composing variant objects
- Stop propagating `variantGuid`, `tagGuids`, `functionalDataGuids`, and `noteGuids` from postgres saved variant data into the aggregated `variantsById`.
- Align fixtures and API tests with the updated response shape/merging behavior.