### PR TITLE
execute existing variants export outside dataproc

### DIFF
--- a/loading_pipeline/lib/tasks/dataproc/misc_test.py
+++ b/loading_pipeline/lib/tasks/dataproc/misc_test.py
@@ -31,8 +31,6 @@ class MiscTest(unittest.TestCase):
                 'SNV_INDEL',
                 '--run-id',
                 'a_misc_run',
-                '--attempt-id',
-                '0',
                 '--sample-type',
                 'WGS',
                 '--callset-path',
@@ -47,5 +45,7 @@ class MiscTest(unittest.TestCase):
                 '[]',
                 '--is-new-gcnv-joint-call',
                 'False',
+                '--attempt-id',
+                '0',
             ],
         )

--- a/loading_pipeline/lib/tasks/dataproc/run_pipeline_on_dataproc.py
+++ b/loading_pipeline/lib/tasks/dataproc/run_pipeline_on_dataproc.py
@@ -7,10 +7,18 @@ from loading_pipeline.lib.tasks.dataproc.base_run_job_on_dataproc import (
     BaseRunJobOnDataprocTask,
 )
 from loading_pipeline.lib.tasks.run_pipeline import RunPipelineTask
+from loading_pipeline.lib.tasks.write_existing_variants_parquet import (
+    WriteExistingVariantsParquetTask,
+)
 
 
 @luigi.util.inherits(BaseLoadingRunParams)
 class RunPipelineOnDataprocTask(BaseRunJobOnDataprocTask):
+    attempt_id = luigi.IntParameter()
+
     @property
     def task(self) -> luigi.Task:
         return RunPipelineTask
+
+    def requires(self) -> [luigi.Task]:
+        return [self.clone(WriteExistingVariantsParquetTask), *super().requires()]

--- a/loading_pipeline/lib/tasks/dataproc/run_pipeline_on_dataproc_test.py
+++ b/loading_pipeline/lib/tasks/dataproc/run_pipeline_on_dataproc_test.py
@@ -14,7 +14,7 @@ from loading_pipeline.lib.test.mock_complete_task import MockCompleteTask
 
 
 @patch(
-    'loading_pipeline.lib.tasks.dataproc.base_run_job_on_dataproc.WriteExistingVariantsParquetTask',
+    'loading_pipeline.lib.tasks.dataproc.run_pipeline_on_dataproc.WriteExistingVariantsParquetTask',
 )
 @patch(
     'loading_pipeline.lib.tasks.dataproc.base_run_job_on_dataproc.CreateDataprocClusterTask',

--- a/loading_pipeline/lib/tasks/dataproc/run_pipeline_on_dataproc_test.py
+++ b/loading_pipeline/lib/tasks/dataproc/run_pipeline_on_dataproc_test.py
@@ -14,6 +14,9 @@ from loading_pipeline.lib.test.mock_complete_task import MockCompleteTask
 
 
 @patch(
+    'loading_pipeline.lib.tasks.dataproc.base_run_job_on_dataproc.WriteExistingVariantsParquetTask',
+)
+@patch(
     'loading_pipeline.lib.tasks.dataproc.base_run_job_on_dataproc.CreateDataprocClusterTask',
 )
 @patch(
@@ -26,6 +29,7 @@ class WriteSuccessFileOnDataprocTaskTest(unittest.TestCase):
         mock_logger: Mock,
         mock_job_controller_client: Mock,
         mock_create_dataproc_cluster: Mock,
+        mock_variants_parquet: Mock,
     ) -> None:
         mock_create_dataproc_cluster.return_value = MockCompleteTask()
         mock_client = mock_job_controller_client.return_value
@@ -63,6 +67,7 @@ class WriteSuccessFileOnDataprocTaskTest(unittest.TestCase):
         self,
         mock_job_controller_client: Mock,
         mock_create_dataproc_cluster: Mock,
+        mock_variants_parquet: Mock,
     ) -> None:
         mock_create_dataproc_cluster.return_value = MockCompleteTask()
         mock_client = mock_job_controller_client.return_value
@@ -91,8 +96,10 @@ class WriteSuccessFileOnDataprocTaskTest(unittest.TestCase):
         mock_logger: Mock,
         mock_job_controller_client: Mock,
         mock_create_dataproc_cluster: Mock,
+        mock_variants_parquet: Mock,
     ) -> None:
         mock_create_dataproc_cluster.return_value = MockCompleteTask()
+        mock_variants_parquet.return_value = MockCompleteTask()
         mock_client = mock_job_controller_client.return_value
         mock_client.get_job.side_effect = [
             google.api_core.exceptions.NotFound(
@@ -139,8 +146,10 @@ class WriteSuccessFileOnDataprocTaskTest(unittest.TestCase):
         mock_logger: Mock,
         mock_job_controller_client: Mock,
         mock_create_dataproc_cluster: Mock,
+        mock_variants_parquet: Mock,
     ) -> None:
         mock_create_dataproc_cluster.return_value = MockCompleteTask()
+        mock_variants_parquet.return_value = MockCompleteTask()
         mock_client = mock_job_controller_client.return_value
         mock_client.get_job.side_effect = [
             google.api_core.exceptions.NotFound(


### PR DESCRIPTION
## Pull request overview

Moves existing-variant Parquet export outside Dataproc by making it a pipeline prerequisite.

**Changes:**
- Adds the export task as a Dataproc prerequisite.
- Updates dependency mocks and parameter-order expectations in tests.