### PR TITLE
Name selected families and individuals in the delete confirm

### DIFF
--- a/ui/pages/Project/components/edit-families-and-individuals/EditFamiliesForm.test.js
+++ b/ui/pages/Project/components/edit-families-and-individuals/EditFamiliesForm.test.js
@@ -33,6 +33,22 @@ test('deletes selected families', async () => {
     </Provider>,
   )
 
+  expect(wrapper.find('DispatchRequestButton').prop('buttonContent')).toEqual('Delete Selected')
+  expect(wrapper.find('DispatchRequestButton').prop('disabled')).toEqual(true)
+
+  wrapper.find('DataTable').prop('selectRows')({ F011652_1: true })
+  wrapper.update()
+  expect(wrapper.find('DispatchRequestButton').prop('disabled')).toEqual(false)
+  expect(wrapper.find('DispatchRequestButton').prop('confirmDialog')).toEqual(
+    'Are you sure you want to delete the following families: 1?',
+  )
+
+  wrapper.find('DataTable').prop('selectRows')({ F011652_1: true, F011652_2: true })
+  wrapper.update()
+  expect(wrapper.find('DispatchRequestButton').prop('confirmDialog')).toEqual(
+    'Are you sure you want to delete the following families: 1, 2?',
+  )
+
   wrapper.find('DispatchRequestButton').prop('onSubmit')()
   await flushAll()
 

--- a/ui/pages/Project/components/edit-families-and-individuals/EditIndividualsForm.test.js
+++ b/ui/pages/Project/components/edit-families-and-individuals/EditIndividualsForm.test.js
@@ -54,3 +54,22 @@ test('shows the analyst-only fields when the user is an analyst', () => {
     'familyId', 'individualId', 'paternalId', 'maternalId', 'sex', 'affected',
   ])
 })
+
+test('confirms which individuals will be deleted', () => {
+  const store = configureStore(STATE_WITH_2_FAMILIES)
+  const wrapper = mount(
+    <Provider store={store}>
+      <EditIndividualsForm modalName="editIndividuals" analysisGroupGuid="AG0000183_test_group" />
+    </Provider>,
+  )
+
+  expect(wrapper.find('DispatchRequestButton').prop('buttonContent')).toEqual('Delete Selected')
+  expect(wrapper.find('DispatchRequestButton').prop('disabled')).toEqual(true)
+
+  wrapper.find('DataTable').prop('selectRows')({ I021476_na19678_1: true, I021475_na19675_1: true })
+  wrapper.update()
+  expect(wrapper.find('DispatchRequestButton').prop('disabled')).toEqual(false)
+  expect(wrapper.find('DispatchRequestButton').prop('confirmDialog')).toEqual(
+    'Are you sure you want to delete the following individuals: NA19678, NA19675?',
+  )
+})

--- a/ui/shared/components/form/EditRecordsForm.jsx
+++ b/ui/shared/components/form/EditRecordsForm.jsx
@@ -108,6 +108,9 @@ class EditRecordsForm extends React.PureComponent {
     const rowsToDelete = Object.entries(recordData).reduce((acc, [recordId, { toDelete }]) => (
       { ...acc, [recordId]: toDelete }
     ), {})
+    const selectedIds = Object.values(recordData).filter(({ toDelete }) => toDelete).map(
+      record => record[filterColumn] || record[idField],
+    )
 
     const getRowFilterVal = filterColumn ? row => row[filterColumn] : null
 
@@ -139,8 +142,9 @@ class EditRecordsForm extends React.PureComponent {
                   initialValues={this.getFilteredRecords(recordData, record => record.toDelete)}
                   onSubmit={onSubmit}
                   onSuccess={closeParentModal}
-                  confirmDialog={`Are you sure you want to delete the selected ${entityKey}?`}
-                  buttonText="Deleted Selected"
+                  confirmDialog={`Are you sure you want to delete the following ${entityKey}: ${selectedIds.join(', ')}?`}
+                  buttonText="Delete Selected"
+                  disabled={!selectedIds.length}
                 />
               }
               getRowFilterVal={getRowFilterVal}


### PR DESCRIPTION
## Summary
- Fixes #2940: the Edit Families / Edit Individuals delete confirm said `the selected families/individuals` and did not list which rows were checked.
- The confirm now names the selected IDs, e.g. `Are you sure you want to delete the following individuals: NA19678, NA19675?`
- Disable **Delete Selected** until at least one row is checked, and fix the button label typo (`Deleted` → `Delete`).

## Test plan
- [x] `npm test -- --testPathPattern='EditFamiliesForm.test|EditIndividualsForm.test' --watchAll=false`
- [ ] Project page → Edit Families & Individuals → Edit Families: with nothing checked, Delete Selected is disabled
- [ ] Check one or more families; confirm lists those family IDs; cancel
- [ ] Edit Individuals tab: same for individual IDs (including after filter + select-all)