### PR TITLE
Vlm detail per sample

### DIFF
--- a/vlm/match.py
+++ b/vlm/match.py
@@ -192,7 +192,7 @@ async def _get_match_detail_results(match: list[tuple], lift_match: Optional[lis
             results += [{
                 'id': phenopacket['id'],
                 'proband': phenopacket,
-                'relatives': [p for p in phenopackets if p != phenopacket],
+                'relatives': [p for p in phenopackets if p is not phenopacket],
                 'pedigree': {'persons': pedigree},
                 'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
             } for phenopacket in phenopackets]

--- a/vlm/match.py
+++ b/vlm/match.py
@@ -170,9 +170,8 @@ async def _get_match_detail_results(match: list[tuple], lift_match: Optional[lis
     async with ClientSession(ONTOLOGY_API_URL) as session:
         for f_i, (samples, has_discovery, has_excluded) in enumerate(match + (lift_match or [])):
             family_id = f'F_{f_i}'
-            proband = None
-            relatives = []
             pedigree = []
+            phenopackets = []
             for s_i, (affected, sex, *sample) in enumerate(samples):
                 individual_id = f'I_{f_i}_{s_i}'
                 sex = SEX_LOOKUP.get(sex, 'OTHER_SEX')
@@ -188,22 +187,15 @@ async def _get_match_detail_results(match: list[tuple], lift_match: Optional[lis
                 phenopacket = await _format_phenopacket(
                     hpo_label_map, mondo_label_map, session, individual_id, has_discovery, has_excluded, sex, *sample,
                 )
-                if affected == 'A' and proband is None:
-                    proband = phenopacket
-                else:
-                    relatives.append(phenopacket)
+                phenopackets.append(phenopacket)
 
-            if not proband:
-                proband = relatives[0]
-                relatives = relatives[1:]
-
-            results.append({
-                'id': family_id,
-                'proband': proband,
-                'relatives': relatives,
+            results += [{
+                'id': phenopacket['id'],
+                'proband': phenopacket,
+                'relatives': [p for p in phenopackets if p != phenopacket],
                 'pedigree': {'persons': pedigree},
                 'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
-            })
+            } for phenopacket in phenopackets]
 
     result_sets = [
         (None, len(results), results),

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -849,7 +849,6 @@ class VlmTestCase(AioHTTPTestCase):
                 'setType': 'Family'
             },
         ]
-        self.maxDiff = None
         await self._test_match_endpoint('match_details', mocked_responses, meta, results, only_37_results, empty_results)
 
     async def _test_match_endpoint(self, path, mocked_responses, meta, results, only_37_results, empty_results):

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -168,122 +168,6 @@ class VlmTestCase(AioHTTPTestCase):
                 'setType': 'Family',
                 'resultsCount': 5,
                 'results': [{
-                    'id': 'I_0_1',
-                    'pedigree': {
-                         'persons': [{
-                             'affected_status': 'UNAFFECTED',
-                             'family_id': 'F_0',
-                             'individual_id': 'I_0_0',
-                             'maternal_id': '0',
-                             'paternal_id': '0',
-                             'sex': 'MALE',
-                         }, {
-                             'affected_status': 'AFFECTED',
-                             'family_id': 'F_0',
-                             'individual_id': 'I_0_1',
-                             'maternal_id': '0',
-                             'paternal_id': '0',
-                             'sex': 'OTHER_SEX',
-                         }],
-                    },
-                    'proband': {
-                        'id': 'I_0_1',
-                        'interpretations': [{
-                            'diagnosis': {
-                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                'genomic_interpretations': [{
-                                    'call': {
-                                        'variation_descriptor': {
-                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                        },
-                                    },
-                                    'interpretation_status': 'REJECTED',
-                                    'subject_or_biosample_id': 'I_0_1',
-                                }],
-                            },
-                            'id': 'I_0_1',
-                            'progress_status': 'UNKNOWN_PROGRESS',
-                        }],
-                        'phenotypic_features': [
-                            {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
-                            {'id': 'HP:0011675', 'label': 'Arrhythmia'},
-                        ],
-                        'subject': {
-                            'id': 'I_0_1',
-                            'sex': 'OTHER_SEX',
-                        },
-                        'meta_data': {
-                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                            'phenopacket_schema_version': '2.0',
-                            'resources': [{
-                                'id': 'geno',
-                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                'name': 'GENO ontology',
-                                'namespacePrefix': 'GENO',
-                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                'version': '2026-02-02',
-                            }, {
-                                'id': 'hp',
-                                'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
-                                'name': 'Human Phenotype Ontology',
-                                'namespacePrefix': 'HP',
-                                'url': 'http://purl.obolibrary.org/obo/hp.owl',
-                                'version': datetime.now().strftime('%Y-%m-%d'),
-                            }, {
-                                'id': 'omim',
-                                'iriPrefix': 'https://www.omim.org/entry/',
-                                'name': 'Online Mendelian Inheritance in Man',
-                                'namespacePrefix': 'OMIM',
-                                'url': 'https://www.omim.org',
-                                'version': datetime.now().strftime('%Y-%m-%d'),
-                            }],
-                        },
-                    },
-                    'relatives': [{
-                        'id': 'I_0_0',
-                        'interpretations': [{
-                            'diagnosis': {
-                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                'genomic_interpretations': [{
-                                    'call': {
-                                        'variation_descriptor': {
-                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                        },
-                                    },
-                                    'interpretation_status': 'REJECTED',
-                                    'subject_or_biosample_id': 'I_0_0',
-                                }],
-                            },
-                            'id': 'I_0_0',
-                            'progress_status': 'UNKNOWN_PROGRESS',
-                        }],
-                        'phenotypic_features': [],
-                        'subject': {
-                            'id': 'I_0_0',
-                            'sex': 'MALE',
-                        },
-                        'meta_data': {
-                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                            'phenopacket_schema_version': '2.0',
-                            'resources': [{
-                                'id': 'geno',
-                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                'name': 'GENO ontology',
-                                'namespacePrefix': 'GENO',
-                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                'version': '2026-02-02',
-                            }, {
-                                'id': 'omim',
-                                'iriPrefix': 'https://www.omim.org/entry/',
-                                'name': 'Online Mendelian Inheritance in Man',
-                                'namespacePrefix': 'OMIM',
-                                'url': 'https://www.omim.org',
-                                'version': datetime.now().strftime('%Y-%m-%d'),
-                            }],
-                        },
-                    }],
-                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
-                }, {
                     'id': 'I_0_0',
                     'pedigree': {
                         'persons': [{
@@ -388,6 +272,122 @@ class VlmTestCase(AioHTTPTestCase):
                                 'namespacePrefix': 'HP',
                                 'url': 'http://purl.obolibrary.org/obo/hp.owl',
                                 'version': datetime.now().strftime('%Y-%m-%d'),
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
+                    }],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_0_1',
+                    'pedigree': {
+                         'persons': [{
+                             'affected_status': 'UNAFFECTED',
+                             'family_id': 'F_0',
+                             'individual_id': 'I_0_0',
+                             'maternal_id': '0',
+                             'paternal_id': '0',
+                             'sex': 'MALE',
+                         }, {
+                             'affected_status': 'AFFECTED',
+                             'family_id': 'F_0',
+                             'individual_id': 'I_0_1',
+                             'maternal_id': '0',
+                             'paternal_id': '0',
+                             'sex': 'OTHER_SEX',
+                         }],
+                    },
+                    'proband': {
+                        'id': 'I_0_1',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_0_1',
+                                }],
+                            },
+                            'id': 'I_0_1',
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [
+                            {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
+                            {'id': 'HP:0011675', 'label': 'Arrhythmia'},
+                        ],
+                        'subject': {
+                            'id': 'I_0_1',
+                            'sex': 'OTHER_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'hp',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
+                                'name': 'Human Phenotype Ontology',
+                                'namespacePrefix': 'HP',
+                                'url': 'http://purl.obolibrary.org/obo/hp.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
+                    },
+                    'relatives': [{
+                        'id': 'I_0_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_0_0',
+                                }],
+                            },
+                            'id': 'I_0_0',
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_0_0',
+                            'sex': 'MALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
                             }, {
                                 'id': 'omim',
                                 'iriPrefix': 'https://www.omim.org/entry/',

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -166,7 +166,7 @@ class VlmTestCase(AioHTTPTestCase):
                 'exists': True,
                 'id': 'TestVLM',
                 'setType': 'Family',
-                'resultsCount': 5,
+                'resultsCount': 7,
                 'results': [{
                     'id': 'I_0_0',
                     'pedigree': {

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -849,6 +849,7 @@ class VlmTestCase(AioHTTPTestCase):
                 'setType': 'Family'
             },
         ]
+        self.maxDiff = None
         await self._test_match_endpoint('match_details', mocked_responses, meta, results, only_37_results, empty_results)
 
     async def _test_match_endpoint(self, path, mocked_responses, meta, results, only_37_results, empty_results):

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -31,139 +31,107 @@ class VlmTestCase(AioHTTPTestCase):
 
     @aioresponses(passthrough=['http://127.0.0.1'])
     async def test_match(self, mocked_responses):
-        response = {
-            'meta': {
-                'apiVersion': 'v1.0',
-                'beaconId': 'com.gnx.beacon.v2',
-                'returnedSchemas': [
-                    {
-                        'entityType': 'genomicVariant',
-                        'schema': 'ga4gh-beacon-variant-v2.0.0',
-                    }
-                ]
-            },
-            'response': {
-                'resultSets': [
-                    {
-                        'exists': True,
-                        'id': 'TestVLM Homozygous',
-                        'results': [],
-                        'resultsCount': 3,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': True,
-                        'id': 'TestVLM Heterozygous',
-                        'results': [],
-                        'resultsCount': 4,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Hemizygous',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Unknown',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                ],
-            }
+        meta = {
+            'apiVersion': 'v1.0',
+            'beaconId': 'com.gnx.beacon.v2',
+            'returnedSchemas': [
+                {
+                    'entityType': 'genomicVariant',
+                    'schema': 'ga4gh-beacon-variant-v2.0.0',
+                }
+            ]
         }
-        only_37_response = {
-            'meta': {
-                'apiVersion': 'v1.0',
-                'beaconId': 'com.gnx.beacon.v2',
-                'returnedSchemas': [
-                    {
-                        'entityType': 'genomicVariant',
-                        'schema': 'ga4gh-beacon-variant-v2.0.0',
-                    }
-                ]
+        results = [
+            {
+                'exists': True,
+                'id': 'TestVLM Homozygous',
+                'results': [],
+                'resultsCount': 3,
+                'setType': 'genomicVariant'
             },
-            'response': {
-                'resultSets': [
-                    {
-                        'exists': True,
-                        'id': 'TestVLM Homozygous',
-                        'results': [],
-                        'resultsCount': 1,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Heterozygous',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Hemizygous',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Unknown',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                ],
-            }
-        }
-        empty_response = {
-            'meta': {
-                'apiVersion': 'v1.0',
-                'beaconId': 'com.gnx.beacon.v2',
-                'returnedSchemas': [
-                    {
-                        'entityType': 'genomicVariant',
-                        'schema': 'ga4gh-beacon-variant-v2.0.0',
-                    }
-                ]
+            {
+                'exists': True,
+                'id': 'TestVLM Heterozygous',
+                'results': [],
+                'resultsCount': 4,
+                'setType': 'genomicVariant'
             },
-            'response': {
-                'resultSets': [
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Homozygous',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Heterozygous',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Hemizygous',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                    {
-                        'exists': False,
-                        'id': 'TestVLM Unknown',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'genomicVariant'
-                    },
-                ],
-            }
-        }
-        await self._test_match_endpoint('match', mocked_responses, response, only_37_response, empty_response)
+            {
+                'exists': False,
+                'id': 'TestVLM Hemizygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Unknown',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+        ]
+        only_37_results = [
+            {
+                'exists': True,
+                'id': 'TestVLM Homozygous',
+                'results': [],
+                'resultsCount': 1,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Heterozygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Hemizygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Unknown',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+        ]
+        empty_results = [
+            {
+                'exists': False,
+                'id': 'TestVLM Homozygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Heterozygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Hemizygous',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+            {
+                'exists': False,
+                'id': 'TestVLM Unknown',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'genomicVariant'
+            },
+        ]
+        await self._test_match_endpoint('match', mocked_responses, meta, results, only_37_results, empty_results)
 
     @aioresponses(passthrough=['http://127.0.0.1'])
     async def test_match_details(self, mocked_responses):
@@ -183,739 +151,707 @@ class VlmTestCase(AioHTTPTestCase):
             'definition': '',
         })
 
-        response = {
-            'meta': {
-                'apiVersion': 'v1.0',
-                'beaconId': 'com.gnx.beacon.v2',
-                'returnedSchemas': [
-                    {
-                        'entityType': 'Family',
-                        'schema': 'phenopacket-2.0',
-                    }
-                ]
-            },
-            'response': {
-                'resultSets': [
-                    {
-                        'exists': True,
-                        'id': 'TestVLM',
-                        'setType': 'Family',
-                        'resultsCount': 5,
-                        'results': [{
+        meta = {
+            'apiVersion': 'v1.0',
+            'beaconId': 'com.gnx.beacon.v2',
+            'returnedSchemas': [
+                {
+                    'entityType': 'Family',
+                    'schema': 'phenopacket-2.0',
+                }
+            ]
+        }
+        results = [
+            {
+                'exists': True,
+                'id': 'TestVLM',
+                'setType': 'Family',
+                'resultsCount': 5,
+                'results': [{
+                    'id': 'I_0_1',
+                    'pedigree': {
+                         'persons': [{
+                             'affected_status': 'UNAFFECTED',
+                             'family_id': 'F_0',
+                             'individual_id': 'I_0_0',
+                             'maternal_id': '0',
+                             'paternal_id': '0',
+                             'sex': 'MALE',
+                         }, {
+                             'affected_status': 'AFFECTED',
+                             'family_id': 'F_0',
+                             'individual_id': 'I_0_1',
+                             'maternal_id': '0',
+                             'paternal_id': '0',
+                             'sex': 'OTHER_SEX',
+                         }],
+                    },
+                    'proband': {
+                        'id': 'I_0_1',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_0_1',
+                                }],
+                            },
                             'id': 'I_0_1',
-                            'pedigree': {
-                                 'persons': [{
-                                     'affected_status': 'UNAFFECTED',
-                                     'family_id': 'F_0',
-                                     'individual_id': 'I_0_0',
-                                     'maternal_id': '0',
-                                     'paternal_id': '0',
-                                     'sex': 'MALE',
-                                 }, {
-                                     'affected_status': 'AFFECTED',
-                                     'family_id': 'F_0',
-                                     'individual_id': 'I_0_1',
-                                     'maternal_id': '0',
-                                     'paternal_id': '0',
-                                     'sex': 'OTHER_SEX',
-                                 }],
-                            },
-                            'proband': {
-                                'id': 'I_0_1',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'REJECTED',
-                                            'subject_or_biosample_id': 'I_0_1',
-                                        }],
-                                    },
-                                    'id': 'I_0_1',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [
-                                    {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
-                                    {'id': 'HP:0011675', 'label': 'Arrhythmia'},
-                                ],
-                                'subject': {
-                                    'id': 'I_0_1',
-                                    'sex': 'OTHER_SEX',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'hp',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
-                                        'name': 'Human Phenotype Ontology',
-                                        'namespacePrefix': 'HP',
-                                        'url': 'http://purl.obolibrary.org/obo/hp.owl',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }, {
-                                        'id': 'omim',
-                                        'iriPrefix': 'https://www.omim.org/entry/',
-                                        'name': 'Online Mendelian Inheritance in Man',
-                                        'namespacePrefix': 'OMIM',
-                                        'url': 'https://www.omim.org',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
-                            },
-                            'relatives': [{
-                                'id': 'I_0_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'REJECTED',
-                                            'subject_or_biosample_id': 'I_0_0',
-                                        }],
-                                    },
-                                    'id': 'I_0_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_0_0',
-                                    'sex': 'MALE',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'omim',
-                                        'iriPrefix': 'https://www.omim.org/entry/',
-                                        'name': 'Online Mendelian Inheritance in Man',
-                                        'namespacePrefix': 'OMIM',
-                                        'url': 'https://www.omim.org',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [
+                            {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
+                            {'id': 'HP:0011675', 'label': 'Arrhythmia'},
+                        ],
+                        'subject': {
+                            'id': 'I_0_1',
+                            'sex': 'OTHER_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'hp',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
+                                'name': 'Human Phenotype Ontology',
+                                'namespacePrefix': 'HP',
+                                'url': 'http://purl.obolibrary.org/obo/hp.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
                             }],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
-                        }, {
+                        },
+                    },
+                    'relatives': [{
+                        'id': 'I_0_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_0_0',
+                                }],
+                            },
                             'id': 'I_0_0',
-                            'pedigree': {
-                                'persons': [{
-                                    'affected_status': 'UNAFFECTED',
-                                    'family_id': 'F_0',
-                                    'individual_id': 'I_0_0',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'MALE',
-                                }, {
-                                    'affected_status': 'AFFECTED',
-                                    'family_id': 'F_0',
-                                    'individual_id': 'I_0_1',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'OTHER_SEX',
-                                }],
-                            },
-                            'proband': {
-                                'id': 'I_0_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'REJECTED',
-                                            'subject_or_biosample_id': 'I_0_0',
-                                        }],
-                                    },
-                                    'id': 'I_0_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_0_0',
-                                    'sex': 'MALE',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'omim',
-                                        'iriPrefix': 'https://www.omim.org/entry/',
-                                        'name': 'Online Mendelian Inheritance in Man',
-                                        'namespacePrefix': 'OMIM',
-                                        'url': 'https://www.omim.org',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
-                            },
-                            'relatives': [{
-                                'id': 'I_0_1',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'REJECTED',
-                                            'subject_or_biosample_id': 'I_0_1',
-                                        }],
-                                    },
-                                    'id': 'I_0_1',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [
-                                    {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
-                                    {'id': 'HP:0011675', 'label': 'Arrhythmia'},
-                                ],
-                                'subject': {
-                                    'id': 'I_0_1',
-                                    'sex': 'OTHER_SEX',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'hp',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
-                                        'name': 'Human Phenotype Ontology',
-                                        'namespacePrefix': 'HP',
-                                        'url': 'http://purl.obolibrary.org/obo/hp.owl',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }, {
-                                        'id': 'omim',
-                                        'iriPrefix': 'https://www.omim.org/entry/',
-                                        'name': 'Online Mendelian Inheritance in Man',
-                                        'namespacePrefix': 'OMIM',
-                                        'url': 'https://www.omim.org',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_0_0',
+                            'sex': 'MALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
                             }],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                        },
+                    }],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_0_0',
+                    'pedigree': {
+                        'persons': [{
+                            'affected_status': 'UNAFFECTED',
+                            'family_id': 'F_0',
+                            'individual_id': 'I_0_0',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'MALE',
                         }, {
+                            'affected_status': 'AFFECTED',
+                            'family_id': 'F_0',
+                            'individual_id': 'I_0_1',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'OTHER_SEX',
+                        }],
+                    },
+                    'proband': {
+                        'id': 'I_0_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_0_0',
+                                }],
+                            },
+                            'id': 'I_0_0',
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_0_0',
+                            'sex': 'MALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
+                    },
+                    'relatives': [{
+                        'id': 'I_0_1',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_0_1',
+                                }],
+                            },
+                            'id': 'I_0_1',
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [
+                            {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
+                            {'id': 'HP:0011675', 'label': 'Arrhythmia'},
+                        ],
+                        'subject': {
+                            'id': 'I_0_1',
+                            'sex': 'OTHER_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'hp',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
+                                'name': 'Human Phenotype Ontology',
+                                'namespacePrefix': 'HP',
+                                'url': 'http://purl.obolibrary.org/obo/hp.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
+                    }],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_1_0',
+                    'pedigree': {
+                        'persons': [{
+                            'affected_status': 'AFFECTED',
+                            'family_id': 'F_1',
+                            'individual_id': 'I_1_0',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'OTHER_SEX',
+                        }],
+                    },
+                    'proband': {
+                        'id': 'I_1_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'REJECTED',
+                                    'subject_or_biosample_id': 'I_1_0',
+                                }],
+                            },
                             'id': 'I_1_0',
-                            'pedigree': {
-                                'persons': [{
-                                    'affected_status': 'AFFECTED',
-                                    'family_id': 'F_1',
-                                    'individual_id': 'I_1_0',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'OTHER_SEX',
-                                }],
-                            },
-                            'proband': {
-                                'id': 'I_1_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'REJECTED',
-                                            'subject_or_biosample_id': 'I_1_0',
-                                        }],
-                                    },
-                                    'id': 'I_1_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [
-                                    {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
-                                    {'id': 'HP:0011675', 'label': 'Arrhythmia'},
-                                ],
-                                'subject': {
-                                    'id': 'I_1_0',
-                                    'sex': 'OTHER_SEX',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'hp',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
-                                        'name': 'Human Phenotype Ontology',
-                                        'namespacePrefix': 'HP',
-                                        'url': 'http://purl.obolibrary.org/obo/hp.owl',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }, {
-                                        'id': 'omim',
-                                        'iriPrefix': 'https://www.omim.org/entry/',
-                                        'name': 'Online Mendelian Inheritance in Man',
-                                        'namespacePrefix': 'OMIM',
-                                        'url': 'https://www.omim.org',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
-                            },
-                            'relatives': [],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [
+                            {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
+                            {'id': 'HP:0011675', 'label': 'Arrhythmia'},
+                        ],
+                        'subject': {
+                            'id': 'I_1_0',
+                            'sex': 'OTHER_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'hp',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
+                                'name': 'Human Phenotype Ontology',
+                                'namespacePrefix': 'HP',
+                                'url': 'http://purl.obolibrary.org/obo/hp.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
+                    },
+                    'relatives': [],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_2_0',
+                    'pedigree': {
+                        'persons': [{
+                            'affected_status': 'MISSING',
+                            'family_id': 'F_2',
+                            'individual_id': 'I_2_0',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'UNKNOWN_SEX',
                         }, {
+                            'affected_status': 'MISSING',
+                            'family_id': 'F_2',
+                            'individual_id': 'I_2_1',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'FEMALE',
+                        }],
+                    },
+                    'proband': {
+                        'id': 'I_2_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'CANDIDATE',
+                                    'subject_or_biosample_id': 'I_2_0',
+                                }],
+                            },
                             'id': 'I_2_0',
-                            'pedigree': {
-                                'persons': [{
-                                    'affected_status': 'MISSING',
-                                    'family_id': 'F_2',
-                                    'individual_id': 'I_2_0',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'UNKNOWN_SEX',
-                                }, {
-                                    'affected_status': 'MISSING',
-                                    'family_id': 'F_2',
-                                    'individual_id': 'I_2_1',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'FEMALE',
-                                }],
-                            },
-                            'proband': {
-                                'id': 'I_2_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'CANDIDATE',
-                                            'subject_or_biosample_id': 'I_2_0',
-                                        }],
-                                    },
-                                    'id': 'I_2_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_2_0',
-                                    'sex': 'UNKNOWN_SEX',
-                                },
-                                'meta_data': {
-                                    'submitted_by': '',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }],
-                                },
-                            },
-                            'relatives': [{
-                                'id': 'I_2_1',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'MONDO:0044970', 'label': 'mitochondrial disease'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'CANDIDATE',
-                                            'subject_or_biosample_id': 'I_2_1',
-                                        }],
-                                    },
-                                    'id': 'I_2_1',
-                                    'progress_status': 'SOLVED',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_2_1',
-                                    'sex': 'FEMALE',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'mondo',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/MONDO_',
-                                        'name': 'Mondo Disease Ontology',
-                                        'namespacePrefix': 'MONDO',
-                                        'url': 'http://purl.obolibrary.org/obo/mondo.owl',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_2_0',
+                            'sex': 'UNKNOWN_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': '',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
                             }],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
