### PR TITLE
disable loading on empty ped file submisison

### DIFF
--- a/seqr/views/apis/anvil_workspace_api.py
+++ b/seqr/views/apis/anvil_workspace_api.py
@@ -226,6 +226,9 @@ def _validate_expected_samples(vcf_samples, loaded_sample_types, loaded_individu
         else:
             errors.append('New data cannot be added to this project until the previously requested data is loaded')
 
+    if not record_family_ids:
+        errors.append('No samples found in the pedigree file')
+
     missing_vcf_samples = set(record_family_ids.keys()) - set(vcf_samples)
     if missing_vcf_samples:
         errors.append(

--- a/seqr/views/apis/anvil_workspace_api_tests.py
+++ b/seqr/views/apis/anvil_workspace_api_tests.py
@@ -684,6 +684,13 @@ class LoadAnvilDataAPITest(AnvilAuthenticationTestCase, AirtableTest):
         url = reverse(add_workspace_data, args=[PROJECT1_GUID])
         self._test_errors(url, ['uploadedFileId', 'fullDataPath', 'vcfSamples'], TEST_WORKSPACE_NAME, has_existing_data=True)
 
+        # Test loading data from empty ped file
+        self.mock_load_file.return_value = LOAD_SAMPLE_DATA[:1]
+        response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))
+        self.assertEqual(response.status_code, 400)
+        response_json = response.json()
+        self.assertListEqual(response_json['errors'], ['No samples found in the pedigree file'])
+
         # Test Individual ID exists in an omitted family and missing loaded samples
         self.mock_load_file.return_value = LOAD_SAMPLE_DATA + INVALID_ADDED_SAMPLE_DATA
         response = self.client.post(url, content_type='application/json', data=json.dumps(REQUEST_BODY))


### PR DESCRIPTION
## Pull request overview

This PR prevents AnVIL workspace data loading requests from proceeding when the uploaded pedigree file contains no sample rows (e.g., header-only), returning a clear validation error instead.

**Changes:**
- Add validation in `_validate_expected_samples` to error when no pedigree samples are present.
- Add a regression test ensuring `add_workspace_data` returns a 400 with the new error on an empty pedigree upload.