### PR TITLE
Prevent duplicate emails from blocking login

### DIFF
--- a/seqr/apps.py
+++ b/seqr/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 class SeqrConfig(AppConfig):
     name = 'seqr'
 
+    def ready(self):
+        import seqr.signals  # noqa: F401
+

--- a/seqr/apps.py
+++ b/seqr/apps.py
@@ -4,5 +4,10 @@ class SeqrConfig(AppConfig):
     name = 'seqr'
 
     def ready(self):
-        import seqr.signals  # noqa: F401
+        from django.contrib.auth.models import User
+        from django.db.models.signals import pre_save
+        from seqr.signals import validate_unique_email
+        pre_save.connect(
+            validate_unique_email, sender=User, dispatch_uid='seqr.validate_unique_email',
+        )
 

--- a/seqr/management/tests/createsuperuser_tests.py
+++ b/seqr/management/tests/createsuperuser_tests.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+
+class CreateSuperuserTest(TestCase):
+    fixtures = ['users']
+
+    def test_command(self):
+        call_command(
+            'createsuperuser', interactive=False, username='new_superuser',
+            email='new_superuser@test.com', verbosity=0,
+        )
+        user = User.objects.get(email='new_superuser@test.com')
+        self.assertEqual(user.username, 'new_superuser')
+        self.assertTrue(user.is_superuser)
+
+        with self.assertRaises(CommandError) as err:
+            call_command(
+                'createsuperuser', interactive=False, username='dup_superuser',
+                email='Test_Superuser@test.com', verbosity=0,
+            )
+        self.assertEqual(str(err.exception), 'That email is already taken.')
+        self.assertFalse(User.objects.filter(username='dup_superuser').exists())

--- a/seqr/signals.py
+++ b/seqr/signals.py
@@ -1,0 +1,15 @@
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.db.models.functions import Lower
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+
+@receiver(pre_save, sender=User)
+def validate_unique_email(sender, instance, raw, **kwargs):
+    if raw or not instance.email:
+        return
+    if User.objects.annotate(email_lower=Lower('email')).filter(
+        email_lower=instance.email.lower(),
+    ).exclude(pk=instance.pk).exists():
+        raise ValidationError('That email is already taken.')

--- a/seqr/signals.py
+++ b/seqr/signals.py
@@ -1,11 +1,8 @@
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db.models.functions import Lower
-from django.db.models.signals import pre_save
-from django.dispatch import receiver
 
 
-@receiver(pre_save, sender=User)
 def validate_unique_email(sender, instance, raw, **kwargs):
     if raw or not instance.email:
         return

--- a/seqr/views/apis/auth_api.py
+++ b/seqr/views/apis/auth_api.py
@@ -30,8 +30,9 @@ def login_view(request):
     # Django's iexact filtering will improperly match unicode characters, which creates a security risk.
     # Instead, query for the lower case match to allow case-insensitive matching
     users = User.objects.annotate(email_lower=Lower('email')).filter(email_lower=request_json['email'].lower())
-    if users.count() != 1:
-        error = 'Invalid credentials'
+    user_count = users.count()
+    if user_count != 1:
+        error = 'Multiple users found with this email' if user_count > 1 else 'Invalid credentials'
         return create_json_response({'error': error}, status=401, reason=error)
 
     user = users.first()

--- a/seqr/views/apis/auth_api_tests.py
+++ b/seqr/views/apis/auth_api_tests.py
@@ -90,6 +90,19 @@ class AuthAPITest(TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.reason_phrase, 'Invalid credentials')
 
+    def test_login_view_duplicate_email(self):
+        dup_user = User.objects.create_user('test_dup_user', 'test_dup_user@institute.com', 'password456')
+        # Bypass save() validation to simulate a pre-existing duplicate email
+        User.objects.filter(pk=dup_user.pk).update(email='test_new_user@institute.com')
+        url = reverse(login_view)
+        response = self.client.post(url, content_type='application/json', data=json.dumps({
+            'email': 'test_new_user@institute.com',
+            'password': 'password123',
+        }))
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.reason_phrase, 'Multiple users found with this email')
+        self.assertEqual(response.json()['error'], 'Multiple users found with this email')
+
     @mock.patch('seqr.views.utils.terra_api_utils.SOCIAL_AUTH_PROVIDER', TEST_OAUTH2_PROVIDER)
     def test_login_view_with_google(self):
         url = reverse(login_view)


### PR DESCRIPTION
## Summary
- Fixes #1439: `createsuperuser` could create two accounts with the same email, and login then rejected both with `Invalid credentials`.
- Reject saving a user whose email already exists (case-insensitive, same matching as login).
- When duplicates already exist, login returns `Multiple users found with this email` instead of a generic 401.

## Test plan
- [x] `./manage.py test seqr.views.apis.auth_api_tests seqr.management.tests.createsuperuser_tests`
- [x] `createsuperuser` with a new email succeeds; a second user with the same email (any case) fails with `That email is already taken.`
- [x] Login with a unique email still works; wrong email/password still returns `Invalid credentials`
- [x] If two users already share an email, login shows `Multiple users found with this email`