-                        }, {
+                        },
+                    },
+                    'relatives': [{
+                        'id': 'I_2_1',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'MONDO:0044970', 'label': 'mitochondrial disease'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'CANDIDATE',
+                                    'subject_or_biosample_id': 'I_2_1',
+                                }],
+                            },
                             'id': 'I_2_1',
-                            'pedigree': {
-                                'persons': [{
-                                    'affected_status': 'MISSING',
-                                    'family_id': 'F_2',
-                                    'individual_id': 'I_2_0',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'UNKNOWN_SEX',
-                                }, {
-                                    'affected_status': 'MISSING',
-                                    'family_id': 'F_2',
-                                    'individual_id': 'I_2_1',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'FEMALE',
-                                }],
-                            },
-                            'proband': {
-                                'id': 'I_2_1',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'MONDO:0044970', 'label': 'mitochondrial disease'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'CANDIDATE',
-                                            'subject_or_biosample_id': 'I_2_1',
-                                        }],
-                                    },
-                                    'id': 'I_2_1',
-                                    'progress_status': 'SOLVED',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_2_1',
-                                    'sex': 'FEMALE',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'mondo',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/MONDO_',
-                                        'name': 'Mondo Disease Ontology',
-                                        'namespacePrefix': 'MONDO',
-                                        'url': 'http://purl.obolibrary.org/obo/mondo.owl',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
-                            },
-                            'relatives': [{
-                                'id': 'I_2_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'CANDIDATE',
-                                            'subject_or_biosample_id': 'I_2_0',
-                                        }],
-                                    },
-                                    'id': 'I_2_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_2_0',
-                                    'sex': 'UNKNOWN_SEX',
-                                },
-                                'meta_data': {
-                                    'submitted_by': '',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }],
-                                },
+                            'progress_status': 'SOLVED',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_2_1',
+                            'sex': 'FEMALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'mondo',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/MONDO_',
+                                'name': 'Mondo Disease Ontology',
+                                'namespacePrefix': 'MONDO',
+                                'url': 'http://purl.obolibrary.org/obo/mondo.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
                             }],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                        },
