### PR TITLE
allow loading data to proejcts with other sample type data

### DIFF
--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -228,12 +228,8 @@ def get_loaded_projects(request, genome_version, sample_type, dataset_type):
         except ValueError as e:
             return create_json_response({'error': str(e)}, status=400)
         projects = projects.filter(guid__in=project_samples.keys())
-    if dataset_type == Dataset.DATASET_TYPE_VARIANT_CALLS:
-        exclude_sample_type = Dataset.SAMPLE_TYPE_WES if sample_type == Dataset.SAMPLE_TYPE_WGS else Dataset.SAMPLE_TYPE_WGS
-        # Include projects with either the matched sample type OR with no loaded data
-        projects = projects.exclude(family__individual__active_datasets__sample_type=exclude_sample_type)
-    else:
-        # All other data types can only be loaded to projects which already have loaded data
+    if dataset_type != Dataset.DATASET_TYPE_VARIANT_CALLS:
+        # All other data types can only be loaded to projects which already have loaded data for the given sample type
         projects = projects.filter(family__individual__active_datasets__sample_type=sample_type)
 
     projects = projects.distinct().order_by('name').values('name', projectGuid=F('guid'), dataTypeLastLoaded=Max(

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -353,6 +353,7 @@ class DataManagerAPITest(AirtableTest):
     PROJECTS = [PROJECT_GUID, NON_ANALYST_PROJECT_GUID]
     VCF_SAMPLES = VCF_SAMPLES
     SKIP_TDR = False
+    WES_LAST_LOADED = None
 
     def _test_request_proxy(self, host, url, proxy_path):
         response_args = {
@@ -1082,13 +1083,16 @@ class DataManagerAPITest(AirtableTest):
         snv_indel_url = snv_indel_url.replace('38', '37')
         response = self.client.get(snv_indel_url)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'projects': self.WGS_PROJECT_OPTIONS})
+        self.assertDictEqual(response.json(), {'projects': self.LOADED_PROJECT_OPTIONS})
         self._assert_expected_get_projects_requests()
 
-        # test projects with no data loaded are returned for any sample type
+        # test projects with matched type data loaded report the correct loaded data
         response = self.client.get(snv_indel_url.replace('WGS', 'WES'))
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.json(), {'projects': self.WES_PROJECT_OPTIONS})
+        self.assertDictEqual(response.json(), {'projects': [
+            {**self.LOADED_PROJECT_OPTIONS[0], 'dataTypeLastLoaded': self.WES_LAST_LOADED},
+            *self.LOADED_PROJECT_OPTIONS[1:],
+        ]})
 
         self._assert_expected_airtable_errors(url)
 
@@ -1347,11 +1351,11 @@ class LocalDataManagerAPITest(AuthenticationTestCase, DataManagerAPITest):
     LOCAL_WRITE_DIR = TRIGGER_CALLSET_DIR
     CALLSET_DIR = ''
     PROJECT_OPTION = PROJECT_OPTION
-    WGS_PROJECT_OPTIONS = [EMPTY_PROJECT_OPTION]
-    WES_PROJECT_OPTIONS = [
-        {'name': '1kg project nåme with uniçøde', 'projectGuid': 'R0001_1kg', 'dataTypeLastLoaded': '2017-02-05T06:13:55.397Z'},
+    LOADED_PROJECT_OPTIONS = [
+        {'name': '1kg project nåme with uniçøde', 'projectGuid': 'R0001_1kg', 'dataTypeLastLoaded': None},
         EMPTY_PROJECT_OPTION,
     ]
+    WES_LAST_LOADED = '2017-02-05T06:13:55.397Z'
     PROJECT_OPTIONS = [{'projectGuid': 'R0001_1kg'}, PROJECT_OPTION]
     REQUEST_BODY = CORE_REQUEST_BODY
     SKIP_TDR = True
@@ -1484,8 +1488,7 @@ class AnvilDataManagerAPITest(AnvilAuthenticationTestCase, DataManagerAPITest):
     TRIGGER_CALLSET_DIR = CALLSET_DIR
     LOCAL_WRITE_DIR = '/mock/tmp'
     PROJECT_OPTION = PROJECT_SAMPLES_OPTION
-    WGS_PROJECT_OPTIONS = [EMPTY_PROJECT_SAMPLES_OPTION]
-    WES_PROJECT_OPTIONS = [EMPTY_PROJECT_SAMPLES_OPTION]
+    LOADED_PROJECT_OPTIONS = [EMPTY_PROJECT_SAMPLES_OPTION]
     PROJECT_OPTIONS = [
         {'projectGuid': 'R0001_1kg', 'sampleIds': ['NA19675_1', 'NA19678', 'NA19679', 'HG00732', 'HG00733']},
         PROJECT_SAMPLES_OPTION,


### PR DESCRIPTION
## Pull request overview

This PR updates the “loaded projects” selection logic for variant-call datasets so projects are not excluded solely because they already contain datasets of the other sample type (WES vs WGS), enabling loading variant calls into projects that previously would have been filtered out. It also updates API tests to reflect the new project-list behavior and ensure `dataTypeLastLoaded` is reported per requested sample type.

**Changes:**
- Relaxed `get_loaded_projects` filtering for `Dataset.DATASET_TYPE_VARIANT_CALLS` to allow projects that may already have the opposite sample type loaded.
- Kept the “must already have data for this sample type” restriction for non-variant dataset types.
- Updated test expectations to validate returned project lists and `dataTypeLastLoaded` behavior for WGS vs WES requests.