### PR TITLE
cleaner import for clinvar constants

### DIFF
--- a/clickhouse_search/constants.py
+++ b/clickhouse_search/constants.py
@@ -79,6 +79,42 @@ CLINVAR_PATH_RANGES = [
     ('benign', 'Benign/Likely_benign', 'Benign'),
 ]
 
+CLINVAR_ASSERTIONS = [
+    'Affects',
+    'association',
+    'association_not_found',
+    'confers_sensitivity',
+    'drug_response',
+    'low_penetrance',
+    'not_provided',
+    'other',
+    'protective',
+    'risk_factor',
+    'no_classification_for_the_single_variant',
+    'no_classifications_from_unflagged_records',
+]
+CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY = 'Conflicting_classifications_of_pathogenicity'
+CLINVAR_DEFAULT_PATHOGENICITY = 'No_pathogenic_assertion'
+CLINVAR_PATHOGENICITIES = [
+    'Pathogenic',
+    'Pathogenic/Likely_pathogenic',
+    'Pathogenic/Likely_pathogenic/Established_risk_allele',
+    'Pathogenic/Likely_pathogenic/Likely_risk_allele',
+    'Pathogenic/Likely_risk_allele',
+    'Likely_pathogenic',
+    'Likely_pathogenic/Likely_risk_allele',
+    'Established_risk_allele',
+    'Likely_risk_allele',
+    CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY,
+    'Uncertain_risk_allele',
+    'Uncertain_significance/Uncertain_risk_allele',
+    'Uncertain_significance',
+    CLINVAR_DEFAULT_PATHOGENICITY,
+    'Likely_benign',
+    'Benign/Likely_benign',
+    'Benign',
+]
+
 HGMD_KEY = 'hgmd'
 HGMD_CLASS_FILTERS = [
     ('disease_causing', 'DM'),

--- a/clickhouse_search/management/commands/reload_clinvar_all_variants.py
+++ b/clickhouse_search/management/commands/reload_clinvar_all_variants.py
@@ -15,6 +15,9 @@ from typing import Optional, Union
 from clickhouse_backend import models
 from clickhouse_search.models.reference_data_models import ClinvarAllVariantsGRCh37SnvIndel, ClinvarAllVariantsSnvIndel, ClinvarAllVariantsMito, \
     ClinvarMvGRCh37SnvIndel, ClinvarMvSnvIndel, ClinvarMvMito, ClinvarSearchMvGRCh37SnvIndel, ClinvarSearchMvSnvIndel, ClinvarSearchMvMito
+from clickhouse_search.constants import \
+    CLINVAR_ASSERTIONS as CORE_CLINVAR_ASSERTIONS, CLINVAR_PATHOGENICITIES as CORE_CLINVAR_PATHOGENICITIES, CLINVAR_DEFAULT_PATHOGENICITY as CORE_CLINVAR_DEFAULT_PATHOGENICITY, \
+    CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY as CORE_CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY
 from reference_data.models import DataVersions
 from seqr.utils.communication_utils import safe_post_to_slack
 
@@ -29,11 +32,11 @@ def replace_spaces_with_underscores(value: Union[list[str], list[tuple[str, int]
     return [s.replace(' ', '_') for s in value]
 
 BATCH_SIZE = 1000
-CLINVAR_ASSERTIONS = replace_underscores_with_spaces(ClinvarAllVariantsSnvIndel.CLINVAR_ASSERTIONS)
-CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY = replace_underscores_with_spaces([ClinvarAllVariantsSnvIndel.CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY])[0]
+CLINVAR_ASSERTIONS = replace_underscores_with_spaces(CORE_CLINVAR_ASSERTIONS)
+CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY = replace_underscores_with_spaces([CORE_CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY])[0]
 CLINVAR_CONFLICTING_DATA_FROM_SUBMITTERS = 'conflicting data from submitters'
-CLINVAR_DEFAULT_PATHOGENICITY = replace_underscores_with_spaces([ClinvarAllVariantsSnvIndel.CLINVAR_DEFAULT_PATHOGENICITY])[0]
-CLINVAR_PATHOGENICITIES = replace_underscores_with_spaces(ClinvarAllVariantsSnvIndel.CLINVAR_PATHOGENICITIES)
+CLINVAR_DEFAULT_PATHOGENICITY = replace_underscores_with_spaces([CORE_CLINVAR_DEFAULT_PATHOGENICITY])[0]
+CLINVAR_PATHOGENICITIES = replace_underscores_with_spaces(CORE_CLINVAR_PATHOGENICITIES)
 CLINVAR_GOLD_STARS_LOOKUP = {
     'no classification for the single variant': 0,
     'no classification provided': 0,

--- a/clickhouse_search/management/tests/reload_clinvar_all_variants_tests.py
+++ b/clickhouse_search/management/tests/reload_clinvar_all_variants_tests.py
@@ -197,7 +197,7 @@ class ReloadClinvarAllVariantsTest(TestCase):
         call_command('reload_clinvar_all_variants')
         mock_logger.assert_called_with('Updating Clinvar ClickHouse tables to 2025-06-30 from 2025-06-23.')
         self.assertEqual(ClinvarAllVariantsSnvIndel.objects.all().count(), BATCH_SIZE * 2 + 10)
-        self.assertEqual(ClinvarAllVariantsSnvIndel.objects.first().pathogenicity, ClinvarAllVariantsSnvIndel.CLINVAR_DEFAULT_PATHOGENICITY)
+        self.assertEqual(ClinvarAllVariantsSnvIndel.objects.first().pathogenicity, 'No_pathogenic_assertion')
         self.assertIsNone(ClinvarAllVariantsSnvIndel.objects.first().gold_stars)
 
     @responses.activate
@@ -417,7 +417,7 @@ class ReloadClinvarAllVariantsTest(TestCase):
         )
         call_command('reload_clinvar_all_variants')
         self.assertEqual(ClinvarAllVariantsSnvIndel.objects.count(), 1)
-        self.assertEqual(ClinvarAllVariantsSnvIndel.objects.first().pathogenicity, ClinvarAllVariantsSnvIndel.CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY)
+        self.assertEqual(ClinvarAllVariantsSnvIndel.objects.first().pathogenicity, 'Conflicting_classifications_of_pathogenicity')
         mock_safe_post_to_slack.assert_called_with(
             SEQR_SLACK_DATA_ALERTS_NOTIFICATION_CHANNEL,
             'Successfully updated Clinvar ClickHouse tables to 2025-06-30.',

--- a/clickhouse_search/models/reference_data_models.py
+++ b/clickhouse_search/models/reference_data_models.py
@@ -6,6 +6,7 @@ from clickhouse_search.backend.engines import Join
 from clickhouse_search.backend.fields import Enum8Field, NestedField, UInt32FieldDeltaCodecField, DictKeyForeignKey
 from clickhouse_search.backend.table_models import FixtureLoadableClickhouseModel, Dictionary, \
     RefreshableMaterializedView, RefreshableMaterializedViewMeta
+from clickhouse_search.constants import CLINVAR_ASSERTIONS, CLINVAR_PATHOGENICITIES
 from seqr.utils.xpos_utils import CHROMOSOME_CHOICES
 from settings import DATABASES, PIPELINE_RUNNER_SERVER
 
@@ -39,43 +40,6 @@ class ReferenceDataDictMeta:
 
 
 class BaseClinvar(FixtureLoadableClickhouseModel):
-
-    CLINVAR_ASSERTIONS = [
-        'Affects',
-        'association',
-        'association_not_found',
-        'confers_sensitivity',
-        'drug_response',
-        'low_penetrance',
-        'not_provided',
-        'other',
-        'protective',
-        'risk_factor',
-        'no_classification_for_the_single_variant',
-        'no_classifications_from_unflagged_records',
-    ]
-    CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY = 'Conflicting_classifications_of_pathogenicity'
-    CLINVAR_DEFAULT_PATHOGENICITY = 'No_pathogenic_assertion'
-    CLINVAR_PATHOGENICITIES = [
-        'Pathogenic',
-        'Pathogenic/Likely_pathogenic',
-        'Pathogenic/Likely_pathogenic/Established_risk_allele',
-        'Pathogenic/Likely_pathogenic/Likely_risk_allele',
-        'Pathogenic/Likely_risk_allele',
-        'Likely_pathogenic',
-        'Likely_pathogenic/Likely_risk_allele',
-        'Established_risk_allele',
-        'Likely_risk_allele',
-        CLINVAR_CONFLICTING_CLASSICATIONS_OF_PATHOGENICITY,
-        'Uncertain_risk_allele',
-        'Uncertain_significance/Uncertain_risk_allele',
-        'Uncertain_significance',
-        CLINVAR_DEFAULT_PATHOGENICITY,
-        'Likely_benign',
-        'Benign/Likely_benign',
-        'Benign',
-    ]
-
     ASSERTIONS_CHOICES = list(enumerate(CLINVAR_ASSERTIONS))
     PATHOGENICITY_CHOICES = list(enumerate(CLINVAR_PATHOGENICITIES))
 


### PR DESCRIPTION
The reload clinvar command has been failing with an odd issue related to importing models before they are fully initialized. Since this is not happening in the main app or in any other cron job, I think this might be because the model is being used in top-level constant code before the app and job are properly initialized, so hopefully this refactor fixes that

## Pull request overview

This PR centralizes ClinVar assertion/pathogenicity enumerations into `clickhouse_search.constants` and updates ClickHouse reference models and the ClinVar reload management command to consume the shared constants instead of defining them on the model class.

**Changes:**
- Moved ClinVar assertion/pathogenicity constants from `BaseClinvar` into `clickhouse_search/constants.py`.
- Updated `clickhouse_search/models/reference_data_models.py` and `reload_clinvar_all_variants.py` to import ClinVar constants from `clickhouse_search.constants`.
- Updated ClinVar reload tests to reflect the refactor (with a couple of new hard-coded strings that should be replaced by constants).