+                    }],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_2_1',
+                    'pedigree': {
+                        'persons': [{
+                            'affected_status': 'MISSING',
+                            'family_id': 'F_2',
+                            'individual_id': 'I_2_0',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'UNKNOWN_SEX',
                         }, {
+                            'affected_status': 'MISSING',
+                            'family_id': 'F_2',
+                            'individual_id': 'I_2_1',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'FEMALE',
+                        }],
+                    },
+                    'proband': {
+                        'id': 'I_2_1',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'MONDO:0044970', 'label': 'mitochondrial disease'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'CANDIDATE',
+                                    'subject_or_biosample_id': 'I_2_1',
+                                }],
+                            },
+                            'id': 'I_2_1',
+                            'progress_status': 'SOLVED',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_2_1',
+                            'sex': 'FEMALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'mondo',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/MONDO_',
+                                'name': 'Mondo Disease Ontology',
+                                'namespacePrefix': 'MONDO',
+                                'url': 'http://purl.obolibrary.org/obo/mondo.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
+                    },
+                    'relatives': [{
+                        'id': 'I_2_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'CANDIDATE',
+                                    'subject_or_biosample_id': 'I_2_0',
+                                }],
+                            },
+                            'id': 'I_2_0',
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_2_0',
+                            'sex': 'UNKNOWN_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': '',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }],
+                        },
+                    }],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_3_0',
+                    'pedigree': {
+                        'persons': [{
+                            'affected_status': 'AFFECTED',
+                            'family_id': 'F_3',
+                            'individual_id': 'I_3_0',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'MALE',
+                        }],
+                    },
+                    'proband': {
+                        'id': 'I_3_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {
+                                                'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'UNKNOWN_STATUS',
+                                    'subject_or_biosample_id': 'I_3_0',
+                                }],
+                            },
                             'id': 'I_3_0',
