### PR TITLE
reenable codacy for pipeline

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,4 +1,3 @@
 ---
 exclude_paths:
   - "deploy/postgres/initdb.sql"
-  - "loading_pipeline/**"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,4 @@
 ---
 exclude_paths:
   - "deploy/postgres/initdb.sql"
+  - "loading_pipeline/deploy/Dockerfile"

--- a/loading_pipeline/api/__main__.py
+++ b/loading_pipeline/api/__main__.py
@@ -9,7 +9,7 @@ def run():
     logger = get_logger(__name__)
     web.run_app(
         app,
-        host='0.0.0.0',  # noqa: S104
+        host='0.0.0.0',  # noqa: S104 # nosec B104
         port=6000,
         access_log=logger,
     )

--- a/loading_pipeline/bin/dataproc_vep_init.bash
+++ b/loading_pipeline/bin/dataproc_vep_init.bash
@@ -54,10 +54,10 @@ EOF
 gcc -Wall -Werror -O2 /vep.c -o /vep
 chmod u+s /vep
 
-gcloud storage cp gs://seqr-pipeline-runner-builds/$DEPLOYMENT_TYPE/$PIPELINE_RUNNER_APP_VERSION/bin/download_vep_reference_data.bash /download_vep_reference_data.bash
+gcloud storage cp "gs://seqr-pipeline-runner-builds/$DEPLOYMENT_TYPE/$PIPELINE_RUNNER_APP_VERSION/bin/download_vep_reference_data.bash" /download_vep_reference_data.bash
 chmod +x /download_vep_reference_data.bash
-./download_vep_reference_data.bash $REFERENCE_GENOME
+./download_vep_reference_data.bash "$REFERENCE_GENOME"
 
-gcloud storage cp gs://seqr-pipeline-runner-builds/$DEPLOYMENT_TYPE/$PIPELINE_RUNNER_APP_VERSION/bin/vep /vep.bash
+gcloud storage cp "gs://seqr-pipeline-runner-builds/$DEPLOYMENT_TYPE/$PIPELINE_RUNNER_APP_VERSION/bin/vep" /vep.bash
 chmod +x /vep.bash
 

--- a/loading_pipeline/bin/download_vep_reference_data.bash
+++ b/loading_pipeline/bin/download_vep_reference_data.bash
@@ -2,7 +2,7 @@
 
 set -eux
 
-REFERENCE_GENOME=$1
+REFERENCE_GENOME="$1"
 VEP_REFERENCE_DATASETS_DIR=${VEP_REFERENCE_DATASETS_DIR:-/var/seqr/vep-reference-data}
 DEFAULT_REFERENCE_DATASETS_DIR="gs://seqr-reference-data"
 if [[ -n "${REFERENCE_DATASETS_DIR:-}" && "$REFERENCE_DATASETS_DIR" == gs://* ]]; then
@@ -12,7 +12,7 @@ else
   echo "Using default GCS path: $REFERENCE_DATASETS_DIR"
 fi
 
-case $REFERENCE_GENOME in
+case "$REFERENCE_GENOME" in
   GRCh38)
     VEP_REFERENCE_DATA_FILES=(
         "$REFERENCE_DATASETS_DIR/vep_data/loftee-beta/GRCh38.tar.gz"

--- a/loading_pipeline/bin/pipeline_worker_test.py
+++ b/loading_pipeline/bin/pipeline_worker_test.py
@@ -128,7 +128,7 @@ class PipelineWorkerTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT sum(ac_wgs)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats_dict`
-            """,
+            """,  # nosec B608
         )
         ac_wgs = cursor.fetchone()[0]
         self.assertEqual(ac_wgs, 69)

--- a/loading_pipeline/bin/pipeline_worker_test.py
+++ b/loading_pipeline/bin/pipeline_worker_test.py
@@ -110,7 +110,7 @@ class PipelineWorkerTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants_memory`
-            """,
+            """, # nosec B608
         )
         annotations_count = cursor.fetchone()[0]
         self.assertEqual(annotations_count, 30)

--- a/loading_pipeline/bin/pipeline_worker_test.py
+++ b/loading_pipeline/bin/pipeline_worker_test.py
@@ -110,7 +110,7 @@ class PipelineWorkerTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants_memory`
-            """, # nosec B608
+            """,  # nosec B608
         )
         annotations_count = cursor.fetchone()[0]
         self.assertEqual(annotations_count, 30)
@@ -119,7 +119,7 @@ class PipelineWorkerTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/entries`
-            """,
+            """,  # nosec B608
         )
         entries_count = cursor.fetchone()[0]
         self.assertEqual(entries_count, 16)

--- a/loading_pipeline/bin/rsync_reference_data.bash
+++ b/loading_pipeline/bin/rsync_reference_data.bash
@@ -2,11 +2,11 @@
 
 set -eux
 
-REFERENCE_GENOME=$1
+REFERENCE_GENOME="$1"
 REFERENCE_DATASETS_DIR=${REFERENCE_DATASETS_DIR:-/var/seqr/seqr-reference-data}
 
 
-case $REFERENCE_GENOME in
+case "$REFERENCE_GENOME" in
   GRCh38)
     ;;
   GRCh37)
