### PR TITLE
explicitly set dataset types to disable in delete family data

### DIFF
--- a/seqr/utils/add_data_utils.py
+++ b/seqr/utils/add_data_utils.py
@@ -63,7 +63,7 @@ def update_airtable_loading_tracking_status(project, status, additional_update=N
         update={'Status': status, **(additional_update or {})},
     )
 
-def trigger_delete_families_search(project, family_guids, user=None):
+def trigger_delete_families_search(project, family_guids, user=None, dataset_types=None):
     num_updated = 0
     updated_families = set()
     for dataset in Dataset.objects.filter(active_individuals__family__guid__in=family_guids).distinct():
@@ -80,6 +80,8 @@ def trigger_delete_families_search(project, family_guids, user=None):
         logger.info(message, user)
 
     variables = {'project_guid': project.guid, 'family_guids': family_guids}
+    if dataset_types:
+        variables['dataset_types'] = dataset_types
     _enqueue_pipeline_request('delete_families', variables, user)
     info.append('Triggered delete family data')
     return info

--- a/seqr/views/apis/data_manager_api.py
+++ b/seqr/views/apis/data_manager_api.py
@@ -424,8 +424,11 @@ def trigger_delete_project(request):
 def trigger_delete_family(request):
     request_json = json.loads(request.body)
     family_guid = request_json.pop('family')
+    dataset_types = request_json.get('datasetTypes') or []
+    if Dataset.DATASET_TYPE_SV_CALLS in dataset_types:
+        dataset_types.append('GCNV')
     project = Project.objects.get(family__guid=family_guid)
-    info = trigger_delete_families_search(project, [family_guid], request.user)
+    info = trigger_delete_families_search(project, [family_guid], request.user, dataset_types)
     return create_json_response({'info': info})
 
 

--- a/seqr/views/apis/data_manager_api_tests.py
+++ b/seqr/views/apis/data_manager_api_tests.py
@@ -1325,7 +1325,7 @@ class DataManagerAPITest(AirtableTest):
         self.check_data_manager_login(url)
 
         Project.objects.filter(guid=PROJECT_GUID).update(genome_version='38')
-        response = self.client.post(url, content_type='application/json', data=json.dumps({'family': 'F000002_2'}))
+        response = self.client.post(url, content_type='application/json', data=json.dumps({'family': 'F000002_2', 'datasetTypes': ['SNV_INDEL', 'SV']}))
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), {
             'info': [
@@ -1340,6 +1340,7 @@ class DataManagerAPITest(AirtableTest):
         self.assertDictEqual(json.loads(responses.calls[-1].request.body), {
             'project_guid': 'R0001_1kg',
             'family_guids': ['F000002_2'],
+            'dataset_types': ['SNV_INDEL', 'SV', 'GCNV'],
         })
 
 

--- a/ui/pages/DataManagement/components/TriggerSearchDataUpdatePages.jsx
+++ b/ui/pages/DataManagement/components/TriggerSearchDataUpdatePages.jsx
@@ -43,7 +43,7 @@ const FAMILY_FIELDS = [
     placeholder: 'Search for a family',
     validate: validators.required,
   },
-  { ...DATASET_TYPE_FIELD, name: 'datasetTypes', multiple: true },
+  { ...DATASET_TYPE_FIELD, name: 'datasetTypes', multiple: true, validate: null },
 ]
 
 const TriggerSearchDataUpdateForm = ({ entity, fields }) => (

--- a/ui/pages/DataManagement/components/TriggerSearchDataUpdatePages.jsx
+++ b/ui/pages/DataManagement/components/TriggerSearchDataUpdatePages.jsx
@@ -43,6 +43,7 @@ const FAMILY_FIELDS = [
     placeholder: 'Search for a family',
     validate: validators.required,
   },
+  { ...DATASET_TYPE_FIELD, name: 'datasetTypes', multiple: true },
 ]
 
 const TriggerSearchDataUpdateForm = ({ entity, fields }) => (


### PR DESCRIPTION
## Pull request overview

Adds explicit dataset-type selection for the Data Management “delete family search” trigger so the backend can forward selected dataset types (including adding `GCNV` when `SV` is selected) to the pipeline runner for targeted deletion.

**Changes:**
- Updated the Data Management UI to submit `datasetTypes` (multi-select) when triggering family search deletion.
- Updated `trigger_delete_family` to accept `datasetTypes`, auto-include `GCNV` when `SV` is present, and pass the list through to the pipeline enqueue.
- Updated backend tests to assert `dataset_types` is included in the pipeline request payload.