-                            'pedigree': {
-                                'persons': [{
-                                    'affected_status': 'AFFECTED',
-                                    'family_id': 'F_3',
-                                    'individual_id': 'I_3_0',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'MALE',
-                                }],
-                            },
-                            'proband': {
-                                'id': 'I_3_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {
-                                                        'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'UNKNOWN_STATUS',
-                                            'subject_or_biosample_id': 'I_3_0',
-                                        }],
+                            'progress_status': 'UNKNOWN_PROGRESS',
+                        }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_3_0',
+                            'sex': 'MALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'seqr-test@gmail.com,test@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }],
+                        },
+                    },
+                    'relatives': [],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }, {
+                    'id': 'I_4_0',
+                    'pedigree': {
+                        'persons': [{
+                            'affected_status': 'AFFECTED',
+                            'family_id': 'F_4',
+                            'individual_id': 'I_4_0',
+                            'maternal_id': '0',
+                            'paternal_id': '0',
+                            'sex': 'MALE',
+                        }],
+                    },
+                    'proband': {
+                        'id': 'I_4_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                        },
                                     },
-                                    'id': 'I_3_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
+                                    'interpretation_status': 'UNKNOWN_STATUS',
+                                    'subject_or_biosample_id': 'I_4_0',
                                 }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_3_0',