@@ -16,7 +16,7 @@ case $REFERENCE_GENOME in
     exit 1
 esac
 
-case $REFERENCE_DATASETS_DIR in
+case "$REFERENCE_DATASETS_DIR" in
   "gs://seqr-reference-data")
     echo "Cannot rsync to the authoritative source"
     exit 1
@@ -26,26 +26,26 @@ case $REFERENCE_DATASETS_DIR in
 esac
 
 if ! [[ "$REFERENCE_DATASETS_DIR" =~ gs://* ]]; then
-  mkdir -p $REFERENCE_DATASETS_DIR/$REFERENCE_GENOME;
+  mkdir -p "$REFERENCE_DATASETS_DIR"/"$REFERENCE_GENOME";
   if [ -f "$REFERENCE_DATASETS_DIR"/"$REFERENCE_GENOME"/_SUCCESS ]; then
      echo "Skipping rsync because already successful"
      exit 0;
   fi
 else
   result=$(gsutil -q stat "$REFERENCE_DATASETS_DIR"/"$REFERENCE_GENOME"/_SUCCESS || echo 1)
-  if [[ $result != 1 ]]; then
+  if [[ "$result" != 1 ]]; then
     echo "Skipping rsync because already successful"
     exit 0;
   fi
 fi
 
-gsutil -m rsync -rd -x '.*\.parquet.*' "gs://seqr-reference-data/v3.2/$REFERENCE_GENOME" $REFERENCE_DATASETS_DIR/$REFERENCE_GENOME
-if ! [[ $REFERENCE_DATASETS_DIR =~ gs://* ]]; then
+gsutil -m rsync -rd -x '.*\.parquet.*' "gs://seqr-reference-data/v3.2/$REFERENCE_GENOME" "$REFERENCE_DATASETS_DIR"/"$REFERENCE_GENOME"
+if ! [[ "$REFERENCE_DATASETS_DIR" =~ gs://* ]]; then
   touch "$REFERENCE_DATASETS_DIR"/"$REFERENCE_GENOME"/_SUCCESS
 else
   # If a different reference datasets dir is provided, sync vep data to the provided bucket.
-  gsutil cp "gs://seqr-reference-data/vep_data/loftee-beta/$REFERENCE_GENOME.tar.gz" $REFERENCE_DATASETS_DIR/vep_data/loftee-beta/$REFERENCE_GENOME.tar.gz
-  gsutil -m rsync -rd "gs://seqr-reference-data/vep/$REFERENCE_GENOME" $REFERENCE_DATASETS_DIR/vep/$REFERENCE_GENOME
+  gsutil cp "gs://seqr-reference-data/vep_data/loftee-beta/$REFERENCE_GENOME.tar.gz" "$REFERENCE_DATASETS_DIR"/vep_data/loftee-beta/"$REFERENCE_GENOME".tar.gz
+  gsutil -m rsync -rd "gs://seqr-reference-data/vep/$REFERENCE_GENOME" "$REFERENCE_DATASETS_DIR"/vep/"$REFERENCE_GENOME"
   touch _SUCCESS
   gsutil cp _SUCCESS "$REFERENCE_DATASETS_DIR"/"$REFERENCE_GENOME"/_SUCCESS
   rm -rf _SUCCESS

--- a/loading_pipeline/bin/run_task.py
+++ b/loading_pipeline/bin/run_task.py
@@ -3,8 +3,8 @@ import sys
 
 import luigi
 
-from loading_pipeline.lib.tasks import *  # noqa: F403
+from loading_pipeline.lib.tasks import *  # noqa: F403 # nosec F403
 
 if __name__ == '__main__':
     # If run does not succeed, exit with 1 status code.
-    luigi.run() or sys.exit(1)
+    luigi.run() or sys.exit(1)  # pylint: disable=W0106

--- a/loading_pipeline/lib/annotations/expression_helpers.py
+++ b/loading_pipeline/lib/annotations/expression_helpers.py
@@ -79,7 +79,7 @@ def _get_expr_for_formatted_hgvs(csq):
                 + protein_letters,
                 hl.delimit(
                     csq.amino_acids.split('').map(
-                        lambda pl: PROTEIN_LETTERS_1TO3.get(pl),
+                        PROTEIN_LETTERS_1TO3.get,
                     ),
                     '',
                 ),
@@ -193,7 +193,7 @@ def get_expr_for_vep_sorted_transcript_consequences_array(
                     c.consequence_terms.size() > 0,
                     hl.sorted(
                         c.consequence_terms,
-                        key=lambda t: TRANSCRIPT_CONSEQUENCE_TERM_RANK_LOOKUP.get(t),
+                        key=TRANSCRIPT_CONSEQUENCE_TERM_RANK_LOOKUP.get,
                     )[0],
                     hl.null(hl.tstr),
                 ),

--- a/loading_pipeline/lib/annotations/expression_helpers.py
+++ b/loading_pipeline/lib/annotations/expression_helpers.py
@@ -8,10 +8,6 @@ TRANSCRIPT_CONSEQUENCE_TERM_RANK_LOOKUP = hl.dict(
 HGVSC_CONSEQUENCES = hl.set(
     ['splice_donor_variant', 'splice_acceptor_variant', 'splice_region_variant'],
 )
-OMIT_TRANSCRIPT_CONSEQUENCE_TERMS = [
-    'upstream_gene_variant',
-    'downstream_gene_variant',
-]
 PROTEIN_LETTERS_1TO3 = hl.dict(
     {
         'A': 'Ala',
@@ -124,7 +120,6 @@ def get_expr_for_xpos(locus: hl.expr.LocusExpression) -> hl.expr.Int64Expression
 def get_expr_for_vep_sorted_transcript_consequences_array(
     vep_root,
     include_coding_annotations=True,
-    omit_consequences=OMIT_TRANSCRIPT_CONSEQUENCE_TERMS,
 ):
     """Sort transcripts by 3 properties:
 
@@ -177,17 +172,11 @@ def get_expr_for_vep_sorted_transcript_consequences_array(
             ],
         )
 
-    omit_consequence_terms = (
-        hl.set(omit_consequences) if omit_consequences else hl.empty_set(hl.tstr)
-    )
-
     result = hl.sorted(
         vep_root.transcript_consequences.map(
             lambda c: c.select(
                 *selected_annotations,
-                consequence_terms=c.consequence_terms.filter(
-                    lambda t: ~omit_consequence_terms.contains(t),
-                ),
+                consequence_terms=c.consequence_terms,
                 domains=c.domains.map(lambda domain: domain.db + ':' + domain.name),
                 major_consequence=hl.cond(
                     c.consequence_terms.size() > 0,

--- a/loading_pipeline/lib/annotations/mito.py
+++ b/loading_pipeline/lib/annotations/mito.py
@@ -58,4 +58,4 @@ def mitotip(ht: hl.Table, **_: Any) -> hl.Expression:
 
 
 def rsid(ht: hl.Table, **_: Any) -> hl.Expression:
-    return ht.rsid.find(lambda x: hl.is_defined(x))
+    return ht.rsid.find(hl.is_defined)

--- a/loading_pipeline/lib/core/environment.py
+++ b/loading_pipeline/lib/core/environment.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 # NB: using os.environ.get inside the dataclass defaults gives a lint error.
 LOCAL_DISK_MOUNT_DIR = os.environ.get('LOCAL_DISK_MOUNT_DIR', '/var/seqr')
-HAIL_TMP_DIR = os.environ.get('HAIL_TMP_DIR', '/tmp')  # noqa: S108
+HAIL_TMP_DIR = os.environ.get('HAIL_TMP_DIR', '/tmp')  # noqa: S108 # nosec B108
 PIPELINE_DATA_DIR = os.environ.get(
     'PIPELINE_DATA_DIR',
     '/var/seqr/pipeline-data',

--- a/loading_pipeline/lib/misc/clickhouse.py
+++ b/loading_pipeline/lib/misc/clickhouse.py
@@ -411,7 +411,7 @@ class ClickhouseReferenceDataset(StrEnum):
                 SELECT {ClickHouseTable.KEY_LOOKUP.key_field}
                 FROM {table_name_builder.src_table(ClickHouseTable.KEY_LOOKUP)}
             )
-            """,
+            """, # nosec B608
         )
         logged_query(
             f"""

--- a/loading_pipeline/lib/misc/clickhouse.py
+++ b/loading_pipeline/lib/misc/clickhouse.py
@@ -411,7 +411,7 @@ class ClickhouseReferenceDataset(StrEnum):
                 SELECT {ClickHouseTable.KEY_LOOKUP.key_field}
                 FROM {table_name_builder.src_table(ClickHouseTable.KEY_LOOKUP)}
             )
-            """, # nosec B608
+            """,  # nosec B608
         )
         logged_query(
             f"""
@@ -424,7 +424,7 @@ class ClickhouseReferenceDataset(StrEnum):
             INNER JOIN {table_name_builder.dst_table(ClickHouseTable.KEY_LOOKUP)} dst
             ON {ClickHouseTable.KEY_LOOKUP.join_condition}
             WHERE src.variantId IN {table_name_builder.staging_dst_prefix}/_tmp_loadable_variantIds`
-            """,
+            """,  # nosec B608
         )
         self.refresh_search(table_name_builder)
 

--- a/loading_pipeline/lib/misc/clickhouse.py
+++ b/loading_pipeline/lib/misc/clickhouse.py
@@ -704,7 +704,7 @@ def optimize_entries(
                 FROM {table_name_builder.staging_dst_table(ClickHouseTable.ENTRIES)}
                 WHERE sign = -1
             );
-            """,
+            """,  # nosec B608
         )[0][0]
 
         merges_running = logged_query(
@@ -838,7 +838,7 @@ def reload_dictionaries(
         logged_query(
             f"""
             SYSTEM RELOAD DICTIONARY {table_name_builder.dst_table(dictionary)}
-            """,
+            """,  # nosec B608
         )
 
 
@@ -858,7 +858,7 @@ def replace_project_partitions(
                 f"""
                 ALTER TABLE {table_name_builder.dst_table(clickhouse_table)}
                 REPLACE PARTITION %(partition)s FROM {table_name_builder.staging_dst_table(clickhouse_table)}
-                """,
+                """,  # nosec B608
                 {'partition': partition},
             )
 
@@ -873,7 +873,7 @@ def exchange_tables(
         logged_query(
             f"""
             EXCHANGE TABLES {table_name_builder.staging_dst_table(clickhouse_table)} AND {table_name_builder.dst_table(clickhouse_table)}
-            """,
+            """,  # nosec B608
         )
 
 
@@ -887,7 +887,7 @@ def direct_insert_annotations(
     logged_query(
         f"""
         CREATE DATABASE {STAGING_CLICKHOUSE_DATABASE}
-        """,
+        """,  # nosec B608
     )
     # NB: Unfortunately there's a bug(?) or inaccuracy if this is attempted without an intermediate
     # temporary table, likely due to writing to a table and joining against it at the same time.
@@ -899,7 +899,7 @@ def direct_insert_annotations(
             LEFT ANTI JOIN {dst_table} dst
             ON {ClickHouseTable.VARIANTS_MEMORY.join_condition}
         )
-        """,
+        """,  # nosec B608
     )
     for (
         clickhouse_table
@@ -913,14 +913,14 @@ def direct_insert_annotations(
             INSERT INTO {disk_backed_dst_table}
             SELECT {clickhouse_table.select_fields}
             FROM {disk_backed_src_table} WHERE {clickhouse_table.key_field} IN {table_name_builder.staging_dst_prefix}/_tmp_loadable_keys`
-            """,
+            """,  # nosec B608
         )
     logged_query(
         f"""
         INSERT INTO {dst_table}
         SELECT {ClickHouseTable.VARIANTS_MEMORY.select_fields}
         FROM {src_table} WHERE {ClickHouseTable.VARIANTS_MEMORY.key_field} IN {table_name_builder.staging_dst_prefix}/_tmp_loadable_keys`
-        """,
+        """,  # nosec B608
     )
     drop_staging_db()
 
@@ -942,7 +942,7 @@ def direct_insert_all_keys(
         SELECT {clickhouse_table.select_fields}
         FROM {src_table}
         {settings}
-        """,
+        """,  # nosec B608
     )
 
 
@@ -1078,7 +1078,7 @@ def delete_family_guids(
             WHERE project_guid = %(project_guid)s
             AND has(%(family_guids)s, family_guid)
         );
-        """,
+        """,  # nosec B608
         {'family_guids': family_guids, 'project_guid': project_guid},
     )[0][0]
     if not entries_exist:
@@ -1136,7 +1136,7 @@ def rebuild_gt_stats(
     max_key = logged_query(
         f"""
         SELECT max(key) FROM {table_name_builder.dst_table(ClickHouseTable.GT_STATS)}
-        """,
+        """,  # nosec B608
     )[0][0]
     if not max_key:
         msg = f'Skipping gt stats rebuild for empty dataset {reference_genome.value}/{dataset_type.value} {project_guids[:10]}...'
@@ -1172,7 +1172,7 @@ def rebuild_gt_stats(
             f"""
             ALTER TABLE {table_name_builder.staging_dst_table(ClickHouseTable.PROJECT_GT_STATS)}
             DROP PARTITION %(partition)s
-            """,
+            """,  # nosec B608
             {'partition': partition},
         )
     select_statement = get_create_mv_statements(

--- a/loading_pipeline/lib/misc/clickhouse.py
+++ b/loading_pipeline/lib/misc/clickhouse.py
@@ -686,7 +686,7 @@ def insert_new_entries(
         INSERT INTO {table_name_builder.staging_dst_table(ClickHouseTable.ENTRIES)} ({dst_list})
         SELECT {src_list}
         FROM {table_name_builder.src_table(ClickHouseTable.ENTRIES)}
-        """,
+        """,  # nosec B608
     )
 
 

--- a/loading_pipeline/lib/misc/clickhouse.py
+++ b/loading_pipeline/lib/misc/clickhouse.py
@@ -632,7 +632,7 @@ def delete_existing_families_from_staging_entries(
         SELECT COLUMNS('.*') EXCEPT(sign, n_partitions, partition_id), -1 as sign
         FROM {table_name_builder.staging_dst_table(ClickHouseTable.ENTRIES)}
         WHERE family_guid in %(family_guids)s
-        """,
+        """,  # nosec B608
         {'family_guids': family_guids},
     )
 

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -545,7 +545,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {STAGING_CLICKHOUSE_DATABASE}.`{table_name_builder.run_id_hash}/GRCh38/SNV_INDEL/project_gt_stats`
             FINAL
             GROUP BY project_guid, key, sample_type
-            """,
+            """,  # nosec B608
         )
         staged_project_gt_stats = cursor.fetchall()
         self.assertCountEqual(

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -425,7 +425,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             ),
         )
         cursor.execute(
-            f'SELECT key, variantId FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`', # nosec B608
+            f'SELECT key, variantId FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`',  # nosec B608
         )
         ret = cursor.fetchall()
         self.assertEqual(
@@ -450,7 +450,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             ),
         )
         cursor.execute(
-            f'SELECT COUNT(*) FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`', # nosec B608
+            f'SELECT COUNT(*) FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`',  # nosec B608
         )
         ret = cursor.fetchone()
         self.assertEqual(ret[0], 6)
@@ -495,7 +495,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
         cursor.execute(
             f"""
             SELECT DISTINCT project_guid FROM {STAGING_CLICKHOUSE_DATABASE}.`{table_name_builder.run_id_hash}/GRCh38/SNV_INDEL/entries`
-            """, # nosec B608
+            """,  # nosec B608
         )
         staged_projects = cursor.fetchall()
         self.assertCountEqual(
@@ -509,7 +509,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {STAGING_CLICKHOUSE_DATABASE}.`{table_name_builder.run_id_hash}/GRCh38/SNV_INDEL/project_gt_stats`
             FINAL
             GROUP BY project_guid, key, sample_type
-            """,
+            """,  # nosec B608
         )
         staged_project_gt_stats = cursor.fetchall()
         self.assertCountEqual(

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -617,7 +617,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT COLUMNS('.*') EXCEPT(is_annotated_in_any_gene, is_gnomad_gt_5_percent)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/entries`
-            """,
+            """,  # nosec B608
         )
         new_entries = cursor.fetchall()
         self.assertCountEqual(
@@ -998,7 +998,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
                        SELECT key, variantId
                        FROM
                        {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`
-                       """,
+                       """,  # nosec B608
         )
         variants_details = cursor.fetchall()
         self.assertCountEqual(
@@ -1027,7 +1027,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT COUNT(*)
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/GCNV/variants_memory`
-           """,
+           """,  # nosec B608
         )
         variants_disk_count = cursor.fetchone()[0]
         self.assertEqual(variants_disk_count, 4)
@@ -1036,7 +1036,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT COUNT(*)
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/GCNV/variants_disk`
-           """,
+           """,  # nosec B608
         )
         variants_disk_count = cursor.fetchone()[0]
         self.assertEqual(variants_disk_count, 4)
@@ -1045,7 +1045,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT COUNT(*)
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/GCNV/key_lookup`
-           """,
+           """,  # nosec B608
         )
         key_lookup_count = cursor.fetchone()[0]
         self.assertEqual(key_lookup_count, 4)
@@ -1054,7 +1054,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT COUNT(*)
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/GCNV/entries`
-           """,
+           """,  # nosec B608
         )
         entries_count = cursor.fetchone()[0]
         self.assertEqual(entries_count, 3)
@@ -1073,7 +1073,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/project_gt_stats`
             FINAL
             GROUP BY project_guid
-            """,
+            """,  # nosec B608
         )
         project_gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -1092,7 +1092,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT sum(ac_wes)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats`
-            """,
+            """,  # nosec B608
         )
         gt_stats = cursor.fetchall()
         self.assertCountEqual(gt_stats, [(12,)])
@@ -1110,7 +1110,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/project_gt_stats`
             FINAL
             GROUP BY project_guid
-            """,
+            """,  # nosec B608
         )
         project_gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -1122,7 +1122,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT sum(ac_wes)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats`
-            """,
+            """,  # nosec B608
         )
         gt_stats = cursor.fetchall()
         self.assertCountEqual(gt_stats, [(10,)])
@@ -1131,7 +1131,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT sum(ac_wes)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats_dict`
-            """,
+            """,  # nosec B608
         )
         gt_stats_dict = cursor.fetchall()
         self.assertCountEqual(gt_stats_dict, [(10,)])
@@ -1147,7 +1147,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             f"""
             ALTER TABLE {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/entries`
             DROP PARTITION (%(project_guid)s, %(partition_id)s)
-            """,
+            """,  # nosec B608
             {'project_guid': 'project_a', 'partition_id': 0},
         )
         cursor.execute(
@@ -1157,7 +1157,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/project_gt_stats`
             WHERE project_guid IN ('project_a', 'project_b')
             GROUP BY project_guid
-            """,
+            """,  # nosec B608
         )
         project_gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -1176,7 +1176,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT sum(ac_wes), sum(ac_wgs)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats`
-            """,
+            """,  # nosec B608
         )
         gt_stats = cursor.fetchall()
         self.assertCountEqual(gt_stats, [(12, 5)])
@@ -1193,7 +1193,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/project_gt_stats`
             WHERE project_guid IN ('project_a', 'project_b')
             GROUP BY project_guid
-            """,
+            """,  # nosec B608
         )
         project_gt_stats = cursor.fetchall()
         self.assertCountEqual(

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -828,7 +828,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT *
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats_dict`
-            """,
+            """,  # nosec B608
         )
         existing_gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -852,7 +852,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT *
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats_dict`
-            """,
+            """,  # nosec B608
         )
         new_gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -874,7 +874,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT *
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats_dict`
-            """,
+            """,  # nosec B608
         )
         new_gt_stats_post_reload = cursor.fetchall()
         self.assertEqual(
@@ -910,7 +910,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/project_gt_stats`
            WHERE project_guid = 'project_d'
            GROUP BY project_guid, key, sample_type
-           """,
+           """,  # nosec B608
         )
         project_gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -926,7 +926,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT *
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats`
-           """,
+           """,  # nosec B608
         )
         gt_stats = cursor.fetchall()
         self.assertCountEqual(
@@ -945,7 +945,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT *
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats_dict`
-           """,
+           """,  # nosec B608
         )
         gt_stats_dict = cursor.fetchall()
         self.assertCountEqual(
@@ -964,7 +964,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT *
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants_memory`
-           """,
+           """,  # nosec B608
         )
         variants_memory = cursor.fetchall()
         self.assertCountEqual(
@@ -981,7 +981,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
            SELECT *
            FROM
            {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants_disk`
-           """,
+           """,  # nosec B608
         )
         variants_disk = cursor.fetchall()
         self.assertCountEqual(

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -576,7 +576,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             {STAGING_CLICKHOUSE_DATABASE}.`{table_name_builder.run_id_hash}/GRCh38/SNV_INDEL/project_gt_stats`
             FINAL
             GROUP BY project_guid, key, sample_type
-            """,
+            """,  # nosec B608
         )
         staged_project_gt_stats = cursor.fetchall()
         self.assertCountEqual(

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -425,7 +425,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             ),
         )
         cursor.execute(
-            f'SELECT key, variantId FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`',
+            f'SELECT key, variantId FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`', # nosec B608
         )
         ret = cursor.fetchall()
         self.assertEqual(
@@ -450,7 +450,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             ),
         )
         cursor.execute(
-            f'SELECT COUNT(*) FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`',
+            f'SELECT COUNT(*) FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`', # nosec B608
         )
         ret = cursor.fetchone()
         self.assertEqual(ret[0], 6)
@@ -495,7 +495,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
         cursor.execute(
             f"""
             SELECT DISTINCT project_guid FROM {STAGING_CLICKHOUSE_DATABASE}.`{table_name_builder.run_id_hash}/GRCh38/SNV_INDEL/entries`
-            """,
+            """, # nosec B608
         )
         staged_projects = cursor.fetchall()
         self.assertCountEqual(

--- a/loading_pipeline/lib/misc/clickhouse_test.py
+++ b/loading_pipeline/lib/misc/clickhouse_test.py
@@ -1205,7 +1205,7 @@ class ClickhouseTest(MockedDatarootTestCase, ClickhouseSchemaTestCase):
             SELECT sum(ac_wes), sum(ac_wgs)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/gt_stats`
-            """,
+            """,  # nosec B608
         )
         gt_stats = cursor.fetchall()
         self.assertCountEqual(gt_stats, [(9, 0)])

--- a/loading_pipeline/lib/misc/terra_data_repository.py
+++ b/loading_pipeline/lib/misc/terra_data_repository.py
@@ -69,12 +69,12 @@ def bq_metrics_query(bq_table_name: str) -> google.cloud.bigquery.table.RowItera
         client.query_and_wait(
             f"""
         SELECT ddl FROM `{bq_table_name}`.INFORMATION_SCHEMA.TABLES where table_name='sample';
-        """,  # noqa: S608
+        """,  # noqa: S608 # nosec B608
         ),
     )[0]
     metrics = [(m if m in table_ddl else f'NULL AS {m}') for m in BIGQUERY_METRICS]
     return client.query_and_wait(
         f"""
         SELECT {','.join(metrics)} FROM `{bq_table_name}.sample`;
-        """,  # noqa: S608
+        """,  # noqa: S608 # nosec B608
     )

--- a/loading_pipeline/lib/misc/terra_data_repository.py
+++ b/loading_pipeline/lib/misc/terra_data_repository.py
@@ -3,7 +3,6 @@ import re
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-import google.cloud.bigquery
 from google.cloud import bigquery
 
 from loading_pipeline.lib.misc.gcp import get_service_account_credentials
@@ -58,7 +57,7 @@ def gen_bq_table_names() -> Generator[str]:
             yield f'{result["accessInformation"]["bigQuery"]["projectId"]}.{result["accessInformation"]["bigQuery"]["datasetName"]}'
 
 
-def bq_metrics_query(bq_table_name: str) -> google.cloud.bigquery.table.RowIterator:
+def bq_metrics_query(bq_table_name: str) -> bigquery.table.RowIterator:
     if not re.match(TABLE_NAME_VALIDATION_REGEX, bq_table_name):
         msg = f'{bq_table_name} does not match expected pattern'
         raise ValueError(msg)

--- a/loading_pipeline/lib/misc/terra_data_repository_test.py
+++ b/loading_pipeline/lib/misc/terra_data_repository_test.py
@@ -131,7 +131,7 @@ TDR_DATASETS = [
 @patch(
     'loading_pipeline.lib.misc.terra_data_repository.get_service_account_credentials',
     return_value=SimpleNamespace(
-        token='abcdefg',  # noqa: S106
+        token='abcdefg',  # noqa: S106 # nosec B106
     ),
 )
 class TerraDataRepositoryTest(unittest.TestCase):

--- a/loading_pipeline/lib/reference_datasets/gnomad_coding_and_noncoding.py
+++ b/loading_pipeline/lib/reference_datasets/gnomad_coding_and_noncoding.py
@@ -35,7 +35,6 @@ def get_ht(
         sorted_transaction_consequences=(
             get_expr_for_vep_sorted_transcript_consequences_array(
                 ht.vep,
-                omit_consequences=[],
             )
         ),
     )

--- a/loading_pipeline/lib/reference_datasets/misc.py
+++ b/loading_pipeline/lib/reference_datasets/misc.py
@@ -29,7 +29,7 @@ def compress_floats(ht: hl.Table):
 def generate_random_string(length=5):
     """Generates a random string of the specified length."""
     letters = string.ascii_letters + string.digits
-    return ''.join(random.choice(letters) for i in range(length))  # noqa: S311
+    return ''.join(random.choice(letters) for i in range(length))  # noqa: S311 # nosec B311
 
 
 def filter_contigs(ht, reference_genome: ReferenceGenome):
@@ -98,7 +98,7 @@ def copyfileobj(fsrc, fdst, decode_content, length=16 * 1024):
 
 @contextlib.contextmanager
 def download_zip_file(url, dataset_name: str, suffix='.zip', decode_content=False):
-    dir_ = f'/tmp/{generate_random_string()}/{dataset_name}'  # noqa: S108
+    dir_ = f'/tmp/{generate_random_string()}/{dataset_name}'  # noqa: S108 # nosec B108
     os.makedirs(dir_, exist_ok=True)
     with (
         tempfile.NamedTemporaryFile(

--- a/loading_pipeline/lib/tasks/exports/misc.py
+++ b/loading_pipeline/lib/tasks/exports/misc.py
@@ -135,7 +135,7 @@ def camelcase_array_structexpression_fields(
         ht = ht.transmute(
             **{
                 snake_to_camelcase(field): ht[field].map(
-                    lambda c: camelcase_hl_struct(c),
+                    camelcase_hl_struct,
                 ),
             },
         )

--- a/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables.py
+++ b/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables.py
@@ -102,14 +102,14 @@ class LoadClickhouseVariantsTablesTask(luigi.WrapperTask):
         max_key = logged_query(
             f"""
             SELECT max(key) FROM {table_name_builder.src_table(ClickHouseTable.VARIANTS_MEMORY)}
-            """, # nosec B608
+            """,  # nosec B608
         )[0][0]
         return logged_query(
             f"""
             SELECT EXISTS (
                 SELECT 1 FROM {table_name_builder.dst_table(ClickHouseTable.VARIANTS_MEMORY)} where key = %(max_key)s
             )
-            """,
+            """,  # nosec B608
             {'max_key': max_key},
         )[0][0]
 

--- a/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables.py
+++ b/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables.py
@@ -102,7 +102,7 @@ class LoadClickhouseVariantsTablesTask(luigi.WrapperTask):
         max_key = logged_query(
             f"""
             SELECT max(key) FROM {table_name_builder.src_table(ClickHouseTable.VARIANTS_MEMORY)}
-            """,
+            """, # nosec B608
         )[0][0]
         return logged_query(
             f"""

--- a/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables_test.py
+++ b/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables_test.py
@@ -124,7 +124,7 @@ class LoadClickhouseVariantsTablesTaskTest(
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants_memory`
-            """,
+            """, # nosec B608
         )
         variants_count = cursor.fetchone()[0]
         self.assertEqual(variants_count, 2)

--- a/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables_test.py
+++ b/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables_test.py
@@ -124,7 +124,7 @@ class LoadClickhouseVariantsTablesTaskTest(
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants_memory`
-            """, # nosec B608
+            """,  # nosec B608
         )
         variants_count = cursor.fetchone()[0]
         self.assertEqual(variants_count, 2)
@@ -133,7 +133,7 @@ class LoadClickhouseVariantsTablesTaskTest(
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/variants/details`
-            """,
+            """,  # nosec B608
         )
         variant_details_count = cursor.fetchone()[0]
         self.assertEqual(variant_details_count, 2)

--- a/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables_test.py
+++ b/loading_pipeline/lib/tasks/variants_migration/load_clickhouse_variants_tables_test.py
@@ -142,7 +142,7 @@ class LoadClickhouseVariantsTablesTaskTest(
             SELECT COUNT(*)
             FROM
             {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/key_lookup`
-            """,
+            """,  # nosec B608
         )
         key_lookups_count = cursor.fetchone()[0]
         self.assertEqual(key_lookups_count, 2)

--- a/loading_pipeline/lib/test/clickhouse_django/settings.py
+++ b/loading_pipeline/lib/test/clickhouse_django/settings.py
@@ -29,16 +29,16 @@ DATABASE_ROUTERS = [
 ]
 
 USE_TZ = True
-SECRET_KEY = 'loading-pipeline-test'  # noqa: S105
+SECRET_KEY = 'loading-pipeline-test'  # noqa: S105 # nosec B105
 DEPLOYMENT_TYPE = os.environ.get('DEPLOYMENT_TYPE', 'dev')
 PIPELINE_RUNNER_SERVER = os.environ.get('PIPELINE_RUNNER_SERVER', 'http://localhost')
 CLICKHOUSE_IN_MEMORY_DIR = os.environ.get(
     'CLICKHOUSE_IN_MEMORY_DIR',
-    '/tmp/loading_pipeline_test_clickhouse_in_memory',  # noqa: S108
+    '/tmp/loading_pipeline_test_clickhouse_in_memory',  # noqa: S108 # nosec B108
 )
 CLICKHOUSE_DATA_DIR = os.environ.get(
     'CLICKHOUSE_DATA_DIR',
-    '/tmp/loading_pipeline_test_clickhouse_data',  # noqa: S108
+    '/tmp/loading_pipeline_test_clickhouse_data',  # noqa: S108 # nosec B108
 )
 
 CLICKHOUSE_WRITER_USER = os.environ.get('CLICKHOUSE_WRITER_USER', 'default')

--- a/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel.py
+++ b/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel.py
@@ -62,7 +62,7 @@ def main(max_insert_threads: int, project_guids: list[str]):
         ENGINE = CollapsingMergeTree(sign)
         PARTITION BY (project_guid, partition_id)
         SETTINGS deduplicate_merge_projection_mode = 'rebuild'
-        """,
+        """, # nosec B608
     )
     if not project_guids:
         project_guids = [
@@ -70,7 +70,7 @@ def main(max_insert_threads: int, project_guids: list[str]):
             for x in logged_query(
                 f"""
             SELECT DISTINCT project_guid from {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/entries`
-            """,
+            """, # nosec B608
             )
         ]
     for project_guid in project_guids:

--- a/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel.py
+++ b/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel.py
@@ -62,7 +62,7 @@ def main(max_insert_threads: int, project_guids: list[str]):
         ENGINE = CollapsingMergeTree(sign)
         PARTITION BY (project_guid, partition_id)
         SETTINGS deduplicate_merge_projection_mode = 'rebuild'
-        """, # nosec B608
+        """,  # nosec B608
     )
     if not project_guids:
         project_guids = [
@@ -70,7 +70,7 @@ def main(max_insert_threads: int, project_guids: list[str]):
             for x in logged_query(
                 f"""
             SELECT DISTINCT project_guid from {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/entries`
-            """, # nosec B608
+            """,  # nosec B608
             )
         ]
     for project_guid in project_guids:
@@ -90,7 +90,7 @@ def main(max_insert_threads: int, project_guids: list[str]):
             SELECT * FROM {Env.CLICKHOUSE_DATABASE}.`GRCh38/SNV_INDEL/entries`
             WHERE project_guid=%(project_guid)s
             SETTINGS max_insert_threads=%(max_insert_threads)s
-            """,
+            """,  # nosec B608
             {'project_guid': project_guid, 'max_insert_threads': max_insert_threads},
             timeout=99999,
         )

--- a/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel_test.py
+++ b/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel_test.py
@@ -72,7 +72,7 @@ class RepartitionGRCh38SnvIndelTest(ClickhouseSchemaTestCase):
                 (2, 'project_b', 'family_b2', 0, 1),
                 (0, 'project_c', 'family_c1', 1, 1),
                 (3, 'project_c', 'family_c2', 1, 1),
-                """, # nosec B608
+                """,  # nosec B608
             )
 
     def tearDown(self):
