### PR TITLE
update debian to supported version

### DIFF
--- a/deploy/docker/seqr/Dockerfile
+++ b/deploy/docker/seqr/Dockerfile
@@ -22,10 +22,10 @@ RUN npm run build
 ############################
 # Python build stage
 ############################
-FROM python:3.11-slim-bullseye AS build
+FROM python:3.11-slim-trixie AS build
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y --no-install-recommends \
     apt-utils \
     bzip2 \
     curl \
@@ -52,7 +52,7 @@ RUN pip install --no-cache-dir wheel \
 ############################
 # Runtime stage
 ############################
-FROM python:3.11-slim-bullseye AS runtime
+FROM python:3.11-slim-trixie AS runtime
 
 # Copy Python virtualenv from build stage
 COPY --from=build /opt/venv /opt/venv


### PR DESCRIPTION
Debian 11 (bullseye) reached end of long term support on 8/31, so updating to Debian 13 (trixie)