-                                    'sex': 'MALE',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'seqr-test@gmail.com,test@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }],
-                                },
                             },
-                            'relatives': [],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
-                        }, {
                             'id': 'I_4_0',
-                            'pedigree': {
-                                'persons': [{
-                                    'affected_status': 'AFFECTED',
-                                    'family_id': 'F_4',
-                                    'individual_id': 'I_4_0',
-                                    'maternal_id': '0',
-                                    'paternal_id': '0',
-                                    'sex': 'MALE',
-                                }],
-                            },
-                            'proband': {
-                                'id': 'I_4_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'UNKNOWN_STATUS',
-                                            'subject_or_biosample_id': 'I_4_0',
-                                        }],
-                                    },
-                                    'id': 'I_4_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [],
-                                'subject': {
-                                    'id': 'I_4_0',
-                                    'sex': 'MALE',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'seqr-test@gmail.com,test@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }],
-                                },
-                            },
-                            'relatives': [],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                            'progress_status': 'UNKNOWN_PROGRESS',
                         }],
+                        'phenotypic_features': [],
+                        'subject': {
+                            'id': 'I_4_0',
+                            'sex': 'MALE',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'seqr-test@gmail.com,test@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }],
+                        },
                     },
-                ],
-            }
-        }
-        only_37_response = {
-            'meta': {
-                'apiVersion': 'v1.0',
-                'beaconId': 'com.gnx.beacon.v2',
-                'returnedSchemas': [
-                    {
-                        'entityType': 'Family',
-                        'schema': 'phenopacket-2.0',
-                    }
-                ]
+                    'relatives': [],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }],
             },