@@ -87,7 +87,7 @@ class RepartitionGRCh38SnvIndelTest(ClickhouseSchemaTestCase):
                 f"""
                 SELECT *, n_partitions, partition_id
                 FROM {REPARTITION_DATABASE_NAME}.`GRCh38/SNV_INDEL/repartitioned_entries`
-                """,
+                """,  # nosec B608
             )
             self.assertCountEqual(
                 cursor.fetchall(),

--- a/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel_test.py
+++ b/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel_test.py
@@ -110,7 +110,7 @@ class RepartitionGRCh38SnvIndelTest(ClickhouseSchemaTestCase):
                 f"""
                 SELECT *, n_partitions, partition_id
                 FROM {REPARTITION_DATABASE_NAME}.`GRCh38/SNV_INDEL/repartitioned_entries`
-                """,
+                """,  # nosec B608
             )
             self.assertCountEqual(
                 cursor.fetchall(),

--- a/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel_test.py
+++ b/loading_pipeline/ops/repartition_clickhouse_grch38_snv_indel_test.py
@@ -72,7 +72,7 @@ class RepartitionGRCh38SnvIndelTest(ClickhouseSchemaTestCase):
                 (2, 'project_b', 'family_b2', 0, 1),
                 (0, 'project_c', 'family_c1', 1, 1),
                 (3, 'project_c', 'family_c2', 1, 1),
-                """,
+                """, # nosec B608
             )
 
     def tearDown(self):


### PR DESCRIPTION
## Pull request overview

This PR enables Codacy analysis for the `loading_pipeline` code and addresses newly surfaced findings primarily by adding targeted security suppressions (`# nosec Bxxx`) around known-safe patterns, plus a few small refactors/quoting fixes.

**Changes:**
- Re-enabled Codacy scanning for `loading_pipeline` by narrowing `.codacy.yaml` exclusions.
- Added `# nosec Bxxx` suppressions for security/static-analysis findings (SQL string construction, bind-to-all-interfaces, test secrets, `/tmp` paths, etc.).
- Minor Python/Hail refactors (lambda-to-function references) and safer bash variable quoting.