### PR TITLE
Treat non-array HPO term fields as empty on the family page

### DIFF
--- a/seqr/fixtures/1kg_project.json
+++ b/seqr/fixtures/1kg_project.json
@@ -479,7 +479,7 @@
         "expected_inheritance": ["R"],
         "features": [{"id": "HP:0001631"}, {"id": "HP:0002011", "qualifiers":  [{"label": "Infantile onset", "type": "age_of_onset"}, {"label": "Mild", "type": "severity"}, {"label": "Nonprogressive", "type": "pace_of_progression"}]}, {"id": "HP:0001636"}],
         "absent_features": [{"id": "HP:0011675"}, {"id": "HP:0001674", "notes":  "originally indicated"}, {"id": "HP:0001508"}],
-        "nonstandard_features": "[]",
+        "nonstandard_features": [],
         "absent_nonstandard_features": null,
         "disorders": ["615593"],
         "candidate_genes": [{"gene": "EHBP1L1", "comments": "comments EHBP1L1"}, {"gene": "ACY3", "comments": "comments ACY3"}],

--- a/ui/shared/components/panel/HpoPanel.jsx
+++ b/ui/shared/components/panel/HpoPanel.jsx
@@ -41,8 +41,10 @@ export const CATEGORY_NAMES = {
   'HP:0033127': 'Musculoskeletal',
 }
 
+const asTermList = value => (Array.isArray(value) ? value : [])
+
 export const getHpoTermsForCategory = (features, nonstandardFeatures) => {
-  const hpoTermsByCategory = (features || []).reduce((acc, hpoTerm) => {
+  const hpoTermsByCategory = asTermList(features).reduce((acc, hpoTerm) => {
     const category = CATEGORY_NAMES[hpoTerm.category] || UNKNOWN_CATEGORY
     if (!acc[category]) {
       acc[category] = [] // init array of features
@@ -51,19 +53,17 @@ export const getHpoTermsForCategory = (features, nonstandardFeatures) => {
     return acc
   }, {})
 
-  if (nonstandardFeatures) {
-    nonstandardFeatures.reduce((acc, term) => {
-      const category = (term.categories || ['']).map(
-        categoryTerm => CATEGORY_NAMES[categoryTerm.id] || categoryTerm.label || UNKNOWN_CATEGORY,
-      ).sort().join(', ')
-      if (!acc[category]) {
-        acc[category] = [] // init array of features
-      }
+  asTermList(nonstandardFeatures).reduce((acc, term) => {
+    const category = (term.categories || ['']).map(
+      categoryTerm => CATEGORY_NAMES[categoryTerm.id] || categoryTerm.label || UNKNOWN_CATEGORY,
+    ).sort().join(', ')
+    if (!acc[category]) {
+      acc[category] = [] // init array of features
+    }
 
-      acc[category].push(term)
-      return acc
-    }, hpoTermsByCategory)
-  }
+    acc[category].push(term)
+    return acc
+  }, hpoTermsByCategory)
 
   return Object.entries(hpoTermsByCategory).map(([categoryName, terms]) => ({ categoryName, terms })).sort(
     (a, b) => a.categoryName.localeCompare(b.categoryName),
@@ -71,7 +71,7 @@ export const getHpoTermsForCategory = (features, nonstandardFeatures) => {
 }
 
 const FeatureSection = React.memo(({ features, nonstandardFeatures, title, color }) => {
-  if ((features || []).length < 1 && (nonstandardFeatures || []).length < 1) {
+  if (asTermList(features).length < 1 && asTermList(nonstandardFeatures).length < 1) {
     return null
   }
   const termsByCategory = getHpoTermsForCategory(features, nonstandardFeatures)

--- a/ui/shared/components/panel/HpoPanel.test.js
+++ b/ui/shared/components/panel/HpoPanel.test.js
@@ -76,3 +76,19 @@ test('test getHpoTermsForCategory', () => {
   ])
 })
 
+test('getHpoTermsForCategory treats a non-array as empty', () => {
+  expect(getHpoTermsForCategory('[]', '[]')).toEqual([])
+  expect(getHpoTermsForCategory(null, '[]')).toEqual([])
+  expect(getHpoTermsForCategory(
+    [{ category: 'HP:0001507', id: 'HP:0004325', label: 'Decreased body weight' }],
+    '[]',
+  )).toEqual([
+    {
+      categoryName: 'Growth Abnormality',
+      terms: [
+        { category: 'HP:0001507', id: 'HP:0004325', label: 'Decreased body weight' },
+      ],
+    },
+  ])
+})
+


### PR DESCRIPTION
## Summary
- The family page calls `.reduce` on `nonstandardFeatures`. If that JSON field is a string (the 1kg fixture stored `"[]"`), the panel throws and the page goes blank.
- Treat a non-array as empty in `getHpoTermsForCategory` / `FeatureSection`, and store a real list in the 1kg fixture.

## Test plan
- [x] `npm test -- --testPathPattern='HpoPanel.test' --watchAll=false`
- [ ] After `loaddata` of `1kg_project`, open `/project/R0001_1kg/family_page/F000001_1` — Family 1 renders (HPO terms for NA19675_1)
- [ ] Family 2 still renders as before
- [ ] Before/after recordings attached as a comment