-            'response': {
-                'resultSets': [
-                    {
-                        'exists': True,
-                        'id': 'TestVLM',
-                        'setType': 'Family',
-                        'resultsCount': 1,
-                        'results': [{
+        ]
+        only_37_results = [
+            {
+                'exists': True,
+                'id': 'TestVLM',
+                'setType': 'Family',
+                'resultsCount': 1,
+                'results': [{
+                    'id': 'I_0_0',
+                    'pedigree': {
+                         'persons': [{
+                             'affected_status': 'AFFECTED',
+                             'family_id': 'F_0',
+                             'individual_id': 'I_0_0',
+                             'maternal_id': '0',
+                             'paternal_id': '0',
+                             'sex': 'OTHER_SEX',
+                         }],
+                    },
+                    'proband': {
+                        'id': 'I_0_0',
+                        'interpretations': [{
+                            'diagnosis': {
+                                'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                'genomic_interpretations': [{
+                                    'call': {
+                                        'variation_descriptor': {
+                                            'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                        },
+                                    },
+                                    'interpretation_status': 'UNKNOWN_STATUS',
+                                    'subject_or_biosample_id': 'I_0_0',
+                                }],
+                            },
                             'id': 'I_0_0',
-                            'pedigree': {
-                                 'persons': [{
-                                     'affected_status': 'AFFECTED',
-                                     'family_id': 'F_0',
-                                     'individual_id': 'I_0_0',
-                                     'maternal_id': '0',
-                                     'paternal_id': '0',
-                                     'sex': 'OTHER_SEX',
-                                 }],
-                            },
-                            'proband': {
-                                'id': 'I_0_0',
-                                'interpretations': [{
-                                    'diagnosis': {
-                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
-                                        'genomic_interpretations': [{
-                                            'call': {
-                                                'variation_descriptor': {
-                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
-                                                },
-                                            },
-                                            'interpretation_status': 'UNKNOWN_STATUS',
-                                            'subject_or_biosample_id': 'I_0_0',
-                                        }],
-                                    },
-                                    'id': 'I_0_0',
-                                    'progress_status': 'UNKNOWN_PROGRESS',
-                                }],
-                                'phenotypic_features': [
-                                    {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
-                                    {'id': 'HP:0011675', 'label': 'Arrhythmia'},
-                                ],
-                                'subject': {
-                                    'id': 'I_0_0',
-                                    'sex': 'OTHER_SEX',
-                                },
-                                'meta_data': {
-                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
-                                    'phenopacket_schema_version': '2.0',
-                                    'resources': [{
-                                        'id': 'geno',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
-                                        'name': 'GENO ontology',
-                                        'namespacePrefix': 'GENO',
-                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
-                                        'version': '2026-02-02',
-                                    }, {
-                                        'id': 'hp',
-                                        'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
-                                        'name': 'Human Phenotype Ontology',
-                                        'namespacePrefix': 'HP',
-                                        'url': 'http://purl.obolibrary.org/obo/hp.owl',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }, {
-                                        'id': 'omim',
-                                        'iriPrefix': 'https://www.omim.org/entry/',
-                                        'name': 'Online Mendelian Inheritance in Man',
-                                        'namespacePrefix': 'OMIM',
-                                        'url': 'https://www.omim.org',
-                                        'version': datetime.now().strftime('%Y-%m-%d'),
-                                    }],
-                                },
-                            },
-                            'relatives': [],
-                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                            'progress_status': 'UNKNOWN_PROGRESS',
                         }],
+                        'phenotypic_features': [
+                            {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
+                            {'id': 'HP:0011675', 'label': 'Arrhythmia'},
+                        ],
+                        'subject': {
+                            'id': 'I_0_0',
+                            'sex': 'OTHER_SEX',
+                        },
+                        'meta_data': {
+                            'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                            'phenopacket_schema_version': '2.0',
+                            'resources': [{
+                                'id': 'geno',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                'name': 'GENO ontology',
+                                'namespacePrefix': 'GENO',
+                                'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                'version': '2026-02-02',
+                            }, {
+                                'id': 'hp',
+                                'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
+                                'name': 'Human Phenotype Ontology',
+                                'namespacePrefix': 'HP',
+                                'url': 'http://purl.obolibrary.org/obo/hp.owl',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }, {
+                                'id': 'omim',
+                                'iriPrefix': 'https://www.omim.org/entry/',
+                                'name': 'Online Mendelian Inheritance in Man',
+                                'namespacePrefix': 'OMIM',
+                                'url': 'https://www.omim.org',
+                                'version': datetime.now().strftime('%Y-%m-%d'),
+                            }],
+                        },
                     },
-                ],
-            }
-        }
-        empty_response = {
-            'meta': {
-                'apiVersion': 'v1.0',
-                'beaconId': 'com.gnx.beacon.v2',
-                'returnedSchemas': [
-                    {
-                        'entityType': 'Family',
-                        'schema': 'phenopacket-2.0',
-                    }
-                ]
+                    'relatives': [],
+                    'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                }],
             },
-            'response': {
-                'resultSets': [
-                    {
-                        'exists': False,
-                        'id': 'TestVLM',
-                        'results': [],
-                        'resultsCount': 0,
-                        'setType': 'Family'
-                    },
-                ],
-            }
-        }
-        await self._test_match_endpoint('match_details', mocked_responses, response, only_37_response, empty_response)
+        ]
+        empty_results = [
+            {
+                'exists': False,
+                'id': 'TestVLM',
+                'results': [],
+                'resultsCount': 0,
+                'setType': 'Family'
+            },
+        ]
+        await self._test_match_endpoint('match_details', mocked_responses, meta, results, only_37_results, empty_results)
 
-    async def _test_match_endpoint(self, path, mocked_responses, response, only_37_response, empty_response):
+    async def _test_match_endpoint(self, path, mocked_responses, meta, results, only_37_results, empty_results):
 
         mocked_responses.post(
             'https://vlm-auth.us.auth0.com/oauth/token', payload={'access_token': 'test_token'}, repeat=True,  # nosec
@@ -931,7 +867,7 @@ class VlmTestCase(AioHTTPTestCase):
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh38&referenceName=1&start=38724419&referenceBases=T&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        full_response = {
+        response = {
             'beaconHandovers': [
                 {
                     'handoverType': {
@@ -942,13 +878,16 @@ class VlmTestCase(AioHTTPTestCase):
                     'email': None,
                 }
             ],
+            'meta': meta,
             'responseSummary': {
                 'exists': True,
                 'total': 7,
             },
-            **response,
+            'response': {
+                'resultSets': results,
+            },
         }
-        self.assertDictEqual(resp_json, full_response)
+        self.assertDictEqual(resp_json, response)
         mocked_responses.assert_called_with(
             'https://vlm-auth.us.auth0.com/oauth/token',
             method='POST',
@@ -966,9 +905,9 @@ class VlmTestCase(AioHTTPTestCase):
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh37&referenceName=1&start=39190091&referenceBases=T&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, full_response)
+        self.assertDictEqual(resp_json, response)
 
-        full_only_37_response = {
+        only_37_response = {
             'beaconHandovers': [
                 {
                     'handoverType': {
@@ -979,21 +918,24 @@ class VlmTestCase(AioHTTPTestCase):
                     'email': None,
                 }
             ],
+            'meta': meta,
             'responseSummary': {
                 'exists': True,
                 'total': 1,
             },
-            **only_37_response,
+            'response': {
+                'resultSets': only_37_results,
+            },
         }
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=hg19&referenceName=chr7&start=143270172&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, full_only_37_response)
+        self.assertDictEqual(resp_json, only_37_response)
 
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh38&referenceName=chr7&start=143573079&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, full_only_37_response)
+        self.assertDictEqual(resp_json, only_37_response)
 
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=hg38&referenceName=chr7&start=143270172&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
@@ -1009,11 +951,14 @@ class VlmTestCase(AioHTTPTestCase):
                     'email': None,
                 }
             ],
+            'meta': meta,
             'responseSummary': {
                 'exists': False,
                 'total': 0,
             },
-            **empty_response,
+            'response': {
+                'resultSets': empty_results,
+            },
         })
 
     @aioresponses(passthrough=['http://127.0.0.1'])

--- a/vlm/test_vlm.py
+++ b/vlm/test_vlm.py
@@ -32,16 +32,6 @@ class VlmTestCase(AioHTTPTestCase):
     @aioresponses(passthrough=['http://127.0.0.1'])
     async def test_match(self, mocked_responses):
         response = {
-            'beaconHandovers': [
-                {
-                    'handoverType': {
-                        'id': 'TestVLM',
-                        'label': 'TestVLM browser',
-                    },
-                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=1-38724419-T-G',
-                    'email': None,
-                }
-            ],
             'meta': {
                 'apiVersion': 'v1.0',
                 'beaconId': 'com.gnx.beacon.v2',
@@ -51,10 +41,6 @@ class VlmTestCase(AioHTTPTestCase):
                         'schema': 'ga4gh-beacon-variant-v2.0.0',
                     }
                 ]
-            },
-            'responseSummary': {
-                'exists': True,
-                'total': 7,
             },
             'response': {
                 'resultSets': [
@@ -90,16 +76,6 @@ class VlmTestCase(AioHTTPTestCase):
             }
         }
         only_37_response = {
-            'beaconHandovers': [
-                {
-                    'handoverType': {
-                        'id': 'TestVLM',
-                        'label': 'TestVLM browser',
-                    },
-                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=37&variantId=7-143270172-A-G',
-                    'email': None,
-                }
-            ],
             'meta': {
                 'apiVersion': 'v1.0',
                 'beaconId': 'com.gnx.beacon.v2',
@@ -109,10 +85,6 @@ class VlmTestCase(AioHTTPTestCase):
                         'schema': 'ga4gh-beacon-variant-v2.0.0',
                     }
                 ]
-            },
-            'responseSummary': {
-                'exists': True,
-                'total': 1,
             },
             'response': {
                 'resultSets': [
@@ -148,16 +120,6 @@ class VlmTestCase(AioHTTPTestCase):
             }
         }
         empty_response = {
-            'beaconHandovers': [
-                {
-                    'handoverType': {
-                        'id': 'TestVLM',
-                        'label': 'TestVLM browser',
-                    },
-                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=7-143270172-A-G',
-                    'email': None,
-                }
-            ],
             'meta': {
                 'apiVersion': 'v1.0',
                 'beaconId': 'com.gnx.beacon.v2',
@@ -167,10 +129,6 @@ class VlmTestCase(AioHTTPTestCase):
                         'schema': 'ga4gh-beacon-variant-v2.0.0',
                     }
                 ]
-            },
-            'responseSummary': {
-                'exists': False,
-                'total': 0,
             },
             'response': {
                 'resultSets': [
@@ -226,16 +184,6 @@ class VlmTestCase(AioHTTPTestCase):
         })
 
         response = {
-            'beaconHandovers': [
-                {
-                    'handoverType': {
-                        'id': 'TestVLM',
-                        'label': 'TestVLM browser',
-                    },
-                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=1-38724419-T-G',
-                    'email': None,
-                }
-            ],
             'meta': {
                 'apiVersion': 'v1.0',
                 'beaconId': 'com.gnx.beacon.v2',
@@ -246,10 +194,6 @@ class VlmTestCase(AioHTTPTestCase):
                     }
                 ]
             },
-            'responseSummary': {
-                'exists': True,
-                'total': 5,
-            },
             'response': {
                 'resultSets': [
                     {
@@ -258,7 +202,7 @@ class VlmTestCase(AioHTTPTestCase):
                         'setType': 'Family',
                         'resultsCount': 5,
                         'results': [{
-                            'id': 'F_0',
+                            'id': 'I_0_1',
                             'pedigree': {
                                  'persons': [{
                                      'affected_status': 'UNAFFECTED',
@@ -374,7 +318,123 @@ class VlmTestCase(AioHTTPTestCase):
                             }],
                             'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
                         }, {
-                            'id': 'F_1',
+                            'id': 'I_0_0',
+                            'pedigree': {
+                                'persons': [{
+                                    'affected_status': 'UNAFFECTED',
+                                    'family_id': 'F_0',
+                                    'individual_id': 'I_0_0',
+                                    'maternal_id': '0',
+                                    'paternal_id': '0',
+                                    'sex': 'MALE',
+                                }, {
+                                    'affected_status': 'AFFECTED',
+                                    'family_id': 'F_0',
+                                    'individual_id': 'I_0_1',
+                                    'maternal_id': '0',
+                                    'paternal_id': '0',
+                                    'sex': 'OTHER_SEX',
+                                }],
+                            },
+                            'proband': {
+                                'id': 'I_0_0',
+                                'interpretations': [{
+                                    'diagnosis': {
+                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                        'genomic_interpretations': [{
+                                            'call': {
+                                                'variation_descriptor': {
+                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                                },
+                                            },
+                                            'interpretation_status': 'REJECTED',
+                                            'subject_or_biosample_id': 'I_0_0',
+                                        }],
+                                    },
+                                    'id': 'I_0_0',
+                                    'progress_status': 'UNKNOWN_PROGRESS',
+                                }],
+                                'phenotypic_features': [],
+                                'subject': {
+                                    'id': 'I_0_0',
+                                    'sex': 'MALE',
+                                },
+                                'meta_data': {
+                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                                    'phenopacket_schema_version': '2.0',
+                                    'resources': [{
+                                        'id': 'geno',
+                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                        'name': 'GENO ontology',
+                                        'namespacePrefix': 'GENO',
+                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                        'version': '2026-02-02',
+                                    }, {
+                                        'id': 'omim',
+                                        'iriPrefix': 'https://www.omim.org/entry/',
+                                        'name': 'Online Mendelian Inheritance in Man',
+                                        'namespacePrefix': 'OMIM',
+                                        'url': 'https://www.omim.org',
+                                        'version': datetime.now().strftime('%Y-%m-%d'),
+                                    }],
+                                },
+                            },
+                            'relatives': [{
+                                'id': 'I_0_1',
+                                'interpretations': [{
+                                    'diagnosis': {
+                                        'disease': {'id': 'OMIM:615123', 'label': 'Immunodeficiency 38'},
+                                        'genomic_interpretations': [{
+                                            'call': {
+                                                'variation_descriptor': {
+                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                                },
+                                            },
+                                            'interpretation_status': 'REJECTED',
+                                            'subject_or_biosample_id': 'I_0_1',
+                                        }],
+                                    },
+                                    'id': 'I_0_1',
+                                    'progress_status': 'UNKNOWN_PROGRESS',
+                                }],
+                                'phenotypic_features': [
+                                    {'id': 'HP:0002011', 'label': 'Morphological central nervous system abnormality'},
+                                    {'id': 'HP:0011675', 'label': 'Arrhythmia'},
+                                ],
+                                'subject': {
+                                    'id': 'I_0_1',
+                                    'sex': 'OTHER_SEX',
+                                },
+                                'meta_data': {
+                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                                    'phenopacket_schema_version': '2.0',
+                                    'resources': [{
+                                        'id': 'geno',
+                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                        'name': 'GENO ontology',
+                                        'namespacePrefix': 'GENO',
+                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                        'version': '2026-02-02',
+                                    }, {
+                                        'id': 'hp',
+                                        'iriPrefix': 'http://purl.obolibrary.org/obo/HP_',
+                                        'name': 'Human Phenotype Ontology',
+                                        'namespacePrefix': 'HP',
+                                        'url': 'http://purl.obolibrary.org/obo/hp.owl',
+                                        'version': datetime.now().strftime('%Y-%m-%d'),
+                                    }, {
+                                        'id': 'omim',
+                                        'iriPrefix': 'https://www.omim.org/entry/',
+                                        'name': 'Online Mendelian Inheritance in Man',
+                                        'namespacePrefix': 'OMIM',
+                                        'url': 'https://www.omim.org',
+                                        'version': datetime.now().strftime('%Y-%m-%d'),
+                                    }],
+                                },
+                            }],
+                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                        }, {
+                            'id': 'I_1_0',
                             'pedigree': {
                                 'persons': [{
                                     'affected_status': 'AFFECTED',
@@ -441,7 +501,7 @@ class VlmTestCase(AioHTTPTestCase):
                             'relatives': [],
                             'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
                         }, {
-                            'id': 'F_2',
+                            'id': 'I_2_0',
                             'pedigree': {
                                 'persons': [{
                                     'affected_status': 'MISSING',
@@ -539,7 +599,105 @@ class VlmTestCase(AioHTTPTestCase):
                             }],
                             'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
                         }, {
-                            'id': 'F_3',
+                            'id': 'I_2_1',
+                            'pedigree': {
+                                'persons': [{
+                                    'affected_status': 'MISSING',
+                                    'family_id': 'F_2',
+                                    'individual_id': 'I_2_0',
+                                    'maternal_id': '0',
+                                    'paternal_id': '0',
+                                    'sex': 'UNKNOWN_SEX',
+                                }, {
+                                    'affected_status': 'MISSING',
+                                    'family_id': 'F_2',
+                                    'individual_id': 'I_2_1',
+                                    'maternal_id': '0',
+                                    'paternal_id': '0',
+                                    'sex': 'FEMALE',
+                                }],
+                            },
+                            'proband': {
+                                'id': 'I_2_1',
+                                'interpretations': [{
+                                    'diagnosis': {
+                                        'disease': {'id': 'MONDO:0044970', 'label': 'mitochondrial disease'},
+                                        'genomic_interpretations': [{
+                                            'call': {
+                                                'variation_descriptor': {
+                                                    'allelic_state': {'id': 'GENO:0000136', 'label': 'homozygous'},
+                                                },
+                                            },
+                                            'interpretation_status': 'CANDIDATE',
+                                            'subject_or_biosample_id': 'I_2_1',
+                                        }],
+                                    },
+                                    'id': 'I_2_1',
+                                    'progress_status': 'SOLVED',
+                                }],
+                                'phenotypic_features': [],
+                                'subject': {
+                                    'id': 'I_2_1',
+                                    'sex': 'FEMALE',
+                                },
+                                'meta_data': {
+                                    'submitted_by': 'test@broadinstitute.org,vlm@broadinstitute.org',
+                                    'phenopacket_schema_version': '2.0',
+                                    'resources': [{
+                                        'id': 'geno',
+                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                        'name': 'GENO ontology',
+                                        'namespacePrefix': 'GENO',
+                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                        'version': '2026-02-02',
+                                    }, {
+                                        'id': 'mondo',
+                                        'iriPrefix': 'http://purl.obolibrary.org/obo/MONDO_',
+                                        'name': 'Mondo Disease Ontology',
+                                        'namespacePrefix': 'MONDO',
+                                        'url': 'http://purl.obolibrary.org/obo/mondo.owl',
+                                        'version': datetime.now().strftime('%Y-%m-%d'),
+                                    }],
+                                },
+                            },
+                            'relatives': [{
+                                'id': 'I_2_0',
+                                'interpretations': [{
+                                    'diagnosis': {
+                                        'genomic_interpretations': [{
+                                            'call': {
+                                                'variation_descriptor': {
+                                                    'allelic_state': {'id': 'GENO:0000135', 'label': 'heterozygous'},
+                                                },
+                                            },
+                                            'interpretation_status': 'CANDIDATE',
+                                            'subject_or_biosample_id': 'I_2_0',
+                                        }],
+                                    },
+                                    'id': 'I_2_0',
+                                    'progress_status': 'UNKNOWN_PROGRESS',
+                                }],
+                                'phenotypic_features': [],
+                                'subject': {
+                                    'id': 'I_2_0',
+                                    'sex': 'UNKNOWN_SEX',
+                                },
+                                'meta_data': {
+                                    'submitted_by': '',
+                                    'phenopacket_schema_version': '2.0',
+                                    'resources': [{
+                                        'id': 'geno',
+                                        'iriPrefix': 'http://purl.obolibrary.org/obo/GENO_',
+                                        'name': 'GENO ontology',
+                                        'namespacePrefix': 'GENO',
+                                        'url': 'http://purl.obolibrary.org/obo/geno.owl',
+                                        'version': '2026-02-02',
+                                    }],
+                                },
+                            }],
+                            'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
+                        }, {
+                            'id': 'I_3_0',
                             'pedigree': {
                                 'persons': [{
                                     'affected_status': 'AFFECTED',
@@ -589,7 +747,7 @@ class VlmTestCase(AioHTTPTestCase):
                             'relatives': [],
                             'meta_data': {'phenopacket_schema_version': '2.0', 'resources': []},
                         }, {
-                            'id': 'F_4',
+                            'id': 'I_4_0',
                             'pedigree': {
                                 'persons': [{
                                     'affected_status': 'AFFECTED',
@@ -643,16 +801,6 @@ class VlmTestCase(AioHTTPTestCase):
             }
         }
         only_37_response = {
-            'beaconHandovers': [
-                {
-                    'handoverType': {
-                        'id': 'TestVLM',
-                        'label': 'TestVLM browser',
-                    },
-                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=37&variantId=7-143270172-A-G',
-                    'email': None,
-                }
-            ],
             'meta': {
                 'apiVersion': 'v1.0',
                 'beaconId': 'com.gnx.beacon.v2',
@@ -663,10 +811,6 @@ class VlmTestCase(AioHTTPTestCase):
                     }
                 ]
             },
-            'responseSummary': {
-                'exists': True,
-                'total': 1,
-            },
             'response': {
                 'resultSets': [
                     {
@@ -675,7 +819,7 @@ class VlmTestCase(AioHTTPTestCase):
                         'setType': 'Family',
                         'resultsCount': 1,
                         'results': [{
-                            'id': 'F_0',
+                            'id': 'I_0_0',
                             'pedigree': {
                                  'persons': [{
                                      'affected_status': 'AFFECTED',
@@ -747,16 +891,6 @@ class VlmTestCase(AioHTTPTestCase):
             }
         }
         empty_response = {
-            'beaconHandovers': [
-                {
-                    'handoverType': {
-                        'id': 'TestVLM',
-                        'label': 'TestVLM browser',
-                    },
-                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=7-143270172-A-G',
-                    'email': None,
-                }
-            ],
             'meta': {
                 'apiVersion': 'v1.0',
                 'beaconId': 'com.gnx.beacon.v2',
@@ -766,10 +900,6 @@ class VlmTestCase(AioHTTPTestCase):
                         'schema': 'phenopacket-2.0',
                     }
                 ]
-            },
-            'responseSummary': {
-                'exists': False,
-                'total': 0,
             },
             'response': {
                 'resultSets': [
@@ -801,7 +931,24 @@ class VlmTestCase(AioHTTPTestCase):
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh38&referenceName=1&start=38724419&referenceBases=T&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, response)
+        full_response = {
+            'beaconHandovers': [
+                {
+                    'handoverType': {
+                        'id': 'TestVLM',
+                        'label': 'TestVLM browser',
+                    },
+                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=1-38724419-T-G',
+                    'email': None,
+                }
+            ],
+            'responseSummary': {
+                'exists': True,
+                'total': 7,
+            },
+            **response,
+        }
+        self.assertDictEqual(resp_json, full_response)
         mocked_responses.assert_called_with(
             'https://vlm-auth.us.auth0.com/oauth/token',
             method='POST',
@@ -819,22 +966,55 @@ class VlmTestCase(AioHTTPTestCase):
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh37&referenceName=1&start=39190091&referenceBases=T&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, response)
+        self.assertDictEqual(resp_json, full_response)
 
+        full_only_37_response = {
+            'beaconHandovers': [
+                {
+                    'handoverType': {
+                        'id': 'TestVLM',
+                        'label': 'TestVLM browser',
+                    },
+                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=37&variantId=7-143270172-A-G',
+                    'email': None,
+                }
+            ],
+            'responseSummary': {
+                'exists': True,
+                'total': 1,
+            },
+            **only_37_response,
+        }
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=hg19&referenceName=chr7&start=143270172&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, only_37_response)
+        self.assertDictEqual(resp_json, full_only_37_response)
 
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=GRCh38&referenceName=chr7&start=143573079&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, only_37_response)
+        self.assertDictEqual(resp_json, full_only_37_response)
 
         async with self.client.request('GET', f'/vlm/{path}?assemblyId=hg38&referenceName=chr7&start=143270172&referenceBases=A&alternateBases=G', headers=headers) as resp:
             self.assertEqual(resp.status, 200)
             resp_json = await resp.json()
-        self.assertDictEqual(resp_json, empty_response)
+        self.assertDictEqual(resp_json, {
+            'beaconHandovers': [
+                {
+                    'handoverType': {
+                        'id': 'TestVLM',
+                        'label': 'TestVLM browser',
+                    },
+                    'url': 'https://test-seqr.org/variant_lookup?genomeVersion=38&variantId=7-143270172-A-G',
+                    'email': None,
+                }
+            ],
+            'responseSummary': {
+                'exists': False,
+                'total': 0,
+            },
+            **empty_response,
+        })
 
     @aioresponses(passthrough=['http://127.0.0.1'])
     async def test_match_error(self, mocked_responses):


### PR DESCRIPTION
## Pull request overview

Updates the VLM `match_details` response to conform to the latest API agreement and provide a separate “family/phenopacket” result per sample (rather than a single result per family)

**Changes:**
- Modify `vlm/match.py` to emit one result per phenopacket, with the selected phenopacket as `proband` and all other phenopackets in the same family as `relatives`.
- Refactor `vlm/test_vlm.py` fixtures to pass `meta` + `resultSets` into a shared helper and validate the updated per-sample `match_details` payload shape. This reduced the amount of duplicated copy-paste fixture data in tests and reduces the risk of inconsistent counts across endpoints